### PR TITLE
Add codebase mapping documents

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,257 @@
+# Architecture
+
+**Analysis Date:** 2026-04-19
+
+## Pattern Overview
+
+**Overall:** Thin SwiftUI menu bar shell over a testable core domain and service layer.
+
+**Key Characteristics:**
+- Keep product rules in `KubebarCore/`, not in SwiftUI views under `Kubebar/Views/`.
+- Render the menu from `MenuDisplayModel`; views in `Kubebar/Views/` must not infer cluster health from raw data.
+- Route external process reads through injectable protocols in `KubebarCore/Services/CommandRunner.swift` and `KubebarCore/Services/KubectlClusterReader.swift`.
+- Treat app-owned configuration as authoritative through `KubebarCore/Services/AppConfigStore.swift`; do not use the terminal's current Kubernetes context as implicit state.
+- Preserve stale-state guarantees through `KubebarCore/Services/RefreshCoordinator.swift` and `KubebarCore/Services/HealthEvaluator.swift`.
+
+## Layers
+
+**macOS App Shell:**
+- Purpose: Start the menu bar app, hold the root view model, and present the current status icon.
+- Location: `Kubebar/`
+- Contains: `Kubebar/KubebarApp.swift`, `Kubebar/MenuBarViewModel.swift`, and SwiftUI views under `Kubebar/Views/`.
+- Depends on: `SwiftUI`, `AppKit`, and public models/services from `KubebarCore/`.
+- Used by: The macOS application target defined in `project.yml` and `Package.swift`.
+- Use this layer for scene wiring, user actions, bindings, and UI-only state. Do not put health scoring, kubectl parsing, config persistence, or display-model construction here.
+
+**View Model Boundary:**
+- Purpose: Bridge UI events to core services while keeping UI-bound state on the main actor.
+- Location: `Kubebar/MenuBarViewModel.swift`
+- Contains: `@MainActor final class MenuBarViewModel`, published `display`, `setupState`, and `isShowingSetup` state.
+- Depends on: `KubebarCore/Services/AppConfigStore.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, `KubebarCore/Services/ContextCatalog.swift`, and `KubebarCore/Services/HealthEvaluator.swift`.
+- Used by: `Kubebar/KubebarApp.swift` and `Kubebar/Views/MenuBarRootView.swift`.
+- Use this boundary to load/save setup, trigger refresh, and call background work with `Task.detached`. Keep long-running or blocking reads out of the main actor.
+
+**SwiftUI Menu Views:**
+- Purpose: Render setup and menu content from already-shaped model data.
+- Location: `Kubebar/Views/`
+- Contains: `Kubebar/Views/MenuBarRootView.swift`, `Kubebar/Views/SetupView.swift`, `Kubebar/Views/WatchlistPickerView.swift`, `Kubebar/Views/StatusSummaryView.swift`, `Kubebar/Views/CompactCountersView.swift`, `Kubebar/Views/WatchlistSectionView.swift`, `Kubebar/Views/StaleBannerView.swift`, `Kubebar/Views/WarningEventsView.swift`, `Kubebar/Views/NodeDetailsView.swift`, and `Kubebar/Views/TrackedItemDetailView.swift`.
+- Depends on: `SwiftUI` and display/setup models from `KubebarCore/Models/`.
+- Used by: `Kubebar/Views/MenuBarRootView.swift` as the menu composition root.
+- Use this layer for layout and simple presentation. Pass closures for actions and bindings for setup state; do not read files, call `kubectl`, or calculate severity.
+
+**Core Models:**
+- Purpose: Define app-owned data shapes shared by services, view model, and tests.
+- Location: `KubebarCore/Models/`
+- Contains: `ClusterSnapshot`, `NodeSummary`, `PodSummary`, `WatchTarget`, `TrackedItemStatus`, `ClusterHealthState`, `MenuDisplayModel`, `MenuCounters`, `WatchItemDisplay`, `StaleBannerDisplay`, `MenuBarStatusPresentation`, `SetupFlowState`, and `WatchlistSelectionState`.
+- Depends on: `Foundation` only.
+- Used by: `KubebarCore/Services/`, `Kubebar/MenuBarViewModel.swift`, `Kubebar/Views/`, and `KubebarTests/`.
+- Use value types here. Add model-derived labels and summaries only when they are stable product concepts, not one-off view formatting.
+
+**Core Services:**
+- Purpose: Own persistence, refresh orchestration, external reads, JSON conversion, and health evaluation.
+- Location: `KubebarCore/Services/`
+- Contains: `KubebarCore/Services/AppConfigStore.swift`, `KubebarCore/Services/CommandRunner.swift`, `KubebarCore/Services/ContextCatalog.swift`, `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, and `KubebarCore/Services/HealthEvaluator.swift`.
+- Depends on: `Foundation` and core models from `KubebarCore/Models/`.
+- Used by: `Kubebar/MenuBarViewModel.swift` and service/model tests under `KubebarTests/`.
+- Use this layer for behavior. Keep service dependencies injectable through protocols or initializer parameters so tests can use fakes instead of shelling out.
+
+**External Command Boundary:**
+- Purpose: Isolate subprocess execution and make `kubectl` reads testable.
+- Location: `KubebarCore/Services/CommandRunner.swift`
+- Contains: `CommandRequest`, `CommandResult`, `CommandRunning`, `CommandRunnerError`, and `ProcessCommandRunner`.
+- Depends on: `Foundation.Process`, `Pipe`, `DispatchSemaphore`, `DispatchGroup`, and a private locked data buffer.
+- Used by: `KubebarCore/Services/ContextCatalog.swift`, `KubebarCore/Services/KubectlClusterReader.swift`, and fake runners in `KubebarTests/Services/`.
+- Use `CommandRunning` for all new shell boundaries. Do not call `Process` directly from unrelated services or UI files.
+
+**Kubernetes Reader:**
+- Purpose: Convert `kubectl` JSON output into app-owned `ClusterSnapshot` data.
+- Location: `KubebarCore/Services/KubectlClusterReader.swift`
+- Contains: `ClusterReading`, `KubectlClusterReader`, private kubectl read cases, raw snapshot storage, and private `Decodable` records for nodes, pods, and events.
+- Depends on: `CommandRunning`, `WatchTarget`, `ClusterSnapshot`, and `JSONDecoder`.
+- Used by: `KubebarCore/Services/RefreshCoordinator.swift`.
+- Use this service for new Kubernetes reads. Always pass the saved context as `--context`; never rely on the process environment's active kube context.
+
+**Health and Display Mapping:**
+- Purpose: Convert snapshots and failures into the only UI render shape.
+- Location: `KubebarCore/Services/HealthEvaluator.swift`
+- Contains: `RefreshFailure` and `HealthEvaluator`.
+- Depends on: `ClusterSnapshot`, `ClusterHealthState`, and `MenuDisplayModel`.
+- Used by: `KubebarCore/Services/RefreshCoordinator.swift`, `Kubebar/MenuBarViewModel.swift`, and `KubebarTests/Models/MenuDisplayModelTests.swift`.
+- Use this service for severity, watchlist ordering, visible watchlist limits, stale banner values, and health sentences. Do not duplicate these decisions in views.
+
+**Configuration Persistence:**
+- Purpose: Save and load the selected context, watchlist, and refresh interval as local app configuration.
+- Location: `KubebarCore/Services/AppConfigStore.swift`
+- Contains: `AppConfig`, `AppConfigStore`, and `AppConfigStoreError`.
+- Depends on: `Foundation.FileManager`, `JSONEncoder`, and `JSONDecoder`.
+- Used by: `Kubebar/MenuBarViewModel.swift` and `KubebarTests/Services/AppConfigStoreTests.swift`.
+- Use this service for app-owned saved state. Keep corrupt config recoverable by throwing `AppConfigStoreError.corruptConfig`.
+
+**Tests:**
+- Purpose: Lock core product behavior and injectable service boundaries.
+- Location: `KubebarTests/`
+- Contains: model tests under `KubebarTests/Models/` and service tests under `KubebarTests/Services/`.
+- Depends on: Swift Testing through `import Testing` and `@testable import KubebarCore`.
+- Used by: `Package.swift`, `project.yml`, and `scripts/swift-quality-gate.sh`.
+- Add tests close to the model or service being changed. UI files currently have no dedicated test target.
+
+## Data Flow
+
+**App Launch and Initial State:**
+
+1. `Kubebar/KubebarApp.swift` creates `MenuBarViewModel` and configures the app as an accessory menu bar utility.
+2. `Kubebar/MenuBarViewModel.swift` loads `AppConfig` from `KubebarCore/Services/AppConfigStore.swift`.
+3. If config is missing or incomplete, `MenuBarViewModel` builds a stale "Not configured" display through `KubebarCore/Services/HealthEvaluator.swift` and shows setup.
+4. If config is complete, `MenuBarViewModel.refreshNow()` starts a refresh and publishes the resulting `MenuDisplayModel`.
+5. `Kubebar/Views/MenuBarRootView.swift` renders either `SetupView` or the menu content from `display`.
+
+**Manual or Automatic Refresh:**
+
+1. `Kubebar/Views/MenuBarRootView.swift` invokes `onRefresh`.
+2. `Kubebar/MenuBarViewModel.swift` calls `KubebarCore/Services/RefreshCoordinator.swift` on a detached task with the current `AppConfig` and previous `ClusterSnapshot`.
+3. `RefreshCoordinator.refresh(config:previousSnapshot:now:)` rejects incomplete setup before any cluster read.
+4. `RefreshCoordinator` calls `ClusterReading.readSnapshot(contextName:watchTargets:now:)`.
+5. `KubebarCore/Services/KubectlClusterReader.swift` runs independent `kubectl get nodes`, `kubectl get pods`, and `kubectl get events` reads through `CommandRunning`.
+6. `KubectlClusterReader` decodes JSON into `NodeSummary`, `PodSummary`, warning event count, and tracked item status.
+7. `RefreshCoordinator` calls `HealthEvaluator.evaluate(...)`.
+8. `MenuBarViewModel` publishes the new `snapshot` and `display` on the main actor.
+
+**Failed Refresh and Stale Data:**
+
+1. `KubebarCore/Services/CommandRunner.swift` or `KubebarCore/Services/KubectlClusterReader.swift` throws a command, timeout, launch, nonzero-exit, or parse error.
+2. `KubebarCore/Services/RefreshCoordinator.swift` keeps the previous snapshot instead of clearing it.
+3. `KubebarCore/Services/HealthEvaluator.swift` returns a `MenuDisplayModel` with `.stale` state and a `StaleBannerDisplay`.
+4. `Kubebar/Views/StaleBannerView.swift` shows the last update age and failure reason.
+5. The menu bar icon uses `KubebarCore/Models/MenuBarStatusPresentation.swift` so stale data cannot look healthy.
+
+**Setup and Watchlist Editing:**
+
+1. `Kubebar/Views/MenuBarRootView.swift` invokes `onEditWatchlist`.
+2. `Kubebar/MenuBarViewModel.swift` sets `isShowingSetup` and calls `ContextCatalog.listContexts()`.
+3. `KubebarCore/Services/ContextCatalog.swift` runs `kubectl config get-contexts -o name` through `CommandRunning`.
+4. `Kubebar/Views/SetupView.swift` binds context selection and watchlist selection to `SetupFlowState`.
+5. `Kubebar/Views/WatchlistPickerView.swift` mutates `WatchlistSelectionState` through bindings.
+6. `MenuBarViewModel.completeSetup()` writes `AppConfig` through `AppConfigStore.save(_:)`, hides setup, and refreshes.
+
+**State Management:**
+- UI-bound state lives in `@MainActor` `Kubebar/MenuBarViewModel.swift`.
+- Persisted app state lives in `AppConfig` and `config.json` written by `KubebarCore/Services/AppConfigStore.swift`.
+- Last successful cluster data lives in `MenuBarViewModel.snapshot` and may be reused only through stale display handling.
+- Domain state uses immutable `let` properties in value types under `KubebarCore/Models/`.
+- Setup state uses mutable value types: `SetupFlowState` and `WatchlistSelectionState`.
+
+## Key Abstractions
+
+**MenuDisplayModel:**
+- Purpose: Single render contract for the menu.
+- Examples: `KubebarCore/Models/MenuDisplayModel.swift`, `Kubebar/Views/MenuBarRootView.swift`, `KubebarTests/Models/MenuDisplayModelTests.swift`.
+- Pattern: Core-built view model. Views consume this shape directly and should not reconstruct counters, stale state, health sentences, or severity.
+
+**ClusterHealthState:**
+- Purpose: Categorical app health state: `OK`, `Watch`, `Bad`, or `Stale`.
+- Examples: `KubebarCore/Models/ClusterHealthState.swift`, `KubebarCore/Models/MenuBarStatusPresentation.swift`, `KubebarCore/Services/HealthEvaluator.swift`.
+- Pattern: Exhaustive enum with display label and menu bar presentation mapping.
+
+**HealthEvaluator:**
+- Purpose: Single source of truth for severity, first-screen watchlist ordering, visible watchlist cap, stale banner construction, and health sentence.
+- Examples: `KubebarCore/Services/HealthEvaluator.swift`, `KubebarTests/Models/MenuDisplayModelTests.swift`.
+- Pattern: Pure value service. Keep inputs explicit and deterministic by passing `Date`.
+
+**RefreshCoordinator:**
+- Purpose: Orchestrate config validation, cluster reads, previous snapshot retention, and display evaluation.
+- Examples: `KubebarCore/Services/RefreshCoordinator.swift`, `KubebarTests/Services/RefreshCoordinatorTests.swift`.
+- Pattern: Small coordinating service with injected `ClusterReading` and `HealthEvaluator`.
+
+**ClusterReading:**
+- Purpose: Injectable boundary for reading Kubernetes state.
+- Examples: `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarTests/Services/RefreshCoordinatorTests.swift`.
+- Pattern: Protocol-backed dependency. Use fake readers in tests and keep `kubectl` details inside `KubectlClusterReader`.
+
+**CommandRunning:**
+- Purpose: Injectable subprocess boundary for shell commands.
+- Examples: `KubebarCore/Services/CommandRunner.swift`, `KubebarTests/Services/KubectlClusterReaderTests.swift`, `KubebarTests/Services/ContextCatalogTests.swift`.
+- Pattern: Protocol-backed adapter around `Process`. Use fake runners to test command consumers.
+
+**AppConfig and AppConfigStore:**
+- Purpose: App-owned persisted context, watch targets, and refresh interval.
+- Examples: `KubebarCore/Services/AppConfigStore.swift`, `Kubebar/MenuBarViewModel.swift`, `KubebarTests/Services/AppConfigStoreTests.swift`.
+- Pattern: Codable config plus store. Keep config persistence separate from UI state.
+
+**WatchTarget and TrackedItemStatus:**
+- Purpose: Represent watched namespaces and workloads, then summarize their current health.
+- Examples: `KubebarCore/Models/WatchTarget.swift`, `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Models/WatchlistSelectionState.swift`.
+- Pattern: Value enum for durable selection, value struct for runtime status.
+
+**SetupFlowState and WatchlistSelectionState:**
+- Purpose: Model first-run setup and watchlist editing state.
+- Examples: `KubebarCore/Models/SetupFlowState.swift`, `KubebarCore/Models/WatchlistSelectionState.swift`, `Kubebar/Views/SetupView.swift`, `Kubebar/Views/WatchlistPickerView.swift`.
+- Pattern: Bindable value state with derived labels and validation flags.
+
+## Entry Points
+
+**macOS Application:**
+- Location: `Kubebar/KubebarApp.swift`
+- Triggers: App launch.
+- Responsibilities: Set accessory activation policy, create `MenuBarExtra`, instantiate `MenuBarViewModel`, pass actions into `MenuBarRootView`, and map `display.state` to a menu bar status icon through `MenuBarStatusPresentation`.
+
+**Menu Composition Root:**
+- Location: `Kubebar/Views/MenuBarRootView.swift`
+- Triggers: SwiftUI rendering from the menu bar scene.
+- Responsibilities: Choose setup vs menu content, render status, stale banner, counters, watchlist, warning events, node details, and actions.
+
+**View Model:**
+- Location: `Kubebar/MenuBarViewModel.swift`
+- Triggers: App initialization, retry button, edit watchlist button, finish setup button.
+- Responsibilities: Load config, maintain current display and setup state, start refresh work, load contexts, save setup, and publish UI state on the main actor.
+
+**Refresh Coordinator:**
+- Location: `KubebarCore/Services/RefreshCoordinator.swift`
+- Triggers: `MenuBarViewModel.refreshNow()`.
+- Responsibilities: Validate config, invoke cluster reader, preserve previous snapshot on failure, and produce `RefreshResult`.
+
+**Kubernetes Snapshot Reader:**
+- Location: `KubebarCore/Services/KubectlClusterReader.swift`
+- Triggers: `RefreshCoordinator.refresh(config:previousSnapshot:now:)`.
+- Responsibilities: Run `kubectl` with the saved context, decode node/pod/event JSON, compute tracked item status, and return `ClusterSnapshot`.
+
+**Context Catalog:**
+- Location: `KubebarCore/Services/ContextCatalog.swift`
+- Triggers: `MenuBarViewModel.openSetup()`.
+- Responsibilities: List available Kubernetes contexts for setup.
+
+**Quality Gate:**
+- Location: `scripts/swift-quality-gate.sh`
+- Triggers: Local development, CI, and the `skills/ship/SKILL.md` workflow.
+- Responsibilities: Detect Xcode project/workspace, run Xcode build/test, then run `swift build` and `swift test` when `Package.swift` exists.
+
+## Error Handling
+
+**Strategy:** Convert external and persistence failures into typed or user-safe errors at service boundaries, then render stale or setup state instead of silently showing healthy data.
+
+**Patterns:**
+- Use typed service errors: `CommandRunnerError` in `KubebarCore/Services/CommandRunner.swift`, `KubectlCommandError` in `KubebarCore/Services/ContextCatalog.swift` and `KubebarCore/Services/KubectlClusterReader.swift`, and `AppConfigStoreError` in `KubebarCore/Services/AppConfigStore.swift`.
+- In `KubebarCore/Services/KubectlClusterReader.swift`, map timeout and launch failures to operator-readable `KubectlCommandError.failed(...)` reasons.
+- In `KubebarCore/Services/RefreshCoordinator.swift`, keep `previousSnapshot` on read failure and pass `RefreshFailure` into `HealthEvaluator`.
+- In `Kubebar/MenuBarViewModel.swift`, recover corrupt or missing config by using `AppConfig()` and showing setup/unavailable state.
+- In `Kubebar/MenuBarViewModel.swift`, display save failure through `SetupFlowState.configurationMessage`.
+- In `KubebarCore/Services/ContextCatalog.swift`, throw `KubectlCommandError.failed(...)` for nonzero `kubectl config get-contexts` results; `MenuBarViewModel.loadContexts()` currently degrades to an empty context list.
+
+## Cross-Cutting Concerns
+
+**Logging:** Not detected. No logging framework or shared logger appears in `Kubebar/`, `KubebarCore/`, or `KubebarTests/`.
+
+**Validation:** Setup validity is modeled by `AppConfig.needsSetup` in `KubebarCore/Services/AppConfigStore.swift` and `SetupFlowState.isConfigured` in `KubebarCore/Models/SetupFlowState.swift`. Refresh validation happens before cluster reads in `KubebarCore/Services/RefreshCoordinator.swift`.
+
+**Authentication:** Not applicable in app code. Kubernetes access is delegated to the user's local `kubectl` configuration through `KubebarCore/Services/CommandRunner.swift` and `KubebarCore/Services/KubectlClusterReader.swift`.
+
+**Freshness:** Stale-state rules live in `docs/architecture/runtime-invariants.md`, `KubebarCore/Services/RefreshCoordinator.swift`, `KubebarCore/Services/HealthEvaluator.swift`, and `Kubebar/Views/StaleBannerView.swift`.
+
+**Concurrency:** UI state is confined to `@MainActor` in `Kubebar/MenuBarViewModel.swift`. Blocking refresh and context listing work runs in `Task.detached`. `KubebarCore/Services/KubectlClusterReader.swift` reads nodes, pods, and events concurrently with `DispatchGroup`; `KubebarCore/Services/CommandRunner.swift` reads stdout/stderr concurrently with `DispatchGroup`.
+
+**Dependency Injection:** Service boundaries use initializer defaults backed by protocols: `CommandRunning` in `KubebarCore/Services/CommandRunner.swift`, `ClusterReading` in `KubebarCore/Services/KubectlClusterReader.swift`, and injectable stores/coordinators/catalogs in `Kubebar/MenuBarViewModel.swift`.
+
+**Architecture Documentation:** `docs/architecture/system-overview.md` and `docs/architecture/runtime-invariants.md` are authoritative for subsystem behavior beyond `AGENTS.md`. Update these files when changing request flow, runtime guarantees, or ownership boundaries.
+
+---
+
+*Architecture analysis: 2026-04-19*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,273 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-04-19
+
+## Tech Debt
+
+**First-use watchlist target discovery:**
+- Issue: The setup state can represent available namespaces and workloads, but the live app only loads context names. `WatchlistPickerView` exposes "Add namespace" and "Add workload" buttons whose default callbacks do nothing.
+- Files: `Kubebar/MenuBarViewModel.swift`, `Kubebar/Views/SetupView.swift`, `Kubebar/Views/WatchlistPickerView.swift`, `KubebarCore/Models/WatchlistSelectionState.swift`, `KubebarCore/Services/ContextCatalog.swift`
+- Impact: A clean first launch cannot build a watchlist through the app UI, so setup cannot reach the configured state without an existing config file or test-only state injection.
+- Fix approach: Add an injectable watch target catalog that reads namespaces and supported workload names for the selected context, wire it through `MenuBarViewModel`, and make the setup view update available targets when the selected context changes.
+
+**Freshness model without age-out:**
+- Issue: `AppConfig.refreshIntervalSeconds` is saved, but there is no scheduler, no periodic refresh task, and no stale threshold applied to an old successful snapshot.
+- Files: `KubebarCore/Services/AppConfigStore.swift`, `Kubebar/MenuBarViewModel.swift`, `KubebarCore/Services/HealthEvaluator.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, `docs/architecture/runtime-invariants.md`
+- Impact: A successful `OK` display can remain visible indefinitely when the app is open and no manual refresh happens, which weakens the invariant that old data never looks current.
+- Fix approach: Own a refresh task in `MenuBarViewModel`, use `refreshIntervalSeconds`, add a max-age rule in `HealthEvaluator`, and cancel/reschedule the task when config changes.
+
+**All-or-nothing cluster reads:**
+- Issue: `KubectlClusterReader` launches node, pod, and warning event reads concurrently, then throws if any read fails.
+- Files: `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, `KubebarTests/Services/KubectlClusterReaderTests.swift`, `KubebarTests/Services/RefreshCoordinatorTests.swift`
+- Impact: A permissions or parsing problem in one section makes the entire menu stale even when other sections are readable.
+- Fix approach: Return structured partial results with per-section failures, keep successful sections fresh, and let `HealthEvaluator` mark unavailable sections without discarding the whole snapshot.
+
+**Coarse Kubernetes health parsing:**
+- Issue: Pod health only checks `status.phase == "Running"`, workload matching only checks exact pod name plus `app.kubernetes.io/name` and `app` labels, and warning events are reduced to a count.
+- Files: `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Models/ClusterSnapshot.swift`, `KubebarCore/Models/WatchTarget.swift`, `Kubebar/Views/WarningEventsView.swift`, `Kubebar/Views/TrackedItemDetailView.swift`
+- Impact: Running but unready pods can look healthy, common Kubernetes controller names can miss their pods, and warning rows cannot explain reason, object, namespace, or time.
+- Fix approach: Decode pod conditions, container statuses, restart counts, owner references, and event fields; map them into richer snapshot fields while keeping UI rendering behind `MenuDisplayModel`.
+
+**Config recovery path:**
+- Issue: `AppConfigStore.load()` reports corrupt config, but `MenuBarViewModel` catches all load errors and silently resets to an empty `AppConfig`.
+- Files: `KubebarCore/Services/AppConfigStore.swift`, `Kubebar/MenuBarViewModel.swift`, `KubebarTests/Services/AppConfigStoreTests.swift`
+- Impact: A malformed saved config presents as first-use setup with no reason, and the app gives the user no recovery message or location of the bad file.
+- Fix approach: Preserve the recoverable error in setup state, show a clear recovery message, and keep the corrupt file intact until the user saves a replacement config.
+
+**Template-era support scripts:**
+- Issue: The repository contains generic setup and Rust panic-check tooling that is not used by the Swift quality gate.
+- Files: `scripts/dev-setup.sh`, `scripts/check_no_panics.py`, `AGENTS.md`, `README.md`
+- Impact: Contributors can see unrelated Rust, TypeScript, Go, and Python setup paths while the product is a Swift/macOS app.
+- Fix approach: Keep `dev-setup.sh` if it remains the repo bootstrapper, but remove or archive unused language checks that do not participate in the Kubebar quality gate.
+
+## Known Bugs
+
+**Clean first launch cannot complete setup through the UI:**
+- Symptoms: The setup screen can list contexts, but it has no live namespace or workload choices; the add buttons have no behavior; "Finish setup" stays disabled while the watchlist is empty.
+- Files: `Kubebar/MenuBarViewModel.swift`, `Kubebar/Views/SetupView.swift`, `Kubebar/Views/WatchlistPickerView.swift`, `KubebarCore/Models/SetupFlowState.swift`, `KubebarCore/Models/WatchlistSelectionState.swift`
+- Trigger: Launch the app with no saved `config.json`, open setup, select a context, and try to add a namespace or workload.
+- Workaround: Create a config through code/tests or implement target discovery before relying on the setup flow.
+
+**Successful data has no freshness timeout:**
+- Symptoms: A successful snapshot keeps the previous `OK`, `Watch`, or `Bad` state until another refresh fails or succeeds.
+- Files: `Kubebar/MenuBarViewModel.swift`, `KubebarCore/Services/HealthEvaluator.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, `KubebarCore/Models/ClusterSnapshot.swift`
+- Trigger: Complete a successful refresh, leave the app idle past the intended refresh cadence, and do not press "Retry now".
+- Workaround: Use manual refresh as the only freshness control until scheduled refresh and max-age evaluation exist.
+
+**Overlapping manual refreshes can overwrite newer state:**
+- Symptoms: Each `refreshNow()` call creates an untracked `Task`; slower earlier requests and faster later requests can finish in either order and both assign `snapshot` and `display`.
+- Files: `Kubebar/MenuBarViewModel.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, `KubebarCore/Services/KubectlClusterReader.swift`
+- Trigger: Press "Retry now" repeatedly while `kubectl` is slow, timing out, or intermittently failing.
+- Workaround: Avoid repeated manual refresh clicks until the view model tracks a refresh task, serializes requests, or discards stale completions.
+
+**Regression-test workflow YAML has unindented script lines:**
+- Symptoms: The Swift test-detection block is outside the `run: |` indentation level, which makes the workflow file structurally invalid or changes the intended script body.
+- Files: `.github/workflows/regression-test-check.yml`
+- Trigger: GitHub Actions loads the `Regression Test Check` workflow for a pull request.
+- Workaround: Fix indentation for the lines beginning with `# Detect test files in Swift commits` through the matching `fi`.
+
+**Overflow watchlist entry is inert text:**
+- Symptoms: The menu shows "View all tracked" when hidden items exist, but it is a `Text` view with no action or expanded list.
+- Files: `Kubebar/Views/WatchlistSectionView.swift`, `KubebarCore/Services/HealthEvaluator.swift`, `KubebarCore/Models/MenuDisplayModel.swift`
+- Trigger: Use more than five configured watch targets.
+- Workaround: Keep watchlists at five or fewer items until the overflow row opens a secondary view or expanded section.
+
+## Security Considerations
+
+**kubectl executable resolution through PATH:**
+- Risk: `ProcessCommandRunner` runs `/usr/bin/env` with `kubectl`, so executable choice depends on the app process environment.
+- Files: `KubebarCore/Services/CommandRunner.swift`, `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Services/ContextCatalog.swift`
+- Current mitigation: The code passes arguments as an array, so context and target names are not shell-interpolated.
+- Recommendations: Resolve and store an absolute `kubectl` path, validate the executable during setup, and show a recovery message when the binary cannot be found.
+
+**Raw kubectl stderr appears in UI state:**
+- Risk: Command errors flow from `stderr` into `KubectlCommandError.failed`, then into the stale banner reason.
+- Files: `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Services/ContextCatalog.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, `Kubebar/Views/StaleBannerView.swift`
+- Current mitigation: Only stderr text is shown; stdout JSON is not displayed.
+- Recommendations: Redact likely paths, tokens, kubeconfig details, and multi-line command output before assigning user-facing failure reasons.
+
+**Local config file permissions are implicit:**
+- Risk: Saved context and watchlist are written with default filesystem permissions.
+- Files: `KubebarCore/Services/AppConfigStore.swift`, `Kubebar/MenuBarViewModel.swift`
+- Current mitigation: The config stores context and target names, not Kubernetes credentials.
+- Recommendations: Create the application support directory with owner-only permissions where possible and avoid expanding config to secrets.
+
+**Full-cluster read scope:**
+- Risk: The app reads pods and warning events across all namespaces even when the watchlist is small.
+- Files: `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Models/WatchTarget.swift`
+- Current mitigation: Reads use the app-owned selected context and do not mutate cluster state.
+- Recommendations: Prefer namespace-scoped reads for namespace targets and selector-based reads for workload targets, then keep only aggregate display data in memory.
+
+## Performance Bottlenecks
+
+**Full-cluster pod and event snapshots:**
+- Problem: Every snapshot runs `kubectl get pods --all-namespaces -o json` and `kubectl get events --all-namespaces --field-selector type=Warning -o json`.
+- Files: `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Services/CommandRunner.swift`
+- Cause: The reader builds global summaries first and filters watch targets in memory.
+- Improvement path: Query only selected namespaces and workloads where possible, keep global counters optional, and add performance tests with large JSON fixtures.
+
+**Process startup per resource:**
+- Problem: Each refresh starts three subprocesses.
+- Files: `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Services/CommandRunner.swift`
+- Cause: `KubectlRead.allCases` maps to independent `kubectl` commands.
+- Improvement path: Keep the concurrent reads for small clusters, but measure command latency and consider command grouping or incremental APIs if polling becomes noisy.
+
+**Unbounded in-memory output buffering:**
+- Problem: stdout and stderr are read fully into memory before parsing.
+- Files: `KubebarCore/Services/CommandRunner.swift`, `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarTests/Services/CommandRunnerTests.swift`
+- Cause: `LockedDataBuffer` stores complete `Data` for each stream.
+- Improvement path: Add output size limits for command failures and large fixture tests for successful JSON decoding.
+
+**Repeated refresh overlap:**
+- Problem: Manual refreshes can run concurrently and multiply the number of active `kubectl` processes.
+- Files: `Kubebar/MenuBarViewModel.swift`, `Kubebar/Views/MenuBarRootView.swift`, `KubebarCore/Services/KubectlClusterReader.swift`
+- Cause: `refreshNow()` has no in-flight guard, debounce, cancellation, or result generation check.
+- Improvement path: Track the active refresh task, disable the retry action while a refresh is running, and ignore completions from older generations.
+
+## Fragile Areas
+
+**View model async lifecycle:**
+- Files: `Kubebar/MenuBarViewModel.swift`, `KubebarCore/Services/RefreshCoordinator.swift`
+- Why fragile: The view model mutates main-actor state after detached work without tracking task lifetime, cancellation, generation, or app shutdown.
+- Safe modification: Add a stored task handle, isolate refresh state transitions, and test ordering with a controllable fake reader.
+- Test coverage: No tests target `MenuBarViewModel`.
+
+**Manual Sendable wrappers and locking:**
+- Files: `KubebarCore/Services/CommandRunner.swift`, `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarTests/Services/KubectlClusterReaderTests.swift`
+- Why fragile: `@unchecked Sendable`, `NSLock`, `DispatchGroup`, and `DispatchSemaphore` require discipline outside Swift's checked concurrency model.
+- Safe modification: Keep the locking boundary tiny, prefer async APIs for new code, and add tests that cover timeout, cancellation, and concurrent failure ordering.
+- Test coverage: Tests cover concurrent reads and large output, but not cancellation, subprocess tree termination, or mixed success/failure ordering.
+
+**Health priority depends on enum raw values:**
+- Files: `KubebarCore/Models/ClusterHealthState.swift`, `KubebarCore/Services/HealthEvaluator.swift`, `KubebarTests/Models/MenuDisplayModelTests.swift`
+- Why fragile: Watchlist sorting uses `state.rawValue >` as priority, tying UI attention order to enum storage values.
+- Safe modification: Add an explicit `attentionPriority` property and test the order for `bad`, `stale`, `watch`, and `ok`.
+- Test coverage: Tests cover bad-before-ok, but not every state ordering combination.
+
+**UI behavior is mostly untested:**
+- Files: `Kubebar/Views/MenuBarRootView.swift`, `Kubebar/Views/SetupView.swift`, `Kubebar/Views/WatchlistPickerView.swift`, `Kubebar/Views/WatchlistSectionView.swift`, `KubebarTests`
+- Why fragile: The documented requirements include keyboard navigation, setup completion, stale banner visibility, and watchlist overflow behavior, but tests target models and services.
+- Safe modification: Add view model tests first, then add snapshot or UI-level checks for the menu states that carry product trust.
+- Test coverage: No `KubebarTests/Views` directory is present.
+
+**CI workflow script embedding:**
+- Files: `.github/workflows/regression-test-check.yml`
+- Why fragile: Shell code inside YAML is indentation-sensitive, and the current test-detection block has no `run: |` indentation.
+- Safe modification: Move the script to `.github/scripts/` and call it from the workflow, or add a YAML lint step.
+- Test coverage: No workflow lint or local CI validation script is present.
+
+## Scaling Limits
+
+**Cluster size:**
+- Current capacity: One refresh starts three `kubectl` commands and holds full node, pod, and warning-event JSON in memory.
+- Limit: Large clusters, high warning-event counts, or slow API servers can hit the default 10-second command timeout.
+- Scaling path: Use scoped reads, selector-based queries, output limits, and incremental refresh options.
+- Files: `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Services/CommandRunner.swift`
+
+**Watchlist size:**
+- Current capacity: First-screen display shows five items by default.
+- Limit: More than five configured targets only produce an inert overflow label.
+- Scaling path: Add a real overflow view, search/filter for setup, and preserve attention ordering in expanded views.
+- Files: `KubebarCore/Services/HealthEvaluator.swift`, `Kubebar/Views/WatchlistSectionView.swift`, `KubebarCore/Models/MenuDisplayModel.swift`
+
+**Refresh concurrency:**
+- Current capacity: No explicit cap on concurrent manual refresh tasks.
+- Limit: Repeated retry actions can run many `kubectl` commands and assign stale results out of order.
+- Scaling path: Serialize refreshes and expose in-progress state to the UI.
+- Files: `Kubebar/MenuBarViewModel.swift`, `Kubebar/Views/MenuBarRootView.swift`
+
+**Configuration model:**
+- Current capacity: One selected context, one array of watch targets, and one integer refresh interval.
+- Limit: No validation for refresh interval bounds, no migration version, and no recovery message for malformed config.
+- Scaling path: Add config versioning, validation, and explicit recovery state before adding new fields.
+- Files: `KubebarCore/Services/AppConfigStore.swift`, `KubebarCore/Models/WatchTarget.swift`, `Kubebar/MenuBarViewModel.swift`
+
+## Dependencies at Risk
+
+**kubectl:**
+- Risk: The app requires `kubectl` to exist in the runtime PATH and to return expected JSON fields.
+- Impact: Missing `kubectl`, incompatible output, RBAC restrictions, or launchd PATH differences make setup or refresh fail.
+- Migration plan: Add setup-time executable validation, an absolute path setting, richer error messages, and fixtures for Kubernetes output variants.
+- Files: `KubebarCore/Services/CommandRunner.swift`, `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Services/ContextCatalog.swift`
+
+**XcodeGen and generated project:**
+- Risk: `project.yml` is the source for `Kubebar.xcodeproj`, while `Package.swift` also defines targets.
+- Impact: Target settings can drift between Swift Package Manager and the generated Xcode project.
+- Migration plan: Treat `project.yml` as the app-project source, add a check that regenerated project output is clean, and keep `Package.swift` limited to package-compatible targets.
+- Files: `project.yml`, `Package.swift`, `Kubebar.xcodeproj`, `README.md`, `scripts/swift-quality-gate.sh`
+
+**GitHub Actions macOS image:**
+- Risk: CI uses `macos-latest`, which can move Xcode and Swift versions.
+- Impact: Builds can change behavior without a repository change.
+- Migration plan: Pin a macOS image and Xcode version when release readiness matters.
+- Files: `.github/workflows/ci.yml`, `project.yml`, `Package.swift`
+
+**Codecov configuration without upload workflow:**
+- Risk: Coverage thresholds exist, but no workflow step uploads coverage.
+- Impact: Coverage expectations may look enforced when CI does not publish coverage data.
+- Migration plan: Add coverage generation and upload, or remove `codecov.yml` until coverage is wired.
+- Files: `codecov.yml`, `.github/workflows/ci.yml`, `scripts/swift-quality-gate.sh`
+
+## Missing Critical Features
+
+**Watch target catalog:**
+- Problem: No code lists namespaces or workload candidates for setup.
+- Blocks: First-use setup, watchlist editing, and trustworthy user onboarding.
+- Files: `Kubebar/MenuBarViewModel.swift`, `Kubebar/Views/WatchlistPickerView.swift`, `KubebarCore/Services/ContextCatalog.swift`
+
+**Scheduled refresh and stale threshold:**
+- Problem: Refresh is initial/manual only, and old success states have no age-based stale transition.
+- Blocks: Daily use as a trustworthy status instrument.
+- Files: `Kubebar/MenuBarViewModel.swift`, `KubebarCore/Services/AppConfigStore.swift`, `KubebarCore/Services/HealthEvaluator.swift`
+
+**Actionable warning and workload reasons:**
+- Problem: Warning events are only counted and workload health is reduced to running pod counts.
+- Blocks: The menu's ability to answer what needs attention without opening another tool.
+- Files: `KubebarCore/Services/KubectlClusterReader.swift`, `Kubebar/Views/WarningEventsView.swift`, `Kubebar/Views/TrackedItemDetailView.swift`
+
+**Operator-facing app verification:**
+- Problem: Tests do not exercise the real menu window, keyboard navigation, setup completion, or visual stale states.
+- Blocks: Confidence that the macOS app communicates the core trust states correctly.
+- Files: `Kubebar/Views/MenuBarRootView.swift`, `Kubebar/Views/SetupView.swift`, `KubebarTests`
+
+## Test Coverage Gaps
+
+**Setup integration:**
+- What's not tested: Loading contexts, selecting a context, populating available targets, selecting watch targets, saving config, and leaving setup through `MenuBarViewModel`.
+- Files: `Kubebar/MenuBarViewModel.swift`, `Kubebar/Views/SetupView.swift`, `Kubebar/Views/WatchlistPickerView.swift`, `KubebarTests/Models/SetupFlowStateTests.swift`, `KubebarTests/Models/WatchlistSelectionStateTests.swift`
+- Risk: The state model tests pass while the app setup path remains unusable.
+- Priority: High
+
+**Freshness and refresh scheduling:**
+- What's not tested: Automatic refresh cadence, max-age stale transition, refresh cancellation, and repeated manual refresh ordering.
+- Files: `Kubebar/MenuBarViewModel.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, `KubebarCore/Services/HealthEvaluator.swift`, `KubebarTests/Services/RefreshCoordinatorTests.swift`
+- Risk: Stale or out-of-order data can overwrite the user's current understanding.
+- Priority: High
+
+**Kubernetes parser edge cases:**
+- What's not tested: Empty pod lists, malformed pod JSON, malformed event JSON, timeout propagation, container readiness, restart counts, owner references, warning event details, and RBAC failures for only one resource type.
+- Files: `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarTests/Services/KubectlClusterReaderTests.swift`
+- Risk: Common real-cluster states can be misclassified or collapsed into generic stale errors.
+- Priority: High
+
+**Command runner failure behavior:**
+- What's not tested: Timeout process-tree cleanup, stderr redaction, non-UTF8 output, massive error output, and launchd-like PATH differences.
+- Files: `KubebarCore/Services/CommandRunner.swift`, `KubebarTests/Services/CommandRunnerTests.swift`
+- Risk: Refreshes can hang, leak subprocesses, or surface unhelpful error text.
+- Priority: Medium
+
+**View and accessibility states:**
+- What's not tested: Menu bar icon readability, stale banner presentation, keyboard navigation, inert overflow row behavior, and setup button reachability.
+- Files: `Kubebar/KubebarApp.swift`, `Kubebar/Views/MenuBarRootView.swift`, `Kubebar/Views/StaleBannerView.swift`, `Kubebar/Views/WatchlistSectionView.swift`, `KubebarTests`
+- Risk: The product can satisfy model tests while failing the actual menu-bar workflow.
+- Priority: Medium
+
+**CI and workflow validity:**
+- What's not tested: YAML syntax, action script indentation, and whether coverage settings are enforced.
+- Files: `.github/workflows/regression-test-check.yml`, `.github/workflows/ci.yml`, `codecov.yml`
+- Risk: Review and quality gates can fail before tests run or silently skip intended checks.
+- Priority: Medium
+
+---
+
+*Concerns audit: 2026-04-19*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -64,7 +64,7 @@
 - Symptoms: The Swift test-detection block is outside the `run: |` indentation level, which makes the workflow file structurally invalid or changes the intended script body.
 - Files: `.github/workflows/regression-test-check.yml`
 - Trigger: GitHub Actions loads the `Regression Test Check` workflow for a pull request.
-- Workaround: Fix indentation for the lines beginning with `# Detect test files in Swift commits` through the matching `fi`.
+- Workaround: Use the `skip-regression-check` label on the pull request to bypass the failing check until the indentation is corrected.
 
 **Overflow watchlist entry is inert text:**
 - Symptoms: The menu shows "View all tracked" when hidden items exist, but it is a `Text` view with no action or expanded list.

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,113 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-04-19
+
+## Naming Patterns
+
+**Files:**
+- Use one primary type per Swift file and name the file after that type, as in `KubebarCore/Services/HealthEvaluator.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, and `Kubebar/Views/MenuBarRootView.swift`.
+- Put SwiftUI views under `Kubebar/Views/` with `View` suffixes, such as `Kubebar/Views/WatchlistPickerView.swift`, `Kubebar/Views/StaleBannerView.swift`, and `Kubebar/Views/StatusSummaryView.swift`.
+- Put core behavior under `KubebarCore/Models/` and `KubebarCore/Services/`, such as `KubebarCore/Models/MenuDisplayModel.swift` and `KubebarCore/Services/KubectlClusterReader.swift`.
+- Put tests under `KubebarTests/Models/` and `KubebarTests/Services/`, mirroring the production area they cover, such as `KubebarTests/Models/MenuDisplayModelTests.swift` for `KubebarCore/Models/MenuDisplayModel.swift`.
+
+**Functions:**
+- Use lowerCamelCase verbs or verb phrases for functions and methods, as in `refreshNow()` in `Kubebar/MenuBarViewModel.swift`, `readSnapshot(contextName:watchTargets:now:)` in `KubebarCore/Services/KubectlClusterReader.swift`, and `listContexts()` in `KubebarCore/Services/ContextCatalog.swift`.
+- Use domain-specific helper names for private transformations, as in `evaluateState(_:)`, `sortByAttention(_:)`, `healthSentence(for:visibleItems:)`, and `relativeAge(from:to:)` in `KubebarCore/Services/HealthEvaluator.swift`.
+- Use behavior-oriented test function names that match `@Test` descriptions, as in `failedRefreshKeepsPreviousDataButMarksItStale()` in `KubebarTests/Models/MenuDisplayModelTests.swift`.
+
+**Variables:**
+- Use lowerCamelCase nouns for local values and stored properties, as in `visibleWatchItemLimit` in `KubebarCore/Services/HealthEvaluator.swift`, `warningEventCount` in `KubebarCore/Models/ClusterSnapshot.swift`, and `selectedTargets` in `KubebarCore/Models/WatchlistSelectionState.swift`.
+- Use `let` by default for immutable state and `var` only for mutable state, as seen across value models in `KubebarCore/Models/ClusterSnapshot.swift` and `KubebarCore/Models/MenuDisplayModel.swift`.
+- Use explicit user-facing names for presentation values, such as `healthSentence`, `staleBanner`, `accessibilityLabel`, and `symbolName` in `KubebarCore/Models/MenuDisplayModel.swift` and `KubebarCore/Models/MenuBarStatusPresentation.swift`.
+
+**Types:**
+- Use UpperCamelCase for structs, enums, protocols, classes, suites, and fakes, as in `MenuDisplayModel`, `ClusterHealthState`, `CommandRunning`, `ProcessCommandRunner`, and `FakeCommandRunner` in `KubebarCore/Models/MenuDisplayModel.swift`, `KubebarCore/Models/ClusterHealthState.swift`, `KubebarCore/Services/CommandRunner.swift`, and `KubebarTests/Services/ContextCatalogTests.swift`.
+- Prefer `struct` and `enum` for app state and domain rules, as in `AppConfig`, `WatchTarget`, `HealthEvaluator`, and `RefreshCoordinator` in `KubebarCore/Services/AppConfigStore.swift`, `KubebarCore/Models/WatchTarget.swift`, `KubebarCore/Services/HealthEvaluator.swift`, and `KubebarCore/Services/RefreshCoordinator.swift`.
+- Use `final class` only where reference semantics or framework integration require it, such as `MenuBarViewModel` in `Kubebar/MenuBarViewModel.swift`, `ProcessCommandRunner` in `KubebarCore/Services/CommandRunner.swift`, and lock-backed test doubles in `KubebarTests/Services/KubectlClusterReaderTests.swift`.
+
+## Code Style
+
+**Formatting:**
+- Tool used: Not detected for a dedicated formatter. No `.swiftformat`, `.swiftlint.yml`, or `.editorconfig` file is present at the repository root; style is enforced through Swift compiler formatting conventions, local examples in `KubebarCore/` and `Kubebar/`, and the quality gate in `scripts/swift-quality-gate.sh`.
+- Indent Swift with 4 spaces, as consistently used in `KubebarCore/Services/HealthEvaluator.swift`, `KubebarCore/Services/KubectlClusterReader.swift`, and `Kubebar/Views/SetupView.swift`.
+- Break long initializers and calls over multiple lines with one argument per line, as in `MenuDisplayModel(...)` construction in `KubebarCore/Services/HealthEvaluator.swift` and `ClusterSnapshot(...)` setup in `KubebarTests/Models/MenuDisplayModelTests.swift`.
+- Keep SwiftUI view bodies declarative and extract subviews into private computed `some View` properties, as in `menuContent` and `actions` in `Kubebar/Views/MenuBarRootView.swift`, plus `header`, `contextPicker`, and `footer` in `Kubebar/Views/SetupView.swift`.
+
+**Linting:**
+- Tool used: Not detected for SwiftLint enforcement. `scripts/dev-setup.sh` treats `swiftlint` as optional, and `scripts/swift-quality-gate.sh` does not invoke it.
+- Key rules from `AGENTS.md`: no force unwraps or `try!` in production without an adjacent safety comment, no production `fatalError` except for documented impossible states, explicit access control, thin views, dependency injection, and exhaustive enum switches.
+- Existing production Swift under `Kubebar/` and `KubebarCore/` contains no `try!`, `as!`, `fatalError`, or panic-style constructs according to the scanned source paths.
+
+## Import Organization
+
+**Order:**
+1. System and Apple frameworks first, as in `Foundation`, `AppKit`, and `SwiftUI` imports in `KubebarCore/Services/CommandRunner.swift`, `Kubebar/KubebarApp.swift`, and `Kubebar/MenuBarViewModel.swift`.
+2. Project modules after system imports, as in `import KubebarCore` after `import SwiftUI` in `Kubebar/Views/MenuBarRootView.swift` and after `import Foundation` / `import SwiftUI` in `Kubebar/MenuBarViewModel.swift`.
+3. Tests import `Foundation` only when needed, then `Testing`, then `@testable import KubebarCore`, as in `KubebarTests/Services/KubectlClusterReaderTests.swift` and `KubebarTests/Models/MenuDisplayModelTests.swift`.
+
+**Path Aliases:**
+- Not detected. Swift module boundaries come from `Package.swift` and `project.yml`: `Kubebar` depends on `KubebarCore`, and `KubebarTests` depends on `KubebarCore`.
+- Do not introduce custom path aliases; add code to the existing Swift targets in `Package.swift` and `project.yml`.
+
+## Error Handling
+
+**Patterns:**
+- Propagate service failures with typed Swift errors from boundary types, as in `CommandRunnerError` in `KubebarCore/Services/CommandRunner.swift`, `KubectlCommandError` in `KubebarCore/Services/ContextCatalog.swift`, and `AppConfigStoreError` in `KubebarCore/Services/AppConfigStore.swift`.
+- Convert lower-level errors into product-specific errors before crossing core service boundaries, as `KubectlClusterReader` maps timeouts, launch failures, non-zero exits, and invalid JSON to `KubectlCommandError.failed(...)` in `KubebarCore/Services/KubectlClusterReader.swift`.
+- Keep stale data explicit instead of silently discarding it. `RefreshCoordinator.refresh(...)` returns the previous snapshot and a stale display after failures in `KubebarCore/Services/RefreshCoordinator.swift`.
+- Use `guard` for required preconditions and early exits, as in missing setup handling in `KubebarCore/Services/RefreshCoordinator.swift`, missing config files in `KubebarCore/Services/AppConfigStore.swift`, and invalid setup completion in `Kubebar/MenuBarViewModel.swift`.
+- Avoid exposing raw implementation errors to the UI. `MenuBarViewModel.completeSetup()` turns save failures into `setupState.configurationMessage` in `Kubebar/MenuBarViewModel.swift`; `loadContexts()` treats context listing failure as an empty context list in the same file.
+
+## Logging
+
+**Framework:** None detected in production Swift.
+
+**Patterns:**
+- No `print`, `Logger`, or `os_log` usage is present in `Kubebar/` or `KubebarCore/`.
+- Surface user-visible failures through display models and setup state rather than logs, as in `StaleBannerDisplay` from `KubebarCore/Models/MenuDisplayModel.swift`, `RefreshFailure` from `KubebarCore/Services/HealthEvaluator.swift`, and `configurationMessage` in `KubebarCore/Models/SetupFlowState.swift`.
+- If logging is added, keep secrets and raw command output out of logs because `AGENTS.md` classifies secrets, config loading, persistence, and public or network-facing behavior as high-risk.
+
+## Comments
+
+**When to Comment:**
+- Production Swift currently uses almost no inline comments in `Kubebar/` and `KubebarCore/`; prefer clear type, method, and property names over explanatory comments.
+- Add comments only for non-obvious safety decisions, especially if using a rule exception from `AGENTS.md` such as a force unwrap, `try!`, `fatalError`, or `@unchecked Sendable`.
+- Keep architecture-level explanations in docs rather than source comments. Use `docs/architecture/system-overview.md` for subsystem flow and `docs/architecture/runtime-invariants.md` for runtime guarantees.
+
+**JSDoc/TSDoc:**
+- Not applicable. This is a Swift codebase.
+- Swift DocC comments are not currently used in `Kubebar/`, `KubebarCore/`, or `KubebarTests/`.
+
+## Function Design
+
+**Size:** Keep functions small and single-purpose.
+- Use short pure helpers for domain transforms, as in `evaluateState(_:)`, `sortByAttention(_:)`, `makeDisplayItem(_:)`, and `shortened(_:)` in `KubebarCore/Services/HealthEvaluator.swift`.
+- Keep longer boundary methods only when coordinating I/O and concurrency, as in `ProcessCommandRunner.run(_:)` in `KubebarCore/Services/CommandRunner.swift` and `readRawSnapshot(contextName:)` in `KubebarCore/Services/KubectlClusterReader.swift`.
+- Keep SwiftUI `body` values thin and delegate sections to private computed properties, as in `Kubebar/Views/SetupView.swift` and `Kubebar/Views/WatchlistPickerView.swift`.
+
+**Parameters:** Prefer explicit labels that describe domain meaning.
+- Use labels such as `contextName`, `watchTargets`, `previousSnapshot`, and `now` in `KubebarCore/Services/KubectlClusterReader.swift` and `KubebarCore/Services/RefreshCoordinator.swift`.
+- Pass `Date` as an explicit `now` parameter in deterministic core behavior, as in `HealthEvaluator.evaluate(...)` in `KubebarCore/Services/HealthEvaluator.swift` and tests in `KubebarTests/Models/MenuDisplayModelTests.swift`.
+- Inject boundaries through initializers with production defaults, as in `KubectlClusterReader(runner:)`, `ContextCatalog(runner:)`, `RefreshCoordinator(reader:evaluator:)`, and `MenuBarViewModel(configStore:refreshCoordinator:contextCatalog:now:)` in `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Services/ContextCatalog.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, and `Kubebar/MenuBarViewModel.swift`.
+
+**Return Values:** Return app-owned value types instead of raw external data.
+- UI-facing code should receive `MenuDisplayModel`, `MenuCounters`, `WatchItemDisplay`, and `StaleBannerDisplay` from `KubebarCore/Models/MenuDisplayModel.swift`.
+- External command readers should return `ClusterSnapshot` and domain summaries, not raw `kubectl` JSON, as in `KubebarCore/Services/KubectlClusterReader.swift` and `KubebarCore/Models/ClusterSnapshot.swift`.
+- Mutating setup and selection helpers update value state directly, as in `selectContext(_:)` in `KubebarCore/Models/SetupFlowState.swift` and `toggle(_:)` in `KubebarCore/Models/WatchlistSelectionState.swift`.
+
+## Module Design
+
+**Exports:** Use explicit public APIs in `KubebarCore` and internal app-only UI types in `Kubebar`.
+- Public core models and services define `public` types, properties, and initializers in `KubebarCore/Models/*.swift` and `KubebarCore/Services/*.swift`.
+- Keep helper details private or file-private within the same file, as in `KubectlRead`, `RawKubectlSnapshot`, `LockedKubectlResults`, `NodeRecord`, and `PodRecord` in `KubebarCore/Services/KubectlClusterReader.swift`.
+- Keep SwiftUI views internal by default in `Kubebar/Views/*.swift`; app composition happens through `Kubebar/KubebarApp.swift` and `Kubebar/MenuBarViewModel.swift`.
+- Mark concurrency-facing values `Sendable` when they cross detached tasks or service boundaries, as in `ClusterSnapshot`, `RefreshResult`, `CommandRequest`, `CommandResult`, and `KubectlClusterReader` in `KubebarCore/Models/ClusterSnapshot.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, `KubebarCore/Services/CommandRunner.swift`, and `KubebarCore/Services/KubectlClusterReader.swift`.
+- Use `@MainActor` for UI-bound state and side effects, as in `MenuBarViewModel` in `Kubebar/MenuBarViewModel.swift`.
+
+**Barrel Files:** Not used.
+- No aggregate export files are present in `KubebarCore/Models/` or `KubebarCore/Services/`.
+- Add new types directly to the appropriate target path instead of introducing a barrel file.
+
+---
+
+*Convention analysis: 2026-04-19*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,111 @@
+# External Integrations
+
+**Analysis Date:** 2026-04-19
+
+## APIs & External Services
+
+**Kubernetes:**
+- Kubernetes clusters are read through the local `kubectl` executable, not through an embedded Kubernetes SDK.
+  - SDK/Client: `kubectl` invoked by `KubebarCore/Services/CommandRunner.swift`.
+  - Auth: delegated to the user's existing `kubectl` and kubeconfig setup; no app-owned credential store is present.
+  - Context discovery: `KubebarCore/Services/ContextCatalog.swift` runs `kubectl config get-contexts -o name`.
+  - Node health: `KubebarCore/Services/KubectlClusterReader.swift` runs `kubectl --context <context> get nodes -o json`.
+  - Pod health: `KubebarCore/Services/KubectlClusterReader.swift` runs `kubectl --context <context> get pods --all-namespaces -o json`.
+  - Warning events: `KubebarCore/Services/KubectlClusterReader.swift` runs `kubectl --context <context> get events --all-namespaces --field-selector type=Warning -o json`.
+  - Output contract: JSON decoded with `JSONDecoder` inside `KubebarCore/Services/KubectlClusterReader.swift`.
+
+**GitHub:**
+- GitHub Actions runs pull request checks and PR labeling.
+  - SDK/Client: GitHub Actions workflows in `.github/workflows/ci.yml`, `.github/workflows/pr-labels.yml`, and `.github/workflows/regression-test-check.yml`.
+  - Auth: `secrets.GITHUB_TOKEN` is used by `.github/workflows/pr-labels.yml`.
+- GitHub API is used by repository helper scripts.
+  - SDK/Client: `gh` CLI in `.github/scripts/pr-labeler.sh` and `.github/scripts/create-labels.sh`.
+  - Auth: `GH_TOKEN` in `.github/workflows/pr-labels.yml` for CI; local `gh` authentication for manual script use.
+  - Repository input: `REPO` and `PR_NUMBER` environment variables in `.github/scripts/pr-labeler.sh`; `REPO` in `.github/scripts/create-labels.sh`.
+- GitHub labeler action applies scope labels.
+  - SDK/Client: `actions/labeler@v5` in `.github/workflows/pr-labels.yml`.
+  - Auth: `secrets.GITHUB_TOKEN`.
+  - Rules: `.github/labeler.yml`.
+
+**Coverage Services:**
+- Codecov thresholds are configured but upload wiring is not detected.
+  - SDK/Client: `codecov.yml` only.
+  - Auth: Not detected.
+
+## Data Storage
+
+**Databases:**
+- None detected. No Core Data, SQLite, database client, ORM, or hosted database integration is present in `Kubebar/`, `KubebarCore/`, `Package.swift`, or `project.yml`.
+
+**File Storage:**
+- Local filesystem only.
+  - Config file: `Application Support/Kubebar/config.json`.
+  - Implementation: `KubebarCore/Services/AppConfigStore.swift`.
+  - Directory selection: `Kubebar/MenuBarViewModel.swift`.
+  - Stored fields: selected Kubernetes context, watch targets, and refresh interval from `AppConfig`.
+- Test-only temporary files are created in `KubebarTests/Services/AppConfigStoreTests.swift`.
+
+**Caching:**
+- External cache: None.
+- In-memory state: `Kubebar/MenuBarViewModel.swift` keeps the latest `ClusterSnapshot?`; `KubebarCore/Services/RefreshCoordinator.swift` uses the previous snapshot when refresh fails so stale data is clearly marked.
+
+## Authentication & Identity
+
+**Auth Provider:**
+- No app-level user authentication provider is present.
+  - Implementation: The app is a local macOS utility and does not create accounts or sessions.
+  - Kubernetes identity: delegated to `kubectl`; Kubebar stores the selected context name, not credentials.
+  - GitHub identity: delegated to GitHub Actions `GITHUB_TOKEN` and local `gh` authentication for repository scripts.
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- None detected. No Sentry, Crashlytics, OpenTelemetry, Datadog, or custom remote error reporting package is present.
+
+**Logs:**
+- App runtime logging framework: Not detected.
+- User-visible failure path: `KubebarCore/Services/RefreshCoordinator.swift` converts reader failures into `RefreshFailure`; `KubebarCore/Services/HealthEvaluator.swift` renders stale display state and failure reasons.
+- CI logs: GitHub Actions logs from `.github/workflows/ci.yml`, `.github/workflows/pr-labels.yml`, and `.github/workflows/regression-test-check.yml`.
+- Coverage status configuration: `codecov.yml`.
+
+## CI/CD & Deployment
+
+**Hosting:**
+- Not applicable for the app. Kubebar is a native macOS app with no hosted runtime.
+
+**CI Pipeline:**
+- Pull request quality gate: `.github/workflows/ci.yml` runs `./scripts/swift-quality-gate.sh ci` on `macos-latest`.
+- Pull request labels: `.github/workflows/pr-labels.yml` runs `actions/labeler@v5` and `.github/scripts/pr-labeler.sh`.
+- Regression test enforcement: `.github/workflows/regression-test-check.yml` requires test changes for fix-style PRs unless `skip-regression-check` is present.
+- Local pre-push gate: `.githooks/pre-push` runs `./scripts/swift-quality-gate.sh local`.
+- Distribution or release deployment automation: Not detected.
+
+## Environment Configuration
+
+**Required env vars:**
+- App runtime: None read directly by Swift source.
+- Kubernetes access: `kubectl` must be installed and configured for the selected context. Standard `kubectl` configuration may come from the user's kubeconfig or environment, but Kubebar does not read kubeconfig values itself.
+- Quality gate overrides: `XCODE_WORKSPACE`, `XCODE_PROJECT`, `XCODE_SCHEME`, `XCODE_CONFIGURATION`, `XCODE_DESTINATION`, and `XCODE_DERIVED_DATA_PATH` are supported by `scripts/swift-quality-gate.sh`.
+- GitHub Actions CI variables: `.github/workflows/ci.yml` passes repository variables named `XCODE_WORKSPACE`, `XCODE_PROJECT`, `XCODE_SCHEME`, `XCODE_CONFIGURATION`, and `XCODE_DESTINATION`.
+- PR label script: `.github/scripts/pr-labeler.sh` requires `PR_NUMBER` and `REPO`; `.github/workflows/pr-labels.yml` also provides `GH_TOKEN`.
+- Label creation script: `.github/scripts/create-labels.sh` requires `REPO`.
+
+**Secrets location:**
+- GitHub workflow token: `secrets.GITHUB_TOKEN` in `.github/workflows/pr-labels.yml`.
+- Local app secrets: None detected.
+- Environment files: `.env.example` exists but its contents were not read. `.gitignore` excludes `.env` and `.env.local`.
+- Kubernetes credentials: managed outside Kubebar by the user's `kubectl`/kubeconfig setup.
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- App runtime: None.
+- Repository automation: GitHub pull request events trigger `.github/workflows/ci.yml`, `.github/workflows/pr-labels.yml`, and `.github/workflows/regression-test-check.yml`.
+
+**Outgoing:**
+- App runtime: No direct HTTP client is present. Kubernetes communication happens indirectly through `kubectl` subprocess calls from `KubebarCore/Services/KubectlClusterReader.swift` and `KubebarCore/Services/ContextCatalog.swift`.
+- Repository automation: `.github/scripts/pr-labeler.sh` and `.github/scripts/create-labels.sh` call GitHub through `gh`.
+
+---
+
+*Integration audit: 2026-04-19*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,100 @@
+# Technology Stack
+
+**Analysis Date:** 2026-04-19
+
+## Languages
+
+**Primary:**
+- Swift 6.0 - Product app, reusable core module, and unit tests. Declared by `Package.swift` and `project.yml`; source lives in `Kubebar/`, `KubebarCore/`, and `KubebarTests/`.
+
+**Secondary:**
+- Bash - Local setup, quality gates, Git hooks, and GitHub helper scripts in `scripts/swift-quality-gate.sh`, `scripts/dev-setup.sh`, `.githooks/pre-push`, `.githooks/commit-msg`, `.github/scripts/pr-labeler.sh`, and `.github/scripts/create-labels.sh`.
+- YAML - XcodeGen, CI, labeler, and coverage configuration in `project.yml`, `.github/workflows/ci.yml`, `.github/workflows/pr-labels.yml`, `.github/workflows/regression-test-check.yml`, `.github/labeler.yml`, and `codecov.yml`.
+- Python 3 - Auxiliary repository script in `scripts/check_no_panics.py`; it is not part of the Swift app runtime.
+
+## Runtime
+
+**Environment:**
+- Native macOS menu bar utility targeting macOS 14.0 or newer.
+- `Kubebar/KubebarApp.swift` uses `SwiftUI.MenuBarExtra` with `.menuBarExtraStyle(.window)`.
+- `Kubebar/KubebarApp.swift` imports `AppKit` and sets `NSApplication` activation policy to `.accessory`.
+- `project.yml` sets `INFOPLIST_KEY_LSUIElement: YES`, so the app runs as a menu bar accessory instead of a regular Dock app.
+
+**Package Manager:**
+- Swift Package Manager, declared by `Package.swift`.
+- Lockfile: missing. No `Package.resolved` is present because no external Swift package dependencies are declared.
+- Additional project generator: XcodeGen through `project.yml`; `README.md` documents `xcodegen generate` after target or source folder changes. The XcodeGen version is not pinned in the repository.
+
+## Frameworks
+
+**Core:**
+- SwiftUI - Menu bar scene, views, setup UI, watchlist UI, and display rendering in `Kubebar/KubebarApp.swift` and `Kubebar/Views/`.
+- AppKit - macOS application activation policy in `Kubebar/KubebarApp.swift`.
+- Foundation - Processes, files, JSON decoding, dates, locks, and concurrency helpers in `KubebarCore/Services/` and `KubebarCore/Models/`.
+- Swift Concurrency - UI-to-background refresh flow uses `Task` and `Task.detached` in `Kubebar/MenuBarViewModel.swift`; subprocess fan-out uses `DispatchGroup` and `DispatchQueue` in `KubebarCore/Services/KubectlClusterReader.swift`.
+
+**Testing:**
+- Swift Testing - Test files import `Testing` and use `@Suite`, `@Test`, and `#expect` in `KubebarTests/Services/` and `KubebarTests/Models/`.
+- Xcode test runner - `scripts/swift-quality-gate.sh` runs `xcodebuild ... test` against the shared `Kubebar` scheme in `Kubebar.xcodeproj/xcshareddata/xcschemes/Kubebar.xcscheme`.
+- SwiftPM test runner - `scripts/swift-quality-gate.sh` runs `swift test` when `Package.swift` is present.
+
+**Build/Dev:**
+- Xcode project - `Kubebar.xcodeproj/` contains the committed macOS app project and shared scheme.
+- XcodeGen - `project.yml` is the source for regenerating `Kubebar.xcodeproj/`.
+- SwiftPM - `Package.swift` defines executable product `Kubebar`, library product `KubebarCore`, and test target `KubebarCoreTests`.
+- Quality gate - `scripts/swift-quality-gate.sh local` runs Xcode build, Xcode tests, `swift build`, and `swift test`.
+- Git hooks - `.githooks/pre-push` runs the Swift quality gate; `.githooks/commit-msg` enforces tests for fix commits.
+- GitHub Actions - `.github/workflows/ci.yml`, `.github/workflows/pr-labels.yml`, and `.github/workflows/regression-test-check.yml` run pull request checks and labels.
+
+## Key Dependencies
+
+**Critical:**
+- Apple SDK frameworks - `SwiftUI`, `AppKit`, and `Foundation` are the only product code frameworks imported by `Kubebar/` and `KubebarCore/`.
+- `kubectl` executable - Required for live Kubernetes reads. `KubebarCore/Services/ContextCatalog.swift` invokes `kubectl config get-contexts -o name`; `KubebarCore/Services/KubectlClusterReader.swift` invokes `kubectl --context <context> get ... -o json`.
+- Local filesystem - Required for app configuration. `Kubebar/MenuBarViewModel.swift` selects the Application Support `Kubebar` directory, and `KubebarCore/Services/AppConfigStore.swift` reads/writes `config.json`.
+
+**Infrastructure:**
+- `xcodebuild` - Required by `scripts/swift-quality-gate.sh` and checked by `scripts/dev-setup.sh`.
+- Swift toolchain - Required by `Package.swift`, `swift build`, and `swift test`; checked by `scripts/dev-setup.sh`.
+- `xcodegen` - Required only when regenerating `Kubebar.xcodeproj` from `project.yml`; documented in `README.md`.
+- GitHub Actions `actions/checkout@v4` - Used by `.github/workflows/ci.yml`, `.github/workflows/pr-labels.yml`, and `.github/workflows/regression-test-check.yml`.
+- GitHub Actions `actions/labeler@v5` - Used by `.github/workflows/pr-labels.yml` with rules from `.github/labeler.yml`.
+- GitHub CLI `gh` and `jq` - Required by `.github/scripts/pr-labeler.sh`; `gh` is also required by `.github/scripts/create-labels.sh`.
+- Codecov configuration - `codecov.yml` defines project and patch coverage status thresholds. No Codecov upload workflow is detected.
+- SwiftLint - Optional only. `scripts/dev-setup.sh` reports it when installed but the quality gate does not run it.
+
+## Configuration
+
+**Environment:**
+- Runtime app configuration is stored as JSON, not environment variables. `KubebarCore/Services/AppConfigStore.swift` encodes `AppConfig` to `config.json`.
+- Default app config location is `Application Support/Kubebar/config.json`, built in `Kubebar/MenuBarViewModel.swift`.
+- App config contains `selectedContext`, `watchTargets`, and `refreshIntervalSeconds` from `KubebarCore/Services/AppConfigStore.swift`.
+- Kubernetes credential handling is delegated to `kubectl`; the Swift app does not parse kubeconfig files, store cluster credentials, or read a `KUBECONFIG` variable directly.
+- `.env.example` exists at the repository root. Its contents were not read. `.gitignore` ignores `.env` and `.env.local`.
+
+**Build:**
+- `Package.swift` sets `swift-tools-version: 6.0`, platform `.macOS(.v14)`, products, and target paths.
+- `project.yml` sets `SWIFT_VERSION: "6.0"`, `MACOSX_DEPLOYMENT_TARGET: "14.0"`, bundle identifiers, target types, and the `Kubebar` scheme.
+- `Kubebar.xcodeproj/xcshareddata/xcschemes/Kubebar.xcscheme` builds `Kubebar.app` and `KubebarCore.framework`, then runs `KubebarTests.xctest`.
+- `scripts/swift-quality-gate.sh` accepts `XCODE_WORKSPACE`, `XCODE_PROJECT`, `XCODE_SCHEME`, `XCODE_CONFIGURATION`, `XCODE_DESTINATION`, and `XCODE_DERIVED_DATA_PATH`.
+- `.github/workflows/ci.yml` passes GitHub repository variables with the same `XCODE_*` names into the quality gate.
+
+## Platform Requirements
+
+**Development:**
+- macOS with Xcode command line tools, because `scripts/dev-setup.sh` requires `swift` and `xcodebuild`.
+- Swift 6-compatible toolchain, matching `Package.swift` and `project.yml`.
+- XcodeGen when changing generated Xcode project structure from `project.yml`.
+- `kubectl` for running the app against real clusters and for live context discovery.
+- GitHub CLI `gh` and `jq` for PR label scripts in `.github/scripts/pr-labeler.sh`.
+- Optional SwiftLint only if the project adopts it; no SwiftLint config is present.
+
+**Production:**
+- macOS 14.0 or newer.
+- Native app bundle identifier `com.nextty.kubebar` from `project.yml`.
+- Local `kubectl` installation with access to the user-selected Kubernetes context.
+- No server backend, database server, hosted API, or external Swift package dependency is required by the app.
+
+---
+
+*Stack analysis: 2026-04-19*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,293 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-04-19
+
+## Directory Layout
+
+```text
+kubebar/
+├── AGENTS.md                    # Repo-wide product, architecture, coding, and quality rules
+├── README.md                    # User/developer overview and build instructions
+├── CONTRIBUTING.md              # Contribution and review expectations
+├── CHANGELOG.md                 # Release history
+├── Package.swift                # Swift Package Manager targets for app, core, and tests
+├── project.yml                  # XcodeGen source for the macOS app project
+├── codecov.yml                  # Coverage service configuration
+├── .env.example                 # Example environment configuration, not loaded by app code
+├── .github/workflows/           # GitHub Actions CI
+├── .github/scripts/             # GitHub helper scripts
+├── .githooks/                   # Repository git hooks
+├── docs/
+│   ├── architecture/            # Authoritative architecture notes
+│   ├── brainstorms/             # Requirements and discovery notes
+│   └── plans/                   # Roadmap and implementation plans
+├── Kubebar/                     # SwiftUI macOS menu bar app target
+│   ├── KubebarApp.swift         # App entry point and menu bar scene
+│   ├── MenuBarViewModel.swift   # Main-actor UI state and service bridge
+│   └── Views/                   # SwiftUI menu and setup views
+├── KubebarCore/                 # Core model and service target
+│   ├── Models/                  # App-owned value models and display contracts
+│   └── Services/                # Persistence, kubectl, refresh, and health logic
+├── KubebarTests/                # Swift Testing unit tests for KubebarCore
+│   ├── Models/                  # Model and display behavior tests
+│   └── Services/                # Service and boundary tests
+├── scripts/                     # Local development and quality gate scripts
+├── skills/                      # Repo-local agent workflow skills
+└── tests/                       # Shell test support area
+```
+
+## Directory Purposes
+
+**`Kubebar/`:**
+- Purpose: Own the macOS app target and all SwiftUI-facing code.
+- Contains: `Kubebar/KubebarApp.swift`, `Kubebar/MenuBarViewModel.swift`, and view files under `Kubebar/Views/`.
+- Key files: `Kubebar/KubebarApp.swift`, `Kubebar/MenuBarViewModel.swift`, `Kubebar/Views/MenuBarRootView.swift`, `Kubebar/Views/SetupView.swift`, `Kubebar/Views/WatchlistPickerView.swift`.
+- Add only app shell, view model, and presentation code here. Keep domain behavior in `KubebarCore/`.
+
+**`Kubebar/Views/`:**
+- Purpose: Render the menu bar window and setup flow from core display/setup models.
+- Contains: Small `View` structs and private helper views.
+- Key files: `Kubebar/Views/MenuBarRootView.swift`, `Kubebar/Views/StatusSummaryView.swift`, `Kubebar/Views/StaleBannerView.swift`, `Kubebar/Views/CompactCountersView.swift`, `Kubebar/Views/WatchlistSectionView.swift`, `Kubebar/Views/TrackedItemDetailView.swift`, `Kubebar/Views/WarningEventsView.swift`, `Kubebar/Views/NodeDetailsView.swift`, `Kubebar/Views/SetupView.swift`, `Kubebar/Views/WatchlistPickerView.swift`.
+- Add new menu sections as separate SwiftUI view files in this directory when they render `MenuDisplayModel` fields or setup bindings.
+
+**`KubebarCore/`:**
+- Purpose: Own product rules, data models, persistence, external reads, and refresh coordination.
+- Contains: `KubebarCore/Models/` and `KubebarCore/Services/`.
+- Key files: `KubebarCore/Models/MenuDisplayModel.swift`, `KubebarCore/Services/HealthEvaluator.swift`, `KubebarCore/Services/RefreshCoordinator.swift`, `KubebarCore/Services/KubectlClusterReader.swift`.
+- Keep this target independent of SwiftUI and AppKit. It should remain testable through `KubebarTests/`.
+
+**`KubebarCore/Models/`:**
+- Purpose: Define shared value types used by services, the view model, views, and tests.
+- Contains: Core state, display contracts, snapshots, setup state, and watch target types.
+- Key files: `KubebarCore/Models/ClusterHealthState.swift`, `KubebarCore/Models/ClusterSnapshot.swift`, `KubebarCore/Models/MenuDisplayModel.swift`, `KubebarCore/Models/MenuBarStatusPresentation.swift`, `KubebarCore/Models/SetupFlowState.swift`, `KubebarCore/Models/WatchTarget.swift`, `KubebarCore/Models/WatchlistSelectionState.swift`.
+- Add new durable data shapes here when they are part of the app's product language or service contracts.
+
+**`KubebarCore/Services/`:**
+- Purpose: Implement behavior around config, subprocesses, Kubernetes reads, health evaluation, and refresh orchestration.
+- Contains: Focused service structs, protocols for injection, typed errors, and private decoding helpers.
+- Key files: `KubebarCore/Services/AppConfigStore.swift`, `KubebarCore/Services/CommandRunner.swift`, `KubebarCore/Services/ContextCatalog.swift`, `KubebarCore/Services/HealthEvaluator.swift`, `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Services/RefreshCoordinator.swift`.
+- Add new services here when they perform behavior that should be unit tested or shared by app/UI callers.
+
+**`KubebarTests/`:**
+- Purpose: Test trusted behavior in the core target.
+- Contains: Swift Testing suites split by models and services.
+- Key files: `KubebarTests/Models/MenuDisplayModelTests.swift`, `KubebarTests/Services/KubectlClusterReaderTests.swift`, `KubebarTests/Services/RefreshCoordinatorTests.swift`, `KubebarTests/Services/AppConfigStoreTests.swift`.
+- Add tests matching the source folder: model tests in `KubebarTests/Models/`, service tests in `KubebarTests/Services/`.
+
+**`docs/`:**
+- Purpose: Hold requirements, plans, roadmap, and architecture notes.
+- Contains: `docs/architecture/`, `docs/brainstorms/`, and `docs/plans/`.
+- Key files: `docs/architecture/README.md`, `docs/architecture/system-overview.md`, `docs/architecture/runtime-invariants.md`, `docs/plans/2026-04-19-002-kubebar-product-roadmap.md`.
+- Update `docs/architecture/` when ownership boundaries, data flow, runtime invariants, or subsystem behavior changes.
+
+**`scripts/`:**
+- Purpose: Provide local setup and verification commands.
+- Contains: `scripts/swift-quality-gate.sh`, `scripts/dev-setup.sh`, and `scripts/check_no_panics.py`.
+- Key files: `scripts/swift-quality-gate.sh`.
+- Keep verification scripts here and reference them from `AGENTS.md`, `README.md`, and CI when behavior changes.
+
+**`.github/`:**
+- Purpose: Run repository automation in GitHub.
+- Contains: `.github/workflows/ci.yml` and helper scripts under `.github/scripts/`.
+- Key files: `.github/workflows/ci.yml`.
+- CI calls `./scripts/swift-quality-gate.sh ci`; keep CI behavior aligned with the local gate.
+
+**`skills/`:**
+- Purpose: Store repo-local agent workflow instructions for GitHub, review, plan, triage, and ship tasks.
+- Contains: `skills/github/SKILL.md`, `skills/review-pr/SKILL.md`, `skills/ship/SKILL.md`, `skills/triage-prs/SKILL.md`, `skills/plan-mode/SKILL.md`, and related workflow skills.
+- Key files: `skills/ship/SKILL.md`, `skills/review-pr/SKILL.md`, `skills/github/SKILL.md`.
+- These files guide contributor/agent workflows and are not part of the app runtime.
+
+**`tests/`:**
+- Purpose: Shell-level test support.
+- Contains: `tests/swift_template_support.sh`.
+- Key files: `tests/swift_template_support.sh`.
+- Keep Swift unit tests in `KubebarTests/`; use this area for shell helpers only.
+
+**`.planning/`:**
+- Purpose: GSD planning and codebase intelligence artifacts.
+- Contains: `.planning/codebase/ARCHITECTURE.md` and `.planning/codebase/STRUCTURE.md` from this mapping pass, plus files written by other mapper agents.
+- Key files: `.planning/codebase/ARCHITECTURE.md`, `.planning/codebase/STRUCTURE.md`.
+- Generated: Yes
+- Committed: Project-dependent
+
+## Key File Locations
+
+**Entry Points:**
+- `Kubebar/KubebarApp.swift`: macOS app entry point, accessory activation policy, menu bar scene, root view wiring, and menu bar label.
+- `Kubebar/Views/MenuBarRootView.swift`: UI composition root for setup and menu content.
+- `Kubebar/MenuBarViewModel.swift`: app-level state owner and bridge from UI actions to core services.
+- `KubebarCore/Services/RefreshCoordinator.swift`: core refresh entry point used by the view model.
+- `scripts/swift-quality-gate.sh`: local and CI quality-gate entry point.
+
+**Configuration:**
+- `Package.swift`: Swift Package Manager manifest with `Kubebar`, `KubebarCore`, and `KubebarCoreTests` targets.
+- `project.yml`: XcodeGen manifest with macOS app, framework, and unit-test targets.
+- `Kubebar.xcodeproj/project.pbxproj`: generated Xcode project committed in the repo.
+- `Kubebar.xcodeproj/xcshareddata/xcschemes/Kubebar.xcscheme`: shared Xcode scheme used by the quality gate.
+- `.github/workflows/ci.yml`: GitHub Actions workflow that runs the Swift quality gate.
+- `codecov.yml`: coverage reporting configuration.
+- `.env.example`: example environment configuration. Do not read real `.env` files.
+
+**Core Logic:**
+- `KubebarCore/Services/HealthEvaluator.swift`: severity, attention ordering, display mapping, watchlist cap, and stale banner logic.
+- `KubebarCore/Services/RefreshCoordinator.swift`: config validation, reader coordination, failure handling, and stale snapshot retention.
+- `KubebarCore/Services/KubectlClusterReader.swift`: Kubernetes JSON reads, decoding, and tracked item status calculation.
+- `KubebarCore/Services/CommandRunner.swift`: subprocess execution boundary.
+- `KubebarCore/Services/AppConfigStore.swift`: persisted selected context and watchlist.
+- `KubebarCore/Services/ContextCatalog.swift`: available Kubernetes context listing.
+- `KubebarCore/Models/MenuDisplayModel.swift`: single render contract for menu UI.
+- `KubebarCore/Models/ClusterSnapshot.swift`: app-owned cluster snapshot shape.
+- `KubebarCore/Models/WatchTarget.swift`: watchlist target and tracked item status shape.
+
+**UI:**
+- `Kubebar/KubebarApp.swift`: menu bar shell and status icon mapping.
+- `Kubebar/MenuBarViewModel.swift`: published UI state and setup/refresh actions.
+- `Kubebar/Views/MenuBarRootView.swift`: menu layout.
+- `Kubebar/Views/SetupView.swift`: setup screen and finish action.
+- `Kubebar/Views/WatchlistPickerView.swift`: namespace/workload watchlist selection UI.
+- `Kubebar/Views/StatusSummaryView.swift`: context, health sentence, and state label.
+- `Kubebar/Views/StaleBannerView.swift`: stale-data warning.
+- `Kubebar/Views/WatchlistSectionView.swift`: first-screen watchlist rows and overflow count.
+
+**Testing:**
+- `KubebarTests/Models/MenuDisplayModelTests.swift`: health display behavior and stale display expectations.
+- `KubebarTests/Models/ClusterHealthStateTests.swift`: health state labels.
+- `KubebarTests/Models/MenuBarStatusPresentationTests.swift`: menu bar icon/accessibility presentation.
+- `KubebarTests/Models/SetupFlowStateTests.swift`: setup validation and copy.
+- `KubebarTests/Models/WatchlistSelectionStateTests.swift`: watchlist selection behavior.
+- `KubebarTests/Services/KubectlClusterReaderTests.swift`: kubectl JSON decoding, error mapping, and concurrent resource reads.
+- `KubebarTests/Services/RefreshCoordinatorTests.swift`: refresh success, stale fallback, and missing setup behavior.
+- `KubebarTests/Services/AppConfigStoreTests.swift`: config load/save/corrupt cases.
+- `KubebarTests/Services/CommandRunnerTests.swift`: process command boundary behavior.
+- `KubebarTests/Services/ContextCatalogTests.swift`: context listing and failure behavior.
+
+**Documentation:**
+- `AGENTS.md`: highest-priority repo-wide contributor/agent contract.
+- `README.md`: project overview, current status, build/test instructions, and project layout.
+- `docs/architecture/system-overview.md`: major subsystems and request flow.
+- `docs/architecture/runtime-invariants.md`: runtime guarantees for product, data, freshness, watchlist, and failures.
+- `docs/architecture/README.md`: architecture notes index.
+- `docs/plans/2026-04-19-002-kubebar-product-roadmap.md`: roadmap entry point.
+
+## Naming Conventions
+
+**Files:**
+- Use PascalCase Swift type names as filenames for app and core files: `KubebarCore/Services/HealthEvaluator.swift`, `KubebarCore/Models/MenuDisplayModel.swift`, `Kubebar/Views/SetupView.swift`.
+- Use `*View.swift` for SwiftUI views: `Kubebar/Views/StatusSummaryView.swift`, `Kubebar/Views/WatchlistPickerView.swift`.
+- Use `*Tests.swift` for Swift Testing suites: `KubebarTests/Services/RefreshCoordinatorTests.swift`.
+- Use lowercase hyphenated names for shell scripts and docs where already established: `scripts/swift-quality-gate.sh`, `docs/architecture/system-overview.md`.
+- Use uppercase root or generated GSD reference docs where established: `AGENTS.md`, `README.md`, `.planning/codebase/ARCHITECTURE.md`.
+
+**Directories:**
+- Use target-aligned PascalCase directories for Swift targets: `Kubebar/`, `KubebarCore/`, `KubebarTests/`.
+- Use domain subdirectories inside targets: `KubebarCore/Models/`, `KubebarCore/Services/`, `Kubebar/Views/`.
+- Use lowercase directories for docs, scripts, tests, and skills: `docs/`, `scripts/`, `tests/`, `skills/`.
+
+## Where to Add New Code
+
+**New Menu Section:**
+- Primary code: `Kubebar/Views/`
+- Data contract: `KubebarCore/Models/MenuDisplayModel.swift`
+- Mapping logic: `KubebarCore/Services/HealthEvaluator.swift`
+- Tests: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- Add the view to `Kubebar/Views/MenuBarRootView.swift` only after the display model exposes the needed field.
+
+**New Health Rule:**
+- Primary code: `KubebarCore/Services/HealthEvaluator.swift`
+- Supporting model: `KubebarCore/Models/ClusterHealthState.swift` only if the categorical state set changes.
+- Tests: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- Keep severity decisions centralized in `HealthEvaluator`.
+
+**New Kubernetes Read:**
+- Primary code: `KubebarCore/Services/KubectlClusterReader.swift`
+- External boundary: `KubebarCore/Services/CommandRunner.swift`
+- Snapshot/model changes: `KubebarCore/Models/ClusterSnapshot.swift` or a new model under `KubebarCore/Models/`.
+- Tests: `KubebarTests/Services/KubectlClusterReaderTests.swift`
+- Use the saved context argument pattern from `KubebarCore/Services/KubectlClusterReader.swift`.
+
+**New External Command Consumer:**
+- Primary code: `KubebarCore/Services/`
+- Shared subprocess boundary: `KubebarCore/Services/CommandRunner.swift`
+- Tests: `KubebarTests/Services/`
+- Depend on `CommandRunning` rather than constructing `Process` directly.
+
+**New Config Field:**
+- Primary code: `KubebarCore/Services/AppConfigStore.swift`
+- UI setup state: `KubebarCore/Models/SetupFlowState.swift` if the field is user-configurable.
+- View model wiring: `Kubebar/MenuBarViewModel.swift`
+- Tests: `KubebarTests/Services/AppConfigStoreTests.swift` and setup/model tests under `KubebarTests/Models/`.
+- Preserve missing and corrupt config recovery behavior.
+
+**New Setup Flow UI:**
+- Primary code: `Kubebar/Views/SetupView.swift` or a new view under `Kubebar/Views/`.
+- State model: `KubebarCore/Models/SetupFlowState.swift` or `KubebarCore/Models/WatchlistSelectionState.swift`.
+- Persistence: `KubebarCore/Services/AppConfigStore.swift`.
+- Tests: `KubebarTests/Models/SetupFlowStateTests.swift` or `KubebarTests/Models/WatchlistSelectionStateTests.swift`.
+
+**New Core Model:**
+- Implementation: `KubebarCore/Models/`
+- Tests: `KubebarTests/Models/`
+- Use a value type (`struct` or `enum`) and explicit public initializers when the app target needs access.
+
+**New Core Service:**
+- Implementation: `KubebarCore/Services/`
+- Tests: `KubebarTests/Services/`
+- Prefer initializer injection for dependencies and protocol boundaries for external reads.
+
+**New Architecture Note:**
+- Implementation: `docs/architecture/`
+- Index update: `docs/architecture/README.md`
+- Use this for details that are too long for `AGENTS.md`.
+
+**New Quality Script:**
+- Implementation: `scripts/`
+- Documentation: `AGENTS.md` and `README.md` if it changes the standard developer workflow.
+- CI wiring: `.github/workflows/ci.yml` if it should run in pull requests.
+
+**Utilities:**
+- Shared helpers for core behavior: `KubebarCore/Services/` or `KubebarCore/Models/`, depending on whether the helper performs behavior or represents data.
+- UI-only helpers: private nested types or private helper views in `Kubebar/Views/`.
+- Test-only helpers: private types inside the relevant `KubebarTests/` file unless multiple test files need the same helper.
+
+## Special Directories
+
+**`docs/architecture/`:**
+- Purpose: Authoritative architecture notes beyond the repo quick-start guide.
+- Generated: No
+- Committed: Yes
+- Key files: `docs/architecture/system-overview.md`, `docs/architecture/runtime-invariants.md`, `docs/architecture/README.md`.
+
+**`Kubebar.xcodeproj/`:**
+- Purpose: Xcode project used for app build/test and shared scheme discovery.
+- Generated: Yes, from `project.yml` through XcodeGen.
+- Committed: Yes
+- Key files: `Kubebar.xcodeproj/project.pbxproj`, `Kubebar.xcodeproj/xcshareddata/xcschemes/Kubebar.xcscheme`.
+
+**`.github/workflows/`:**
+- Purpose: Pull request CI.
+- Generated: No
+- Committed: Yes
+- Key files: `.github/workflows/ci.yml`.
+
+**`skills/`:**
+- Purpose: Repo-local agent workflow definitions for GitHub and project operations.
+- Generated: No
+- Committed: Yes
+- Key files: `skills/github/SKILL.md`, `skills/review-pr/SKILL.md`, `skills/ship/SKILL.md`, `skills/plan-mode/SKILL.md`.
+
+**`.planning/codebase/`:**
+- Purpose: Generated GSD codebase map consumed by planning and execution commands.
+- Generated: Yes
+- Committed: Project-dependent
+- Key files: `.planning/codebase/ARCHITECTURE.md`, `.planning/codebase/STRUCTURE.md`.
+
+**`scripts/__pycache__/`:**
+- Purpose: Python bytecode cache from script execution.
+- Generated: Yes
+- Committed: No
+- Key files: `scripts/__pycache__/check_no_panics.cpython-314.pyc`.
+
+---
+
+*Structure analysis: 2026-04-19*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,231 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-04-19
+
+## Test Framework
+
+**Runner:**
+- Swift Testing, shipped with the Swift 6 toolchain declared in `Package.swift` and `project.yml`.
+- Config: `Package.swift` defines `.testTarget(name: "KubebarCoreTests", dependencies: ["KubebarCore"], path: "KubebarTests")`.
+- Config: `project.yml` defines the `KubebarTests` Xcode unit-test target and includes it in the shared `Kubebar` scheme.
+- Quality gate: `scripts/swift-quality-gate.sh` runs Xcode build, Xcode test, `swift build`, and `swift test` when both Xcode and SwiftPM project shapes are present.
+
+**Assertion Library:**
+- Swift Testing macros from `import Testing`, mainly `#expect(...)` and `#expect(throws:)`, as used in `KubebarTests/Models/MenuDisplayModelTests.swift`, `KubebarTests/Services/ContextCatalogTests.swift`, and `KubebarTests/Services/AppConfigStoreTests.swift`.
+- XCTest is not used in current test files under `KubebarTests/`.
+
+**Run Commands:**
+```bash
+./scripts/swift-quality-gate.sh local  # Run the full local gate from AGENTS.md
+swift test                             # Run SwiftPM tests only
+xcodebuild -project Kubebar.xcodeproj -scheme Kubebar -configuration Debug -destination 'platform=macOS' test CODE_SIGNING_ALLOWED=NO  # Run Xcode tests
+```
+
+- Watch mode: Not detected. No watch command is configured in `Package.swift`, `project.yml`, `scripts/swift-quality-gate.sh`, or `.github/workflows/ci.yml`.
+- CI command: `.github/workflows/ci.yml` runs `./scripts/swift-quality-gate.sh ci` on pull requests to `main`.
+
+## Test File Organization
+
+**Location:**
+- Tests are separate from production code under `KubebarTests/`.
+- Model tests live in `KubebarTests/Models/`, mirroring `KubebarCore/Models/`.
+- Service tests live in `KubebarTests/Services/`, mirroring `KubebarCore/Services/`.
+- No UI snapshot or interaction tests are present for `Kubebar/Views/` or `Kubebar/MenuBarViewModel.swift`.
+
+**Naming:**
+- Test files use `<Subject>Tests.swift`, such as `KubebarTests/Models/ClusterHealthStateTests.swift`, `KubebarTests/Models/MenuDisplayModelTests.swift`, and `KubebarTests/Services/KubectlClusterReaderTests.swift`.
+- Test suites use `@Suite("Human readable subject")`, as in `@Suite("Menu display model")` in `KubebarTests/Models/MenuDisplayModelTests.swift`.
+- Test cases use `@Test("behavior statement")` with lowerCamelCase function names, as in `@Test("failed refresh keeps previous data but marks it stale")` and `failedRefreshKeepsPreviousDataButMarksItStale()` in `KubebarTests/Models/MenuDisplayModelTests.swift`.
+
+**Structure:**
+```text
+KubebarTests/
++-- Models/      # Tests for pure value models and display mapping in KubebarCore/Models/
++-- Services/    # Tests for service boundaries, config persistence, refresh behavior, and kubectl reading
+```
+
+## Test Structure
+
+**Suite Organization:**
+Use this Swift Testing pattern from `KubebarTests/Services/ContextCatalogTests.swift`:
+
+```swift
+import Testing
+@testable import KubebarCore
+
+@Suite("Context catalog")
+struct ContextCatalogTests {
+    @Test("lists kubectl contexts from command output")
+    func listsKubectlContextsFromCommandOutput() throws {
+        let runner = FakeCommandRunner(result: CommandResult(stdout: "prod\nstaging\n\n", stderr: "", exitCode: 0))
+        let catalog = ContextCatalog(runner: runner)
+
+        #expect(try catalog.listContexts() == ["prod", "staging"])
+        #expect(runner.lastRequest?.executable == "kubectl")
+    }
+}
+```
+
+**Patterns:**
+- Arrange values inline at the top of each test, act once, then assert concrete output fields. `KubebarTests/Models/MenuDisplayModelTests.swift` constructs `ClusterSnapshot`, calls `HealthEvaluator().evaluate(...)`, and asserts the resulting `MenuDisplayModel`.
+- Use deterministic dates instead of `Date()` when asserting time-derived output. `KubebarTests/Models/MenuDisplayModelTests.swift` and `KubebarTests/Services/RefreshCoordinatorTests.swift` use `Date(timeIntervalSince1970:)`.
+- Use `throws` on tests that call throwing APIs directly, as in `KubebarTests/Services/KubectlClusterReaderTests.swift`, `KubebarTests/Services/CommandRunnerTests.swift`, and `KubebarTests/Services/AppConfigStoreTests.swift`.
+- Use `#expect(throws:)` for expected errors, as in `KubebarTests/Services/ContextCatalogTests.swift` and `KubebarTests/Services/AppConfigStoreTests.swift`.
+- Keep fakes local to the test file and mark them `private`, as in `FakeCommandRunner` in `KubebarTests/Services/ContextCatalogTests.swift` and `FakeClusterReader` in `KubebarTests/Services/RefreshCoordinatorTests.swift`.
+
+## Mocking
+
+**Framework:** Manual fakes. No mocking framework is detected in `Package.swift`, `project.yml`, or `KubebarTests/`.
+
+**Patterns:**
+Use protocol-backed fakes for command and reader boundaries, as in `KubebarTests/Services/RefreshCoordinatorTests.swift`:
+
+```swift
+private struct FakeClusterReader: ClusterReading {
+    let result: Result<ClusterSnapshot, Error>
+
+    func readSnapshot(contextName: String, watchTargets: [WatchTarget], now: Date) throws -> ClusterSnapshot {
+        try result.get()
+    }
+}
+```
+
+Use command-output lookup fakes for `kubectl` behavior, as in `KubebarTests/Services/KubectlClusterReaderTests.swift`:
+
+```swift
+private final class FakeMultiCommandRunner: CommandRunning, @unchecked Sendable {
+    private let results: [[String]: CommandResult]
+
+    init(results: [[String]: CommandResult]) {
+        self.results = results
+    }
+
+    func run(_ request: CommandRequest) throws -> CommandResult {
+        results[request.arguments] ?? CommandResult(stdout: "", stderr: "unexpected command", exitCode: 1)
+    }
+}
+```
+
+**What to Mock:**
+- Mock external command execution through `CommandRunning`, as in `KubebarTests/Services/KubectlClusterReaderTests.swift` and `KubebarTests/Services/ContextCatalogTests.swift`.
+- Mock cluster reads through `ClusterReading`, as in `KubebarTests/Services/RefreshCoordinatorTests.swift`.
+- Use temporary directories for filesystem writes, as in `makeTemporaryDirectory()` in `KubebarTests/Services/AppConfigStoreTests.swift`.
+- Use static JSON strings for kubectl fixtures inside the relevant test file, as in `nodesJSON`, `podsJSON`, and `warningEventsJSON` in `KubebarTests/Services/KubectlClusterReaderTests.swift`.
+
+**What NOT to Mock:**
+- Do not mock pure value transformations. Test `HealthEvaluator` and model computed properties directly, as in `KubebarTests/Models/MenuDisplayModelTests.swift`, `KubebarTests/Models/SetupFlowStateTests.swift`, and `KubebarTests/Models/WatchlistSelectionStateTests.swift`.
+- Do not shell out to real `kubectl` in unit tests. `KubebarCore/Services/CommandRunner.swift` is covered separately by `KubebarTests/Services/CommandRunnerTests.swift`, while `KubebarCore/Services/KubectlClusterReader.swift` uses fake runners.
+- Do not depend on the terminal's current Kubernetes context. Production code uses app-owned context values in `KubebarCore/Services/KubectlClusterReader.swift`, and tests pass `contextName: "prod"` explicitly.
+
+## Fixtures and Factories
+
+**Test Data:**
+Use inline domain values for small model tests, as in `KubebarTests/Models/MenuDisplayModelTests.swift`:
+
+```swift
+let snapshot = ClusterSnapshot(
+    contextName: "prod",
+    nodeSummary: NodeSummary(ready: 3, total: 3),
+    podSummary: PodSummary(running: 12, total: 12),
+    warningEventCount: 0,
+    trackedItems: [
+        TrackedItemStatus(target: .workload(namespace: "api", name: "checkout"), state: .ok, reason: "6/6 pods running")
+    ],
+    capturedAt: Date(timeIntervalSince1970: 100)
+)
+```
+
+Use inline JSON strings for kubectl parser coverage, as in `KubebarTests/Services/KubectlClusterReaderTests.swift`:
+
+```swift
+private let nodesJSON = """
+{
+  "items": [
+    {"status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+  ]
+}
+"""
+```
+
+**Location:**
+- Fixtures are currently co-located in the test file that uses them, such as `KubebarTests/Services/KubectlClusterReaderTests.swift`.
+- No shared fixture directory or factory module is detected under `KubebarTests/`.
+- Add shared factories only when duplication becomes meaningful across several test files; otherwise keep fixtures local and private like the existing tests.
+
+## Coverage
+
+**Requirements:** Codecov status is configured but local coverage generation is not.
+- `codecov.yml` sets project coverage target to 80% with a 2% threshold.
+- `codecov.yml` sets patch coverage target to 90%.
+- `.github/workflows/ci.yml` does not upload coverage, and `scripts/swift-quality-gate.sh` does not enable coverage.
+
+**View Coverage:**
+```bash
+# Not configured in this repository.
+# The supported verification command is:
+./scripts/swift-quality-gate.sh local
+```
+
+## Test Types
+
+**Unit Tests:**
+- Primary test type. Use for health states, display mapping, setup state, watchlist selection, config persistence, command running, context parsing, kubectl JSON parsing, and refresh coordination in `KubebarTests/Models/*.swift` and `KubebarTests/Services/*.swift`.
+- Unit tests assert product invariants from `docs/architecture/runtime-invariants.md`, especially stale-data behavior, fixed health labels, watchlist cap, and app-owned context reads.
+
+**Integration Tests:**
+- Lightweight integration exists through `ProcessCommandRunner` exercising real `/bin/sh` output behavior in `KubebarTests/Services/CommandRunnerTests.swift`.
+- `scripts/swift-quality-gate.sh` provides build-and-test integration across Xcode and SwiftPM.
+- `tests/swift_template_support.sh` tests repository template support and quality gate detection with stubbed `swift` and `xcodebuild` commands.
+
+**E2E Tests:**
+- Not used. No UI automation, simulator, menu bar interaction, or snapshot testing is configured in `Package.swift`, `project.yml`, `KubebarTests/`, or `.github/workflows/`.
+
+## Common Patterns
+
+**Async Testing:**
+Current core APIs are mostly synchronous. Concurrency is tested by observing behavior through a fake runner, as in `KubebarTests/Services/KubectlClusterReaderTests.swift`:
+
+```swift
+@Test("reads independent kubectl resources concurrently")
+func readsIndependentKubectlResourcesConcurrently() throws {
+    let runner = SlowRecordingCommandRunner(results: [
+        ["--context", "prod", "get", "nodes", "-o", "json"]: CommandResult(stdout: nodesJSON, stderr: "", exitCode: 0)
+    ])
+    let reader = KubectlClusterReader(runner: runner)
+
+    _ = try reader.readSnapshot(
+        contextName: "prod",
+        watchTargets: [.workload(namespace: "api", name: "checkout")],
+        now: Date(timeIntervalSince1970: 100)
+    )
+
+    #expect(runner.maximumConcurrentRequests > 1)
+}
+```
+
+**Error Testing:**
+Use `#expect(throws:)` with exact domain errors, as in `KubebarTests/Services/ContextCatalogTests.swift`:
+
+```swift
+#expect(throws: KubectlCommandError.failed("no kubeconfig")) {
+    try catalog.listContexts()
+}
+```
+
+Use stale-display assertions for recoverable refresh failures, as in `KubebarTests/Services/RefreshCoordinatorTests.swift`:
+
+```swift
+#expect(result.snapshot == previous)
+#expect(result.display.state == .stale)
+#expect(result.display.staleBanner?.reason == "cluster unreachable")
+```
+
+## Regression Enforcement
+
+- Local commit hook `.githooks/commit-msg` requires test changes for `fix:`, `hotfix:`, or `bugfix:` commits unless `[skip-regression-check]` is present.
+- CI workflow `.github/workflows/regression-test-check.yml` applies the same regression-test rule to fix pull requests unless the `skip-regression-check` label is present.
+- The regression checker detects Swift test files by path and file name patterns, so place regression tests in `KubebarTests/` or use a `*Tests.swift`, `*Spec.swift`, or `*SnapshotTests.swift` suffix.
+
+---
+
+*Testing analysis: 2026-04-19*


### PR DESCRIPTION
## Summary
- Add a full `.planning/codebase/` map for the repository
- Cover stack, integrations, architecture, structure, conventions, testing, and concerns
- Capture the current codebase state in seven reference documents

## Testing
- Not run (not requested)