### PR TITLE
Polish menu bar states and keyboard navigation

### DIFF
--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-01-PLAN.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-01-PLAN.md
@@ -1,0 +1,273 @@
+---
+phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+plan: "01"
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - KubebarCore/Models/MenuBarStatusPresentation.swift
+  - KubebarCore/Models/MenuDisplayModel.swift
+  - KubebarCore/Services/HealthEvaluator.swift
+  - KubebarTests/Models/MenuBarStatusPresentationTests.swift
+  - KubebarTests/Models/MenuDisplayModelTests.swift
+autonomous: true
+requirements: [R1, R13, R20]
+user_setup: []
+must_haves:
+  truths:
+    - "The menu bar still has exactly four categorical states: OK, Watch, Bad, and Stale."
+    - "OK uses the custom KubebarLogo in the menu bar, while the opened menu can still render an explicit OK symbol and text."
+    - "Watch, Bad, and Stale have non-color reasons available in the display model."
+    - "Long watch target titles are preserved as full app-owned names for tooltip/accessibility rendering."
+  artifacts:
+    - "KubebarCore/Models/MenuBarStatusPresentation.swift preserves .custom(\"KubebarLogo\") for OK and the locked Watch/Bad/Stale SF Symbols."
+    - "KubebarCore/Models/MenuDisplayModel.swift exposes primaryStatusReason."
+    - "KubebarCore/Services/HealthEvaluator.swift derives one primary reason and keeps watch item titles untruncated."
+    - "KubebarTests/Models/MenuBarStatusPresentationTests.swift proves four icon sources and accessibility labels."
+    - "KubebarTests/Models/MenuDisplayModelTests.swift proves primaryStatusReason and full-name preservation."
+  key_links:
+    - "HealthEvaluator.evaluate(...) returns MenuDisplayModel.primaryStatusReason without SwiftUI inferring health."
+    - "WatchItemDisplay.title carries the full WatchTarget.displayTitle for later middle truncation in SwiftUI."
+    - "MenuBarStatusPresentation.icon remains the source used by KubebarApp for the menu bar label."
+---
+
+<objective>
+Create the Phase 06 core presentation contract for icon states, opened-menu reasons, and full-name preservation.
+
+Purpose: Issue #6 needs the app to be readable from the menu bar and from the opened menu without relying on color or shortened Kubernetes names. This plan keeps health and display decisions in KubebarCore, not SwiftUI views.
+
+Output: Tested icon presentation, `primaryStatusReason`, and full watch item names ready for view rendering.
+</objective>
+
+<execution_context>
+@$HOME/.codex/get-shit-done/workflows/execute-plan.md
+@$HOME/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@AGENTS.md
+@docs/plans/2026-04-19-002-kubebar-product-roadmap.md
+@docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md
+@docs/architecture/runtime-invariants.md
+@docs/architecture/system-overview.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-RESEARCH.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-VALIDATION.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+@.planning/codebase/ARCHITECTURE.md
+@.planning/codebase/STRUCTURE.md
+@.planning/codebase/TESTING.md
+@.planning/codebase/CONCERNS.md
+@KubebarCore/Models/MenuBarStatusPresentation.swift
+@KubebarCore/Models/MenuDisplayModel.swift
+@KubebarCore/Services/HealthEvaluator.swift
+@KubebarTests/Models/MenuBarStatusPresentationTests.swift
+@KubebarTests/Models/MenuDisplayModelTests.swift
+
+<interfaces>
+Existing contracts to preserve and extend:
+
+```swift
+public struct MenuBarStatusPresentation: Equatable, Sendable {
+    public enum IconSource: Equatable, Sendable {
+        case system(String)
+        case custom(String)
+    }
+
+    public var icon: IconSource { get }
+    public var symbolName: String { get }
+    public var accessibilityLabel: String { get }
+}
+
+public struct MenuDisplayModel: Equatable, Sendable {
+    public let state: ClusterHealthState
+    public let contextName: String
+    public let healthSentence: String
+    public let lastUpdated: String
+    public let counters: MenuCounters
+    public let visibleWatchItems: [WatchItemDisplay]
+    public let hiddenWatchItemCount: Int
+    public let staleBanner: StaleBannerDisplay?
+}
+
+public struct WatchItemDisplay: Equatable, Sendable, Identifiable {
+    public let id: String
+    public let title: String
+    public let state: ClusterHealthState
+    public let reason: String
+    public let detail: WatchItemDetailDisplay
+}
+```
+</interfaces>
+</context>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Core state -> menu bar icon | `ClusterHealthState` becomes a compressed icon in the macOS menu bar. |
+| HealthEvaluator -> SwiftUI views | App-owned display strings become the only values views are allowed to render. |
+| Kubernetes names -> display model | Context, namespace, workload, and warning-derived names enter user-visible display fields. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-06-01-01 | Spoofing | MenuBarStatusPresentation and MenuDisplayModel | mitigate | Per D-01 and D-04, keep menu bar OK as `.custom("KubebarLogo")` and expose `primaryStatusReason == "Cluster looks healthy"` for OK so the opened menu can show explicit OK text. |
+| T-06-01-02 | Information Disclosure by confusion | HealthEvaluator.primaryStatusReason | mitigate | Per D-06, D-07, and D-08, derive exactly one short non-color reason for Watch, Bad, and Stale; detailed reasons remain in watchlist, detail, stale banner, warning event, or section notice data. |
+| T-06-01-03 | Spoofing | WatchItemDisplay.title | mitigate | Per D-13, D-14, D-15, and D-16, stop tail pre-truncation in core; preserve full app-owned names for view-level middle truncation and accessibility. |
+| T-06-01-04 | Information Disclosure | MenuDisplayModel display strings | mitigate | Per D-15 and runtime invariants, only carry app-owned context/resource names and sanitized reasons; do not add raw kubectl stdout, stderr, or JSON fields to tooltip/accessibility contracts. |
+| T-06-01-05 | Denial of Service | Keyboard navigation contract | mitigate | Per D-17, expose core fields needed by native SwiftUI controls in Plan 02; do not create mouse-only view logic or hidden state that requires custom UI inspection. |
+</threat_model>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Lock four menu bar icon sources and accessibility labels</name>
+  <files>KubebarCore/Models/MenuBarStatusPresentation.swift, KubebarTests/Models/MenuBarStatusPresentationTests.swift</files>
+  <read_first>
+    AGENTS.md
+    docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+    KubebarCore/Models/MenuBarStatusPresentation.swift
+    KubebarTests/Models/MenuBarStatusPresentationTests.swift
+  </read_first>
+  <action>
+Update `KubebarTests/Models/MenuBarStatusPresentationTests.swift` before changing production code.
+
+Required assertions:
+- Per D-01, `MenuBarStatusPresentation(state: .ok).icon == .custom("KubebarLogo")`.
+- Per D-02 and D-03, Watch/Bad/Stale icon sources remain `.system("exclamationmark.triangle")`, `.system("xmark.octagon")`, and `.system("clock.badge.exclamationmark")`.
+- Per D-04, `MenuBarStatusPresentation(state: .ok).symbolName == "checkmark.circle"` remains available for the opened menu summary, but it must not replace `.custom("KubebarLogo")` for the menu bar icon.
+- Per D-05, accessibility labels remain exactly `Kubebar OK`, `Kubebar Watch`, `Kubebar Bad`, and `Kubebar Stale`.
+
+Only edit `MenuBarStatusPresentation.swift` if those tests fail. If editing is needed, preserve `IconSource`, `icon`, `symbolName`, and `accessibilityLabel` as public Foundation-only core APIs; do not import SwiftUI into KubebarCore.
+  </action>
+  <verify>
+    <automated>swift test --filter MenuBarStatusPresentationTests</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "\\.custom\\(\"KubebarLogo\"\\)|exclamationmark.triangle|xmark.octagon|clock.badge.exclamationmark" KubebarTests/Models/MenuBarStatusPresentationTests.swift` finds all four icon-source assertions.
+    - `rg -n "Kubebar OK|Kubebar Watch|Kubebar Bad|Kubebar Stale" KubebarTests/Models/MenuBarStatusPresentationTests.swift` finds all four accessibility assertions.
+    - `rg -n "case \\.ok:[[:space:]]*$|\\.custom\\(\"KubebarLogo\"\\)" KubebarCore/Models/MenuBarStatusPresentation.swift` confirms OK still maps to the custom logo.
+    - `! rg -n "import SwiftUI|NSStatusItem|NSMenu" KubebarCore/Models/MenuBarStatusPresentation.swift KubebarTests/Models/MenuBarStatusPresentationTests.swift`
+    - `swift test --filter MenuBarStatusPresentationTests` passes.
+  </acceptance_criteria>
+  <done>The four-state menu bar presentation is locked by tests, including OK as the brand logo and distinct accessibility labels.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Add primaryStatusReason to the display model</name>
+  <files>KubebarCore/Models/MenuDisplayModel.swift, KubebarCore/Services/HealthEvaluator.swift, KubebarTests/Models/MenuDisplayModelTests.swift</files>
+  <read_first>
+    AGENTS.md
+    docs/architecture/runtime-invariants.md
+    docs/architecture/system-overview.md
+    docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-RESEARCH.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+    KubebarCore/Models/MenuDisplayModel.swift
+    KubebarCore/Services/HealthEvaluator.swift
+    KubebarTests/Models/MenuDisplayModelTests.swift
+  </read_first>
+  <action>
+Add a core-owned opened-menu reason field, per D-04, D-06, D-07, and D-08.
+
+In `MenuDisplayModel.swift`:
+- Add `public let primaryStatusReason: String` immediately after `healthSentence`.
+- Add initializer parameter `primaryStatusReason: String? = nil` immediately after `healthSentence: String`.
+- Assign `self.primaryStatusReason = primaryStatusReason ?? healthSentence` so existing direct test construction remains source-compatible.
+
+In `HealthEvaluator.swift`:
+- For the no-snapshot fallback, set `primaryStatusReason` to `failure?.reason ?? "No previous cluster data"`.
+- In `displayModel(from:...)`, calculate `let staleReason = failureReason ?? freshnessReason` before constructing `MenuDisplayModel`.
+- Pass `primaryStatusReason: primaryStatusReason(for: resolvedState, snapshot: snapshot, visibleItems: visibleItems, warningEventSummaries: warningEventSummaries, sectionNotices: sectionNotices, staleReason: staleReason)`.
+- Add a private helper named exactly `primaryStatusReason(for:snapshot:visibleItems:warningEventSummaries:sectionNotices:staleReason:)`.
+- The helper must return one string only:
+  - `.ok`: exactly `Cluster looks healthy`.
+  - `.bad`: first `.bad` visible watch item `reason`; else node deficit as `"{n} nodes not ready"`; else pod deficit as `"{n} pods not running"`; else `Cluster needs attention`.
+  - `.watch`: first `.watch` visible watch item `reason`; else first `sectionNotices.first?.reason`; else warning count as `"{n} warning events"` when `snapshot.warningEventCount > 0`; else pod deficit as `"{n} pods not running"`; else `Cluster has warnings`.
+  - `.stale`: `staleReason ?? "Last cluster status is stale"`.
+- Keep `healthSentence(for:visibleItems:)` as the longer sentence used elsewhere; do not make `StatusSummaryView` infer severity.
+
+In `MenuDisplayModelTests.swift`, add or update tests for these exact expectations:
+- Healthy snapshot: `display.primaryStatusReason == "Cluster looks healthy"`.
+- Bad visible watch item with reason `1 pod pending`: `display.primaryStatusReason == "1 pod pending"`.
+- Watch state caused only by two warning events: `display.primaryStatusReason == "2 warning events"`.
+- Unavailable warning events with reason `invalid event JSON`: `display.primaryStatusReason == "invalid event JSON"`.
+- Failed refresh with `RefreshFailure(reason: "kubectl timed out")`: `display.primaryStatusReason == "kubectl timed out"`.
+  </action>
+  <verify>
+    <automated>swift test --filter MenuDisplayModelTests</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "primaryStatusReason" KubebarCore/Models/MenuDisplayModel.swift KubebarCore/Services/HealthEvaluator.swift KubebarTests/Models/MenuDisplayModelTests.swift` finds the field, mapper, and tests.
+    - `rg -n "Cluster looks healthy|1 pod pending|2 warning events|invalid event JSON|kubectl timed out" KubebarTests/Models/MenuDisplayModelTests.swift` finds all exact reason expectations.
+    - `rg -n "primaryStatusReason\\(for:.*visibleItems" KubebarCore/Services/HealthEvaluator.swift` finds the core-owned helper.
+    - `! rg -n "primaryStatusReason|warningEventCount|nodesSection|podsSection" Kubebar/Views`
+    - `swift test --filter MenuDisplayModelTests` passes.
+  </acceptance_criteria>
+  <done>`MenuDisplayModel` carries one non-color opened-menu reason for OK, Watch, Bad, and Stale without moving health logic into SwiftUI.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Preserve full watch item titles for middle truncation</name>
+  <files>KubebarCore/Models/MenuDisplayModel.swift, KubebarCore/Services/HealthEvaluator.swift, KubebarTests/Models/MenuDisplayModelTests.swift</files>
+  <read_first>
+    AGENTS.md
+    docs/architecture/runtime-invariants.md
+    docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-RESEARCH.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+    KubebarCore/Models/MenuDisplayModel.swift
+    KubebarCore/Services/HealthEvaluator.swift
+    KubebarTests/Models/MenuDisplayModelTests.swift
+  </read_first>
+  <action>
+Remove core tail pre-truncation so Plan 02 can apply SwiftUI middle truncation with full tooltip/accessibility text.
+
+Implementation:
+- Per D-13 and D-14, change `makeDisplayItem(_:,now:)` so `WatchItemDisplay.title` is exactly `item.target.displayTitle`.
+- Per D-15, do not add a separate shortened-only display value. The full app-owned name must remain in `WatchItemDisplay.title`.
+- Per D-16, do not add multi-line title strings or embedded newline formatting.
+- Remove the private `shortened(_ value:limit:)` helper if it no longer has callers. Keep `shortenedWarningMessage(_:)` unchanged because warning messages are capped user-facing details, not resource names.
+- Update the existing test named `longWatchItemTitlesTruncateConsistently` to prove full-name preservation. Rename it to `longWatchItemTitlesStayFullForMiddleTruncation`.
+- The test must expect exactly `production-namespace/checkout-api-with-a-very-long-name`, not a prefix ending in an ellipsis.
+- Add a second long-name test with two similar workload names ending in `-api` and `-worker`; assert both suffixes remain present in `visibleWatchItems.map(\.title)` so tail differences are preserved.
+  </action>
+  <verify>
+    <automated>swift test --filter MenuDisplayModelTests</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "longWatchItemTitlesStayFullForMiddleTruncation|checkout-api-with-a-very-long-name|checkout-worker" KubebarTests/Models/MenuDisplayModelTests.swift` finds full-name preservation tests.
+    - `rg -n "title: item.target.displayTitle" KubebarCore/Services/HealthEvaluator.swift` confirms the full title enters `WatchItemDisplay`.
+    - `! rg -n "shortened\\(item.target.displayTitle\\)|checkout-api-with-a-.|prefix\\(limit - 1\\)" KubebarCore/Services/HealthEvaluator.swift KubebarTests/Models/MenuDisplayModelTests.swift`
+    - `! rg -n "\\\\n" KubebarCore/Services/HealthEvaluator.swift KubebarCore/Models/MenuDisplayModel.swift`
+    - `swift test --filter MenuDisplayModelTests` passes.
+  </acceptance_criteria>
+  <done>Core display data preserves full watch target names, including suffix differences needed for Kubernetes resource scanning.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `swift test --filter MenuBarStatusPresentationTests` passes.
+- `swift test --filter MenuDisplayModelTests` passes.
+- `rg -n "primaryStatusReason|KubebarLogo|checkout-api-with-a-very-long-name" KubebarCore KubebarTests` shows the Phase 06 core contracts and tests.
+- `! rg -n "NSStatusItem|NSMenu|Open in k9s|notarization|distribution|dashboard|raw kubectl" KubebarCore KubebarTests/Models`
+</verification>
+
+<success_criteria>
+- R1 is covered by locked four-state presentation tests.
+- R13 is covered by `primaryStatusReason` tests for OK, Watch, Bad, and Stale.
+- R20 is covered by full-name preservation in `WatchItemDisplay.title`.
+- D-01 through D-08 and D-13 through D-16 are implemented in core-owned contracts without adding deferred scope.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-01-SUMMARY.md`.
+</output>

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-01-SUMMARY.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-01-SUMMARY.md
@@ -1,0 +1,148 @@
+---
+phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+plan: "01"
+subsystem: core-display
+tags: [swift, macos, menu-bar, accessibility, watchlist]
+
+requires:
+  - phase: 05-expand-kubectl-data-into-actionable-warning-and-workload-reasons
+    provides: actionable warning and workload reason data
+provides:
+  - Four-state menu bar icon source regression coverage
+  - Core-owned primaryStatusReason display contract
+  - Full watch target title preservation for later middle truncation
+affects: [menu-bar-status, status-summary, watchlist-rows, keyboard-navigation]
+
+tech-stack:
+  added: []
+  patterns:
+    - HealthEvaluator owns status reason selection
+    - MenuDisplayModel carries render-ready status reason data
+    - WatchItemDisplay.title preserves full app-owned target names
+
+key-files:
+  created:
+    - .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-01-SUMMARY.md
+  modified:
+    - KubebarCore/Models/MenuDisplayModel.swift
+    - KubebarCore/Services/HealthEvaluator.swift
+    - KubebarTests/Models/MenuBarStatusPresentationTests.swift
+    - KubebarTests/Models/MenuDisplayModelTests.swift
+
+key-decisions:
+  - "Kept OK as the custom KubebarLogo in the menu bar while preserving checkmark.circle for opened-menu summaries."
+  - "Kept one top-level status reason in KubebarCore instead of deriving health in SwiftUI views."
+  - "Stopped core tail truncation for watch target titles so views can apply middle truncation with full tooltip and accessibility values."
+
+patterns-established:
+  - "Status reason contract: MenuDisplayModel.primaryStatusReason is computed by HealthEvaluator and defaults to healthSentence for source compatibility."
+  - "Full title contract: WatchItemDisplay.title stores WatchTarget.displayTitle without pre-truncation."
+
+requirements-completed: [R1, R13, R20]
+
+duration: 5 min
+completed: 2026-04-21
+---
+
+# Phase 06 Plan 01: Core Presentation Contract Summary
+
+**Four-state menu bar icons, core-owned status reasons, and full watch target names are locked by model tests.**
+
+## Performance
+
+- **Duration:** 5 min
+- **Started:** 2026-04-21T15:58:49Z
+- **Completed:** 2026-04-21T16:03:42Z
+- **Tasks:** 3
+- **Files modified:** 4
+
+## Accomplishments
+
+- Locked all four menu bar icon sources in tests, including `OK` as `.custom("KubebarLogo")`.
+- Added `primaryStatusReason` to `MenuDisplayModel` and derived one concise reason for `OK`, `Watch`, `Bad`, and `Stale`.
+- Preserved full watch target titles in core display data so Phase 06 view work can apply middle truncation without losing suffixes.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Lock four menu bar icon sources and accessibility labels** - `c6731d6` (test)
+2. **Task 2 RED: Add failing primary status reason coverage** - `75cd407` (test)
+3. **Task 2 GREEN: Add primary status reasons** - `aa519b0` (feat)
+4. **Task 3 RED: Add failing full title coverage** - `9976be8` (test)
+5. **Task 3 GREEN: Preserve full watch item titles** - `bfc45c0` (feat)
+
+## Files Created/Modified
+
+- `KubebarCore/Models/MenuDisplayModel.swift` - Adds `primaryStatusReason` with a source-compatible initializer default.
+- `KubebarCore/Services/HealthEvaluator.swift` - Selects one primary status reason and passes full watch target names into `WatchItemDisplay`.
+- `KubebarTests/Models/MenuBarStatusPresentationTests.swift` - Locks custom and SF Symbol icon sources plus accessibility labels.
+- `KubebarTests/Models/MenuDisplayModelTests.swift` - Covers primary reasons and full-title preservation.
+- `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-01-SUMMARY.md` - Records plan results.
+
+## Decisions Made
+
+- Used the existing `MenuBarStatusPresentation.icon` contract for menu bar state assertions instead of adding view-level checks.
+- Made `primaryStatusReason` optional in the initializer so any direct construction still falls back to `healthSentence`.
+- Removed only watch target title shortening; warning message capping remains in place because it limits secondary warning detail copy.
+
+## Deviations from Plan
+
+### Verification Adjustments
+
+**1. Task 3 negative grep pattern conflicted with a required full-name assertion**
+- **Found during:** Task 3 acceptance checks
+- **Issue:** The plan required the exact string `checkout-api-with-a-very-long-name`, but its negative regex `checkout-api-with-a-.` also matches that required string.
+- **Fix:** Kept the required full-name test and verified the actual forbidden patterns with `shortened(item.target.displayTitle)`, `checkout-api-with-a-...`, and `prefix(limit - 1)`.
+- **Files modified:** None for the adjustment
+- **Verification:** `swift test --filter MenuDisplayModelTests` passed, and source checks confirmed full titles enter `WatchItemDisplay`.
+- **Committed in:** No separate commit; code behavior is covered by `bfc45c0`.
+
+### Auto-fixed Issues
+
+None.
+
+---
+
+**Total deviations:** 1 verification adjustment, 0 auto-fixed code issues.
+**Impact on plan:** No behavior scope changed. The implementation satisfies the intended full-name preservation contract.
+
+## Issues Encountered
+
+- Task 1's new tests passed immediately because production already mapped `OK` to `KubebarLogo`; no production edit was needed.
+- `./scripts/swift-quality-gate.sh local` printed a non-blocking CoreSimulator version warning, but the macOS build/test and SwiftPM build/test completed successfully.
+
+## Verification
+
+- `swift test --filter MenuBarStatusPresentationTests` - passed.
+- `swift test --filter MenuDisplayModelTests` - passed.
+- `rg -n "primaryStatusReason|KubebarLogo|checkout-api-with-a-very-long-name" KubebarCore KubebarTests` - found the Phase 06 core contracts and tests.
+- Negative deferred-scope grep for `NSStatusItem|NSMenu|Open in k9s|notarization|distribution|dashboard|raw kubectl` in `KubebarCore` and `KubebarTests/Models` - passed.
+- `swift test` - passed, 86 tests.
+- `./scripts/swift-quality-gate.sh local` - passed.
+
+## Known Stubs
+
+None. Default initializer values found during scan are existing source-compatible defaults, not UI stubs.
+
+## Threat Flags
+
+None. This plan added display-model fields and tests only; it did not add new endpoints, auth paths, file access, subprocess boundaries, or schema changes.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+Ready for Phase 06 Plan 02. The core now exposes the status reason and full watch target names that the SwiftUI views need for opened-menu rendering, middle truncation, tooltip, and accessibility work.
+
+## Self-Check: PASSED
+
+- Summary file exists.
+- Task commits found: `c6731d6`, `75cd407`, `aa519b0`, `9976be8`, `bfc45c0`.
+- No unexpected tracked file deletions were found in task commits.
+
+---
+*Phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation*
+*Completed: 2026-04-21*

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-02-PLAN.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-02-PLAN.md
@@ -1,0 +1,304 @@
+---
+phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+plan: "02"
+type: execute
+wave: 2
+depends_on: ["06-01"]
+files_modified:
+  - Kubebar/Views/StatusSummaryView.swift
+  - Kubebar/Views/MenuBarRootView.swift
+  - Kubebar/Views/WatchlistSectionView.swift
+  - Kubebar/Views/TrackedItemDetailView.swift
+  - Kubebar/Views/WarningEventsView.swift
+  - Kubebar/Views/SetupView.swift
+  - Kubebar/Views/WatchlistPickerView.swift
+autonomous: true
+requirements: [R13, R18, R19, R20, R21]
+user_setup: []
+must_haves:
+  truths:
+    - "Opening the menu shows symbol, state text, and one reason for OK, Watch, Bad, and Stale."
+    - "The opened menu remains ordered as summary, stale signal, counters, watchlist, warning events, node details, refresh, and actions."
+    - "Long context, namespace, workload, and warning names use one-line middle truncation with full tooltip/accessibility text."
+    - "Setup, refresh, edit watchlist, detail disclosure, warning sections, and secondary controls stay reachable through native keyboard behavior."
+  artifacts:
+    - "Kubebar/Views/StatusSummaryView.swift renders MenuBarStatusPresentation plus MenuDisplayModel.primaryStatusReason."
+    - "Kubebar/Views/MenuBarRootView.swift preserves watchlist-first order and adds native shortcuts for refresh/edit actions."
+    - "Kubebar/Views/WatchlistSectionView.swift keeps rows one-line and uses middle truncation/help/accessibility."
+    - "Kubebar/Views/SetupView.swift and Kubebar/Views/WatchlistPickerView.swift keep setup/edit controls native and keyboard reachable."
+  key_links:
+    - "StatusSummaryView imports KubebarCore and uses MenuBarStatusPresentation(state: display.state)."
+    - "Every long visible resource name is rendered from a full app-owned display value with `.truncationMode(.middle)` and `.help(Text(...))`."
+    - "MenuBarRootView does not change the SwiftUI MenuBarExtra.window shell or add AppKit status-item architecture."
+---
+
+<objective>
+Polish the SwiftUI menu so Phase 06 core state is readable, native-feeling, middle-truncated, and keyboard reachable.
+
+Purpose: Issue #6 is a menu-readability and keyboard-navigation phase. This plan renders the contracts from Plan 01 without turning Kubebar into a dashboard or moving health logic into views.
+
+Output: Updated SwiftUI menu, setup, watchlist, warning, and detail views using native controls, one-line middle truncation, tooltip/accessibility full names, and concise status presentation.
+</objective>
+
+<execution_context>
+@$HOME/.codex/get-shit-done/workflows/execute-plan.md
+@$HOME/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@AGENTS.md
+@docs/plans/2026-04-19-002-kubebar-product-roadmap.md
+@docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md
+@docs/architecture/runtime-invariants.md
+@docs/architecture/system-overview.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-RESEARCH.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-VALIDATION.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+@.planning/codebase/ARCHITECTURE.md
+@.planning/codebase/STRUCTURE.md
+@.planning/codebase/TESTING.md
+@.planning/codebase/CONCERNS.md
+@KubebarCore/Models/MenuBarStatusPresentation.swift
+@KubebarCore/Models/MenuDisplayModel.swift
+@Kubebar/Views/StatusSummaryView.swift
+@Kubebar/Views/MenuBarRootView.swift
+@Kubebar/Views/WatchlistSectionView.swift
+@Kubebar/Views/TrackedItemDetailView.swift
+@Kubebar/Views/WarningEventsView.swift
+@Kubebar/Views/SetupView.swift
+@Kubebar/Views/WatchlistPickerView.swift
+
+<interfaces>
+Plan 01 must provide this display contract:
+
+```swift
+public struct MenuDisplayModel: Equatable, Sendable {
+    public let state: ClusterHealthState
+    public let contextName: String
+    public let healthSentence: String
+    public let primaryStatusReason: String
+    public let lastUpdated: String
+    public let counters: MenuCounters
+    public let warningEventSummaries: [WarningEventDisplay]
+    public let sectionNotices: [SectionAvailabilityDisplay]
+    public let visibleWatchItems: [WatchItemDisplay]
+    public let hiddenWatchItemCount: Int
+    public let staleBanner: StaleBannerDisplay?
+}
+
+public struct WatchItemDisplay: Equatable, Sendable, Identifiable {
+    public let title: String // full app-owned target display name
+    public let reason: String
+    public let detail: WatchItemDetailDisplay
+}
+```
+</interfaces>
+</context>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| MenuDisplayModel -> SwiftUI | Core-owned state and reasons become visible menu content. |
+| App-owned names -> tooltip/accessibility | Full names become hover help and assistive text. |
+| Keyboard input -> menu actions | Native controls trigger refresh, setup completion, edit watchlist, retry, and disclosures. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-06-02-01 | Spoofing | StatusSummaryView | mitigate | Per D-01 and D-04, keep the menu bar logo behavior untouched and render opened-menu OK explicitly with `MenuBarStatusPresentation.symbolName`, `display.state.label`, and `display.primaryStatusReason`. |
+| T-06-02-02 | Information Disclosure by confusion | StatusSummaryView, WatchlistSectionView, WarningEventsView | mitigate | Per D-06, D-07, and D-08, render symbol, status text, and one reason; do not add color-only or multi-line incident summaries. |
+| T-06-02-03 | Spoofing | Long-name text in menu/setup views | mitigate | Per D-13, D-14, D-15, and D-16, apply `.lineLimit(1)`, `.truncationMode(.middle)`, `.help(Text(fullName))`, and `.accessibilityLabel(fullName)` to full app-owned names. |
+| T-06-02-04 | Information Disclosure | Tooltip/accessibility text | mitigate | Use `display.contextName`, `item.title`, `summary.summary`, `notice` strings, context names, namespace names, and workload display titles only; do not expose raw kubectl stdout/stderr/JSON. |
+| T-06-02-05 | Denial of Service | Keyboard navigation | mitigate | Per D-10 and D-17, keep `Button`, `Picker`, `Toggle`, and `DisclosureGroup`; add standard shortcuts to primary actions without custom key handlers, CodexBar provider plumbing, CLI subproducts, or AppKit migration. |
+</threat_model>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Render explicit opened-menu status summary</name>
+  <files>Kubebar/Views/StatusSummaryView.swift, Kubebar/Views/MenuBarRootView.swift</files>
+  <read_first>
+    AGENTS.md
+    docs/architecture/system-overview.md
+    docs/architecture/runtime-invariants.md
+    docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-RESEARCH.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+    KubebarCore/Models/MenuBarStatusPresentation.swift
+    KubebarCore/Models/MenuDisplayModel.swift
+    Kubebar/Views/StatusSummaryView.swift
+    Kubebar/Views/MenuBarRootView.swift
+  </read_first>
+  <action>
+Update the opened top status area per D-04, D-06, D-07, D-08, D-09, D-10, D-11, and D-12.
+
+In `StatusSummaryView.swift`:
+- Keep `import KubebarCore`.
+- Create `private var presentation: MenuBarStatusPresentation { MenuBarStatusPresentation(state: display.state) }`.
+- Replace the current two-line layout with a compact render-only layout:
+  - Top line: `Text(display.contextName)` as `.font(.headline)`, `.lineLimit(1)`, `.truncationMode(.middle)`, `.help(Text(display.contextName))`, and `.accessibilityLabel(display.contextName)`.
+  - Status line: `Image(systemName: presentation.symbolName)` plus `Text(display.state.label)` plus `Text(display.primaryStatusReason)`.
+  - The status label must show exact state text `OK`, `Watch`, `Bad`, or `Stale` from `display.state.label`.
+  - `display.primaryStatusReason` must be `.lineLimit(1)` and must not be expanded into a multi-line summary.
+- Set the whole status block accessibility label to exactly the interpolated form `"\(presentation.accessibilityLabel), \(display.primaryStatusReason), context \(display.contextName)"`.
+- Do not use color as the only state cue. Color or foregroundStyle may be secondary only because symbol, state text, and reason are present.
+- Per D-10, do not copy CodexBar provider registries, widgets, update plumbing, keychain/cookie usage providers, CLI subproducts, AppKit `NSStatusItem`, or `NSMenu`.
+
+In `MenuBarRootView.swift`:
+- Preserve this menu order exactly: `StatusSummaryView`, `StaleBannerView`, `CompactCountersView`, `WatchlistSectionView`, `WarningEventsView`, `NodeDetailsView`, `Divider`, `refreshControls`, `actions`.
+- Keep `.frame(width: 340)` unless the updated text visibly clips during compile-run QA; if width changes, keep it between `340` and `380` and do not add horizontal scrolling.
+  </action>
+  <verify>
+    <automated>swift build</automated>
+    <automated>swift test --filter MenuDisplayModelTests</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "MenuBarStatusPresentation\\(state: display.state\\)|presentation.symbolName|display.primaryStatusReason|display.state.label" Kubebar/Views/StatusSummaryView.swift` finds the explicit opened-menu state rendering.
+    - `rg -n "truncationMode\\(\\.middle\\)|help\\(Text\\(display.contextName\\)\\)|accessibilityLabel\\(display.contextName\\)" Kubebar/Views/StatusSummaryView.swift` finds context middle truncation and full-name fallback.
+    - `rg -n "StatusSummaryView\\(display: display\\).*StaleBannerView\\(banner: display.staleBanner\\).*CompactCountersView\\(counters: display.counters\\).*WatchlistSectionView\\(display: display\\)" Kubebar/Views/MenuBarRootView.swift` may not match across lines; if not, inspect the block and confirm the exact order remains unchanged.
+    - `! rg -n "NSStatusItem|NSMenu|provider registry|keychain|cookie|Open in k9s|dashboard|widget" Kubebar/Views/StatusSummaryView.swift Kubebar/Views/MenuBarRootView.swift`
+    - `swift build` passes.
+    - `swift test --filter MenuDisplayModelTests` passes.
+  </acceptance_criteria>
+  <done>The opened menu explicitly explains the compressed menu bar signal with state symbol, state text, and one reason.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Apply middle truncation and full-name fallbacks</name>
+  <files>Kubebar/Views/StatusSummaryView.swift, Kubebar/Views/WatchlistSectionView.swift, Kubebar/Views/TrackedItemDetailView.swift, Kubebar/Views/WarningEventsView.swift, Kubebar/Views/SetupView.swift, Kubebar/Views/WatchlistPickerView.swift</files>
+  <read_first>
+    AGENTS.md
+    docs/architecture/runtime-invariants.md
+    docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-RESEARCH.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+    KubebarCore/Models/MenuDisplayModel.swift
+    Kubebar/Views/StatusSummaryView.swift
+    Kubebar/Views/WatchlistSectionView.swift
+    Kubebar/Views/TrackedItemDetailView.swift
+    Kubebar/Views/WarningEventsView.swift
+    Kubebar/Views/SetupView.swift
+    Kubebar/Views/WatchlistPickerView.swift
+  </read_first>
+  <action>
+Apply the same long-name pattern everywhere Phase 06 exposes context, namespace, workload, or warning-location text, per D-13, D-14, D-15, and D-16.
+
+Required SwiftUI pattern for every full name:
+```swift
+Text(fullName)
+    .lineLimit(1)
+    .truncationMode(.middle)
+    .help(Text(fullName))
+    .accessibilityLabel(fullName)
+```
+
+Specific edits:
+- `StatusSummaryView.swift`: keep the Task 1 context treatment.
+- `WatchlistSectionView.swift`: apply the pattern to `Text(item.title)`. Keep `Text(item.reason)` one line. Keep `DisclosureGroup` for each visible item.
+- `TrackedItemDetailView.swift`: apply one-line middle truncation, help, and accessibility to `Examples: ...`, `Latest warning: ...`, and latest warning message when rendered. Keep message `lineLimit(2)` but add `.help(Text(message))` and `.accessibilityLabel(message)`.
+- `WarningEventsView.swift`: apply one-line middle truncation, help, and accessibility to `summary.summary` and each section notice string. Keep warning messages capped by the existing model and add help/accessibility for the rendered message.
+- `SetupView.swift`: in the context picker, change `Text(context).tag(Optional(context))` to a label that applies the pattern to the context string before `.tag(Optional(context))`.
+- `WatchlistPickerView.swift`: replace title-only `Toggle(namespace, isOn: ...)` and `Toggle(workload.displayTitle, isOn: ...)` with label-based toggles:
+  - `Toggle(isOn: binding(for: .namespace(namespace))) { Text(namespace) ... }`
+  - `Toggle(isOn: binding(for: workload.target)) { Text(workload.displayTitle) ... }`
+- `WatchlistPickerView.swift`: change `DisclosureGroup(group.key)` to label content with `Text(group.key)` using the same truncation/help/accessibility modifiers.
+
+Do not add multi-line primary menu rows, custom text measurement, custom hover tracking, new UI automation, AppKit menu rewrites, or raw kubectl output fields.
+  </action>
+  <verify>
+    <automated>swift build</automated>
+    <automated>swift test --filter MenuDisplayModelTests</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "truncationMode\\(\\.middle\\)" Kubebar/Views/StatusSummaryView.swift Kubebar/Views/WatchlistSectionView.swift Kubebar/Views/TrackedItemDetailView.swift Kubebar/Views/WarningEventsView.swift Kubebar/Views/SetupView.swift Kubebar/Views/WatchlistPickerView.swift` finds middle truncation in all six files.
+    - `rg -n "help\\(Text\\(" Kubebar/Views/StatusSummaryView.swift Kubebar/Views/WatchlistSectionView.swift Kubebar/Views/TrackedItemDetailView.swift Kubebar/Views/WarningEventsView.swift Kubebar/Views/SetupView.swift Kubebar/Views/WatchlistPickerView.swift` finds tooltip/help fallback in all six files.
+    - `rg -n "accessibilityLabel" Kubebar/Views/StatusSummaryView.swift Kubebar/Views/WatchlistSectionView.swift Kubebar/Views/TrackedItemDetailView.swift Kubebar/Views/WarningEventsView.swift Kubebar/Views/SetupView.swift Kubebar/Views/WatchlistPickerView.swift` finds accessibility fallback in all six files.
+    - `! rg -n "lineLimit\\([2-9]\\).*item.title|lineLimit\\([2-9]\\).*context|NSStatusItem|NSMenu|raw kubectl|stdout|stderr|JSONDecoder" Kubebar/Views`
+    - `swift build` passes.
+    - `swift test --filter MenuDisplayModelTests` passes.
+  </acceptance_criteria>
+  <done>Long names stay one-line and scannable while full values remain available through hover help and accessibility text.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add native keyboard affordances without changing scope</name>
+  <files>Kubebar/Views/MenuBarRootView.swift, Kubebar/Views/SetupView.swift, Kubebar/Views/WatchlistPickerView.swift, Kubebar/Views/WatchlistSectionView.swift</files>
+  <read_first>
+    AGENTS.md
+    docs/architecture/runtime-invariants.md
+    docs/architecture/system-overview.md
+    docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-RESEARCH.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+    Kubebar/Views/MenuBarRootView.swift
+    Kubebar/Views/SetupView.swift
+    Kubebar/Views/WatchlistPickerView.swift
+    Kubebar/Views/WatchlistSectionView.swift
+  </read_first>
+  <action>
+Make keyboard reachability explicit using native SwiftUI controls, per D-17, D-18, D-20, R18, R19, and R21.
+
+In `MenuBarRootView.swift`:
+- Keep `Picker("Refresh cadence", selection: refreshCadenceBinding)` as a native `.pickerStyle(.menu)`.
+- Add `.keyboardShortcut("r", modifiers: .command)` to `Button("Retry now", action: onRefresh)`.
+- Keep `.disabled(isRefreshing)` on the retry button so D-20 can verify enabled and disabled refresh paths.
+- Add `.keyboardShortcut("e", modifiers: .command)` to `Button("Edit watchlist", action: onEditWatchlist)`.
+- Add `.help(Text(isRefreshing ? "Refresh in progress" : "Refresh now"))` to Retry and `.help(Text("Edit watchlist"))` to Edit watchlist.
+
+In `SetupView.swift`:
+- Add `.keyboardShortcut(.defaultAction)` to `Button("Finish setup", action: onComplete)`.
+- Keep `.disabled(!state.isConfigured)` so D-20 can verify setup enabled and disabled paths.
+- Keep context and refresh cadence as native `Picker` controls; do not replace them with custom rows.
+
+In `WatchlistPickerView.swift`:
+- Keep namespace and workload choices as native `Toggle` controls.
+- Keep workload grouping as native `DisclosureGroup`.
+- Add `.keyboardShortcut("r", modifiers: .command)` and `.help(Text("Retry loading watch targets"))` to both `Button("Retry", action: onRetryTargets)` instances.
+
+In `WatchlistSectionView.swift`:
+- Keep each visible watchlist row behind native `DisclosureGroup` so details remain keyboard reachable.
+- If editing the overflow row, keep it non-prominent and do not show more than the existing first-screen `3-5` visible watchlist rows.
+
+Do not add custom key event handlers, focus engines, AppKit bridges, `Open in k9s`, deep troubleshooting actions, dashboards, or distribution work.
+  </action>
+  <verify>
+    <automated>swift build</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "Button\\(\"Retry now\"|keyboardShortcut\\(\"r\", modifiers: \\.command\\)|disabled\\(isRefreshing\\)|help\\(Text\\(isRefreshing \\? \"Refresh in progress\" : \"Refresh now\"\\)\\)" Kubebar/Views/MenuBarRootView.swift` finds refresh keyboard and disabled-state coverage.
+    - `rg -n "Button\\(\"Edit watchlist\"|keyboardShortcut\\(\"e\", modifiers: \\.command\\)|help\\(Text\\(\"Edit watchlist\"\\)\\)" Kubebar/Views/MenuBarRootView.swift` finds edit keyboard coverage.
+    - `rg -n "Button\\(\"Finish setup\"|keyboardShortcut\\(\\.defaultAction\\)|disabled\\(!state.isConfigured\\)" Kubebar/Views/SetupView.swift` finds setup keyboard and disabled-state coverage.
+    - `rg -n "Toggle\\(|DisclosureGroup\\(|Button\\(\"Retry\"|Retry loading watch targets|keyboardShortcut\\(\"r\", modifiers: \\.command\\)" Kubebar/Views/WatchlistPickerView.swift Kubebar/Views/WatchlistSectionView.swift` finds native setup/watchlist controls.
+    - `! rg -n "onKey|keyDown|NSEvent|NSStatusItem|NSMenu|Open in k9s|notarization|distribution|dashboard" Kubebar/Views`
+    - `swift build` passes.
+  </acceptance_criteria>
+  <done>Refresh, edit watchlist, setup completion, retry target loading, and disclosure details remain native and keyboard reachable.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `swift build` passes.
+- `swift test --filter MenuDisplayModelTests` passes.
+- `rg -n "primaryStatusReason|truncationMode\\(\\.middle\\)|help\\(Text\\(|keyboardShortcut" Kubebar/Views` shows the Phase 06 rendering affordances.
+- `! rg -n "NSStatusItem|NSMenu|Open in k9s|notarization|distribution|dashboard|raw kubectl|JSONDecoder" Kubebar/Views`
+</verification>
+
+<success_criteria>
+- R13 is satisfied because status meaning uses symbol, text, and reason rather than color alone.
+- R18 and R19 are satisfied because the existing watchlist-first native menu order is preserved without card/dashboard expansion.
+- R20 is satisfied because long names use one-line middle truncation with full tooltip/accessibility fallback.
+- R21 is satisfied because primary actions, setup controls, watchlist toggles, and detail disclosures remain native keyboard-reachable controls.
+- D-04 through D-18 and D-20 are reflected in SwiftUI rendering or verification hooks without adding deferred scope.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-02-SUMMARY.md`.
+</output>

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-02-SUMMARY.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-02-SUMMARY.md
@@ -1,0 +1,136 @@
+---
+phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+plan: "02"
+subsystem: ui
+tags: [swift, macos, menu-bar, accessibility, keyboard, truncation, watchlist]
+
+requires:
+  - phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+    provides: core status reason and full watch target title contracts from Plan 01
+provides:
+  - Opened-menu status summary with symbol, state text, and one primary reason
+  - One-line middle truncation plus full help and accessibility fallback for long menu names
+  - Native keyboard shortcuts for refresh, edit watchlist, retry target loading, and setup completion
+affects: [menu-bar-status, watchlist-rows, setup-flow, warning-events, keyboard-navigation]
+
+tech-stack:
+  added: []
+  patterns:
+    - SwiftUI views render MenuDisplayModel without deciding health
+    - Full app-owned names stay in display data while views apply middle truncation
+    - Keyboard reachability uses native Button, Picker, Toggle, and DisclosureGroup controls
+
+key-files:
+  created:
+    - .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-02-SUMMARY.md
+  modified:
+    - Kubebar/Views/StatusSummaryView.swift
+    - Kubebar/Views/MenuBarRootView.swift
+    - Kubebar/Views/WatchlistSectionView.swift
+    - Kubebar/Views/TrackedItemDetailView.swift
+    - Kubebar/Views/WarningEventsView.swift
+    - Kubebar/Views/SetupView.swift
+    - Kubebar/Views/WatchlistPickerView.swift
+
+key-decisions:
+  - "Kept the MenuBarExtra.window shell and watchlist-first menu order unchanged."
+  - "Used view-level middle truncation with help and accessibility text instead of changing core display strings."
+  - "Added standard SwiftUI keyboard shortcuts only, with no custom key handlers or AppKit menu rewrite."
+
+patterns-established:
+  - "Opened status summary: state symbol, exact state label, and MenuDisplayModel.primaryStatusReason explain the menu bar signal."
+  - "Long-name rendering: lineLimit(1), truncationMode(.middle), help(Text(fullValue)), and accessibilityLabel(fullValue)."
+  - "Action reachability: Retry now uses Command-R, Edit watchlist uses Command-E, Finish setup uses the default action."
+
+requirements-completed: [R13, R18, R19, R20, R21]
+
+duration: 4 min
+completed: 2026-04-21
+---
+
+# Phase 06 Plan 02: Menu Readability and Keyboard Polish Summary
+
+**Opened menu status, long-name fallbacks, and native keyboard shortcuts now make the menu readable without expanding scope.**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-04-21T16:06:24Z
+- **Completed:** 2026-04-21T16:10:33Z
+- **Tasks:** 3
+- **Files modified:** 7
+
+## Accomplishments
+
+- The opened menu now explains the compressed menu bar signal with a status symbol, exact state text, and one primary reason.
+- Long context, namespace, workload, warning, and detail names stay one-line with middle truncation while preserving full values for hover help and accessibility.
+- Refresh, edit watchlist, setup completion, retry target loading, and detail disclosure remain native keyboard-reachable controls.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Render explicit opened-menu status summary** - `2b3505c` (feat)
+2. **Task 2: Apply middle truncation and full-name fallbacks** - `1cbb00e` (feat)
+3. **Task 3: Add native keyboard affordances without changing scope** - `fb15ba6` (feat)
+
+## Files Created/Modified
+
+- `Kubebar/Views/StatusSummaryView.swift` - Renders the opened-menu state symbol, state text, primary reason, and full context fallback.
+- `Kubebar/Views/MenuBarRootView.swift` - Preserves menu order and adds native refresh/edit shortcuts with help text.
+- `Kubebar/Views/WatchlistSectionView.swift` - Keeps watchlist rows behind DisclosureGroup and applies full-title fallback to row titles.
+- `Kubebar/Views/TrackedItemDetailView.swift` - Adds full help and accessibility fallback for example pods, latest warning summary, and warning messages.
+- `Kubebar/Views/WarningEventsView.swift` - Adds one-line middle truncation and full fallback for warning summaries, notices, and messages.
+- `Kubebar/Views/SetupView.swift` - Keeps native setup controls and adds context-name fallback plus default setup action.
+- `Kubebar/Views/WatchlistPickerView.swift` - Keeps native toggles/disclosures and adds full fallback plus retry shortcuts.
+- `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-02-SUMMARY.md` - Records plan execution.
+
+## Decisions Made
+
+- Kept `MenuBarExtra.window`, the 340-point menu width, and the existing order: summary, stale signal, counters, watchlist, warning events, node details, refresh, and actions.
+- Kept all health meaning in `MenuDisplayModel` and only rendered `primaryStatusReason` in SwiftUI.
+- Used standard SwiftUI controls and shortcuts instead of custom key events or AppKit bridges.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+- `./scripts/swift-quality-gate.sh local` printed the existing CoreSimulator version warning, but the macOS Xcode build/test and SwiftPM build/test completed successfully.
+- `gsd-sdk`, `.planning/STATE.md`, and `.planning/ROADMAP.md` were unavailable in this worktree. Per user instruction, no STATE or ROADMAP files were created or updated.
+
+## Verification
+
+- `swift build` - passed.
+- `swift test --filter MenuDisplayModelTests` - passed, 18 tests.
+- `rg -n "primaryStatusReason|truncationMode\\(\\.middle\\)|help\\(Text\\(|keyboardShortcut" Kubebar/Views` - found the Phase 06 rendering and keyboard affordances.
+- Negative grep for `NSStatusItem|NSMenu|Open in k9s|notarization|distribution|dashboard|raw kubectl|JSONDecoder` in `Kubebar/Views` - passed.
+- `./scripts/swift-quality-gate.sh local` - passed, including Xcode build/test and SwiftPM build/test with 86 Swift tests.
+
+## Known Stubs
+
+None. Stub-pattern scan only found existing default no-op callback closures in view initializers; those are intentional preview/test defaults, not UI data stubs.
+
+## Threat Flags
+
+None. This plan only changed SwiftUI rendering and native shortcuts; it added no new network endpoints, auth paths, file access, subprocess boundaries, or schema changes.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+Ready for Phase 06 Plan 03. The SwiftUI menu now consumes the Plan 01 display contract directly, keeps watchlist-first order, preserves full names for assistive use, and uses native controls for keyboard reachability.
+
+---
+*Phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation*
+*Completed: 2026-04-21*
+
+## Self-Check: PASSED
+
+- Summary file exists.
+- Task commits found: `2b3505c`, `1cbb00e`, `fb15ba6`.
+- Key modified files exist.
+- No unexpected tracked file deletions were found in task commits.

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-03-PLAN.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-03-PLAN.md
@@ -1,0 +1,256 @@
+---
+phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+plan: "03"
+type: execute
+wave: 3
+depends_on: ["06-02"]
+files_modified:
+  - docs/architecture/runtime-invariants.md
+  - .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md
+autonomous: false
+requirements: [R1, R13, R18, R19, R20, R21]
+user_setup: []
+must_haves:
+  truths:
+    - "Runtime invariants document the Phase 06 menu bar state, non-color, truncation, and keyboard rules."
+    - "Phase 06 UAT covers OK, Watch, Bad, and Stale."
+    - "Phase 06 UAT covers setup, edit watchlist, refresh enabled, refresh disabled, watchlist details, warning events, and secondary sections."
+    - "Final verification includes both the Swift quality gate and visible-app smoke launch."
+  artifacts:
+    - "docs/architecture/runtime-invariants.md records opened-menu OK, symbol/text/reason, middle truncation, full-name fallback, and keyboard reachability."
+    - ".planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md records automated and manual QA coverage for issue #6."
+  key_links:
+    - "06-UAT.md references `./scripts/swift-quality-gate.sh local` and `./scripts/compile-and-run.sh`."
+    - "06-UAT.md maps manual checks back to D-18, D-19, D-20, and R21."
+    - "Runtime invariants stay aligned with AGENTS.md watchlist-first and no-deep-troubleshooting rules."
+---
+
+<objective>
+Record Phase 06 runtime guarantees and create the UAT checklist for real menu keyboard verification.
+
+Purpose: Unit tests can prove core behavior, but issue #6 also needs a visible menu and keyboard checklist. This plan captures the manual QA contract without adding a new UI automation stack or deferred product scope.
+
+Output: Updated runtime invariants, Phase 06 UAT file, full quality-gate command coverage, visible-app smoke coverage, and a human verification checkpoint for keyboard traversal.
+</objective>
+
+<execution_context>
+@$HOME/.codex/get-shit-done/workflows/execute-plan.md
+@$HOME/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@AGENTS.md
+@docs/plans/2026-04-19-002-kubebar-product-roadmap.md
+@docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md
+@docs/architecture/runtime-invariants.md
+@docs/architecture/system-overview.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-RESEARCH.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-VALIDATION.md
+@.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+@.planning/codebase/ARCHITECTURE.md
+@.planning/codebase/STRUCTURE.md
+@.planning/codebase/TESTING.md
+@.planning/codebase/CONCERNS.md
+@Kubebar/Views/StatusSummaryView.swift
+@Kubebar/Views/MenuBarRootView.swift
+@Kubebar/Views/WatchlistSectionView.swift
+@Kubebar/Views/WarningEventsView.swift
+@Kubebar/Views/SetupView.swift
+@Kubebar/Views/WatchlistPickerView.swift
+</context>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Runtime docs -> later implementation | Documented invariants guide subsequent changes and reviews. |
+| UAT checklist -> human verification | Manual observations become acceptance evidence for menu-bar behavior. |
+| Visible app -> local cluster context | Live menu checks may reveal local context/resource names. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-06-03-01 | Spoofing | Runtime invariants and UAT | mitigate | Per D-01 and D-04, document that OK may be the logo in the menu bar but the opened menu must explicitly show OK text. UAT must include OK. |
+| T-06-03-02 | Information Disclosure by confusion | Runtime invariants and UAT | mitigate | Per D-06, D-07, and D-08, document and verify symbol + state text + one short reason for Watch, Bad, and Stale; no color-only status acceptance. |
+| T-06-03-03 | Spoofing | Long-name UAT | mitigate | Per D-13 through D-16, document and verify middle truncation plus full tooltip/accessibility fallback for context, namespace, workload, and warning names. |
+| T-06-03-04 | Information Disclosure | Tooltip/accessibility UAT evidence | mitigate | UAT instructions must record only app-owned names or redacted observations; do not paste raw kubectl stdout, stderr, kubeconfig paths, token-like strings, or JSON. |
+| T-06-03-05 | Denial of Service | Keyboard UAT | mitigate | Per D-17, D-18, D-19, and D-20, require Full Keyboard Access traversal of setup, refresh enabled/disabled, edit watchlist, details, warning events, and secondary sections. |
+</threat_model>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Update runtime invariants for Phase 06</name>
+  <files>docs/architecture/runtime-invariants.md</files>
+  <read_first>
+    AGENTS.md
+    docs/architecture/runtime-invariants.md
+    docs/architecture/system-overview.md
+    docs/plans/2026-04-19-002-kubebar-product-roadmap.md
+    docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-RESEARCH.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+  </read_first>
+  <action>
+Update `docs/architecture/runtime-invariants.md` with Phase 06 rules, preserving existing product/data/freshness/watchlist/failure rules.
+
+Required additions:
+- Under Product Rules, add: `OK uses the brand logo in the menu bar, but the opened menu must explicitly show OK text.`
+- Under Failure Rules, add: `Watch, Bad, and Stale must be expressed with symbol, state text, and one short reason; color alone is not enough.`
+- Under Data Rules or Watchlist Rules, add: `Context, namespace, workload, and warning names stay app-owned display strings; tooltips and accessibility labels must not expose raw kubectl output.`
+- Under Watchlist Rules, replace or extend the existing truncation bullets with: `Long context, namespace, workload, and warning names use one-line middle truncation in views, preserving full names for tooltip and accessibility text.`
+- Under Watchlist Rules, add: `Primary watchlist rows stay one line; detailed reasons stay in watchlist detail, stale banner, warning event, or section notice areas.`
+- Add a new `## Keyboard Rules` section with bullets:
+  - `Setup, refresh, edit watchlist, watchlist detail, warning events, and secondary sections must be reachable through native macOS keyboard navigation.`
+  - `Refresh and setup completion must keep enabled and disabled states visible and testable.`
+  - `Keyboard support uses native SwiftUI controls and shortcuts, not custom AppKit status-item handling.`
+
+Do not add AppKit `NSStatusItem`, distribution, notarization, `Open in k9s`, deep troubleshooting, dashboard, or UI automation promises.
+  </action>
+  <verify>
+    <automated>rg -n "opened menu must explicitly show OK|symbol, state text, and one short reason|one-line middle truncation|Keyboard Rules|native SwiftUI controls" docs/architecture/runtime-invariants.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "opened menu must explicitly show OK" docs/architecture/runtime-invariants.md` finds the OK-logo invariant.
+    - `rg -n "symbol, state text, and one short reason|color alone is not enough" docs/architecture/runtime-invariants.md` finds the non-color invariant.
+    - `rg -n "one-line middle truncation|tooltip and accessibility" docs/architecture/runtime-invariants.md` finds long-name invariants.
+    - `rg -n "Keyboard Rules|Setup, refresh, edit watchlist, watchlist detail, warning events, and secondary sections" docs/architecture/runtime-invariants.md` finds keyboard invariants.
+    - `! rg -n "NSStatusItem|Open in k9s|notarization|distribution|dashboard|UI automation target" docs/architecture/runtime-invariants.md`
+  </acceptance_criteria>
+  <done>Runtime invariants explicitly preserve Phase 06 behavior for later implementation and review.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create Phase 06 UAT and run final commands</name>
+  <files>.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md</files>
+  <read_first>
+    AGENTS.md
+    docs/architecture/runtime-invariants.md
+    docs/plans/2026-04-19-002-kubebar-product-roadmap.md
+    docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-VALIDATION.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+    .planning/phases/05-expand-kubectl-data-into-actionable-warning-and-workload-reasons/05-UAT.md
+  </read_first>
+  <action>
+Create `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` using the prior UAT style.
+
+Required frontmatter:
+```yaml
+---
+status: pending-human-verification
+phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+source:
+  - 06-01-SUMMARY.md
+  - 06-02-SUMMARY.md
+started: YYYY-MM-DDTHH:MM:SSZ
+updated: YYYY-MM-DDTHH:MM:SSZ
+---
+```
+
+Required sections:
+- `## Automated Verification`
+  - Include rows for `swift test --filter MenuBarStatusPresentationTests`, `swift test --filter MenuDisplayModelTests`, `swift build`, `./scripts/swift-quality-gate.sh local`, and `./scripts/compile-and-run.sh`.
+  - Record result as `pending`, `pass`, or `blocked`; include one evidence sentence per row.
+- `## Manual Menu State Checks`
+  - Include checks for `OK`, `Watch`, `Bad`, and `Stale` per D-19.
+  - Each check must state expected opened-menu behavior: state text visible, symbol visible, one short reason visible, no color-only meaning.
+- `## Manual Keyboard Checks`
+  - Include setup, finish setup enabled, finish setup disabled, refresh enabled, refresh disabled, edit watchlist, watchlist detail disclosure, warning events, node details or other secondary sections, and target-load retry per D-17 and D-20.
+  - Include instruction to enable macOS Full Keyboard Access if traversal skips non-text controls.
+- `## Long Name Checks`
+  - Include context, namespace, workload, warning summary, and setup picker names.
+  - Expected result must say middle truncation preserves beginning and end, and full value is present in hover help/accessibility.
+- `## Scope Guards`
+  - Include checks that no AppKit `NSStatusItem`, distribution/notarization, `Open in k9s`, dashboard UI, raw kubectl output, or new UI automation stack was added.
+- `## Computer Use Notes`
+  - State that prior menu-bar extras may not be inspectable through automation; manual keyboard checks are the source of truth when automation cannot inspect SystemUIServer.
+
+Run these commands and record their actual result in the UAT file:
+1. `swift test --filter MenuBarStatusPresentationTests`
+2. `swift test --filter MenuDisplayModelTests`
+3. `swift build`
+4. `./scripts/swift-quality-gate.sh local`
+5. `./scripts/compile-and-run.sh`
+
+If `./scripts/compile-and-run.sh` launches the app but the menu cannot be inspected non-interactively, record the launch as pass and leave manual traversal rows as `pending-human-verification`.
+  </action>
+  <verify>
+    <automated>swift test --filter MenuBarStatusPresentationTests</automated>
+    <automated>swift test --filter MenuDisplayModelTests</automated>
+    <automated>swift build</automated>
+    <automated>./scripts/swift-quality-gate.sh local</automated>
+    <automated>./scripts/compile-and-run.sh</automated>
+  </verify>
+  <acceptance_criteria>
+    - `test -f .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md`
+    - `rg -n "OK|Watch|Bad|Stale" .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` finds all four state checks.
+    - `rg -n "setup|Finish setup|refresh enabled|refresh disabled|Edit watchlist|watchlist detail|Warning events|secondary sections|Full Keyboard Access" .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` finds keyboard checks.
+    - `rg -n "middle truncation|hover help|accessibility|context|namespace|workload|warning summary|setup picker" .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` finds long-name checks.
+    - `rg -n "swift-quality-gate.sh local|compile-and-run.sh|MenuBarStatusPresentationTests|MenuDisplayModelTests" .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` finds command evidence rows.
+    - `rg -n "NSStatusItem|Open in k9s|notarization|distribution|dashboard|raw kubectl output|UI automation stack" .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` finds scope guards.
+  </acceptance_criteria>
+  <done>Phase 06 has a concrete UAT file with automated command evidence and manual keyboard/state checks ready for sign-off.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: Human keyboard traversal sign-off</name>
+  <files>.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md</files>
+  <read_first>
+    AGENTS.md
+    docs/architecture/runtime-invariants.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+    .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md
+  </read_first>
+  <action>
+Ask the human verifier to run the visible app from `./scripts/compile-and-run.sh`, open the Kubebar menu, and complete the `06-UAT.md` manual keyboard checklist.
+
+Exact verification steps:
+1. Enable macOS Full Keyboard Access if Tab traversal skips controls.
+2. Confirm the opened menu state area shows state text, a symbol, and one reason for the state currently available in the live app.
+3. Confirm UAT rows exist for OK, Watch, Bad, and Stale; if the live cluster cannot force a state, leave that row `pending-human-verification` and rely on model tests for deterministic state coverage.
+4. Confirm keyboard traversal reaches setup, Finish setup enabled/disabled, Retry now enabled/disabled, Edit watchlist, watchlist detail disclosures, warning events, node details or other secondary sections, and target-load retry.
+5. Confirm long context, namespace, workload, warning, and setup picker names use middle truncation and expose full values through hover help/accessibility when available.
+6. Confirm no AppKit status-item rewrite, distribution/notarization, Open in k9s, dashboard, raw kubectl output, or new UI automation stack appeared.
+
+After verification, update `06-UAT.md` manual rows from `pending-human-verification` to `pass` or `blocked` with concise evidence. Do not record raw kubectl output, token-like strings, kubeconfig paths, or full JSON in evidence.
+  </action>
+  <verify>
+    <automated>rg -n "pending-human-verification|pass|blocked|Full Keyboard Access|Manual Keyboard Checks" .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - `rg -n "Manual Menu State Checks|Manual Keyboard Checks|Long Name Checks|Scope Guards" .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` finds all manual sections.
+    - `rg -n "pass|blocked|pending-human-verification" .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` finds explicit status values for manual rows.
+    - `! rg -n "client-key-data|client-certificate-data|certificate-authority-data|token:|password:|apiVersion:|kind: Config" .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md`
+  </acceptance_criteria>
+  <done>The user-visible keyboard and menu-state behavior is either signed off or explicitly blocked with evidence in `06-UAT.md`.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `swift test --filter MenuBarStatusPresentationTests` passes.
+- `swift test --filter MenuDisplayModelTests` passes.
+- `swift build` passes.
+- `./scripts/swift-quality-gate.sh local` passes.
+- `./scripts/compile-and-run.sh` launches the visible app smoke path.
+- `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` contains manual rows for D-18, D-19, and D-20.
+- `! rg -n "NSStatusItem|Open in k9s|notarization|distribution|dashboard UI|raw kubectl output|new UI automation stack" docs/architecture/runtime-invariants.md .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md`
+</verification>
+
+<success_criteria>
+- R1, R13, R18, R19, R20, and R21 are documented and verified through tests, UAT, or both.
+- D-18 is satisfied by automatic tests plus a manual QA checklist.
+- D-19 is satisfied by explicit OK, Watch, Bad, and Stale UAT rows.
+- D-20 is satisfied by setup, edit watchlist, and refresh enabled/disabled UAT rows.
+- The final gate includes `./scripts/swift-quality-gate.sh local` and `./scripts/compile-and-run.sh`.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-03-SUMMARY.md`.
+</output>

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-03-SUMMARY.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-03-SUMMARY.md
@@ -1,0 +1,154 @@
+---
+phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+plan: "03"
+subsystem: qa-docs
+tags: [macos, menu-bar, keyboard, accessibility, uat, swift]
+
+requires:
+  - phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+    provides: core status reason, full-name display contract, opened-menu rendering, and native keyboard affordances from Plans 01 and 02
+provides:
+  - Phase 06 runtime invariants for opened-menu OK text, non-color status reasons, middle truncation, and keyboard reachability
+  - Phase 06 UAT checklist with automated command evidence and explicit manual menu/keyboard rows
+  - Visible-app smoke launch evidence with manual keyboard traversal left pending
+affects: [runtime-invariants, uat, menu-verification, keyboard-navigation]
+
+tech-stack:
+  added: []
+  patterns:
+    - Runtime invariants document durable menu behavior before later changes
+    - UAT records automated pass evidence separately from manual menu-bar verification
+    - Manual keyboard traversal remains pending unless a human verifies the visible menu
+
+key-files:
+  created:
+    - .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md
+    - .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-03-SUMMARY.md
+  modified:
+    - docs/architecture/runtime-invariants.md
+
+key-decisions:
+  - "Recorded the Phase 06 manual keyboard checkpoint as pending-human-verification instead of fabricating a pass."
+  - "Kept scope guards semantic and grep-compatible by describing command transcript exposure without adding forbidden product-scope terms to runtime docs."
+  - "Skipped STATE.md and ROADMAP.md updates because they are missing in this worktree and the user explicitly requested not to create or update them."
+
+patterns-established:
+  - "UAT rows use pass, blocked, or pending-human-verification with concise evidence."
+  - "Computer Use limitations are documented when menu-bar extras cannot be inspected non-interactively."
+
+requirements-completed: [R1, R13, R18, R19, R20, R21]
+
+duration: 4 min
+completed: 2026-04-21
+---
+
+# Phase 06 Plan 03: Runtime Invariants and UAT Summary
+
+**Phase 06 menu runtime rules and UAT evidence now cover automated checks, visible launch, and pending human keyboard traversal.**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-04-21T16:13:52Z
+- **Completed:** 2026-04-21T16:17:54Z
+- **Tasks:** 2 automated tasks completed, 1 manual checkpoint pending
+- **Files modified:** 3
+
+## Accomplishments
+
+- Added Phase 06 runtime invariants for opened-menu OK text, symbol/text/reason status expression, one-line middle truncation, tooltip/accessibility fallbacks, and native keyboard reachability.
+- Created `06-UAT.md` with automated command evidence for focused tests, full quality gate, and visible-app smoke launch.
+- Left all real menu state, keyboard traversal, and long-name visual checks as `pending-human-verification` because the menu bar extra could not be inspected reliably through Computer Use.
+
+## Task Commits
+
+Each automated task was committed atomically:
+
+1. **Task 1: Update runtime invariants for Phase 06** - `0f486e7` (docs)
+2. **Task 2: Create Phase 06 UAT and run final commands** - `d2177a3` (docs)
+3. **Task 3: Human keyboard traversal sign-off** - pending-human-verification, no commit
+
+**Plan metadata:** pending final docs commit
+
+## Files Created/Modified
+
+- `docs/architecture/runtime-invariants.md` - Records Phase 06 runtime guarantees for menu status, names, and keyboard reachability.
+- `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` - Records automated command results plus pending manual state, keyboard, and long-name checks.
+- `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-03-SUMMARY.md` - Records this plan outcome.
+
+## Decisions Made
+
+- Manual keyboard traversal remains pending because no human verified the visible menu, and Computer Use returned Apple event timeout `-10005` for both `com.nextty.kubebar` and `SystemUIServer`.
+- UAT treats model tests as deterministic evidence for OK, Watch, Bad, and Stale state coverage, while visible menu state rows remain pending until human verification.
+- STATE.md and ROADMAP.md were not created or updated because this worktree does not contain them and the user explicitly excluded those updates.
+
+## Deviations from Plan
+
+### Verification Adjustments
+
+**1. Scope-guard wording avoids contradictory grep requirements**
+- **Found during:** Task 1 and Task 2 verification
+- **Issue:** The plan required scope guard language while the final negative grep also rejects several exact excluded-scope phrases.
+- **Fix:** Preserved the same safety meaning with neutral wording such as command transcripts, status-item rewrite, packaging/signing scope, k9s handoff, dashboard surface, and menu automation stack.
+- **Files modified:** `docs/architecture/runtime-invariants.md`, `06-UAT.md`
+- **Verification:** Task acceptance checks passed, and the final negative grep over runtime invariants plus UAT passed.
+- **Committed in:** `0f486e7`, `d2177a3`
+
+### Auto-fixed Issues
+
+None.
+
+---
+
+**Total deviations:** 1 verification wording adjustment, 0 auto-fixed code issues.
+**Impact on plan:** No product behavior changed. The documentation keeps the intended safety boundaries while allowing the plan's verification commands to pass.
+
+## Issues Encountered
+
+- `gsd-sdk` is not installed in this worktree. This did not block execution because the user explicitly requested no STATE.md or ROADMAP.md updates.
+- `.planning/STATE.md` and `.planning/ROADMAP.md` are missing. They were not created.
+- `./scripts/swift-quality-gate.sh local` and `./scripts/compile-and-run.sh` printed the existing CoreSimulator version warning, but macOS build/test and SwiftPM build/test completed successfully.
+- Computer Use could not inspect the running menu-bar extra; manual keyboard traversal remains pending.
+
+## Verification
+
+- `swift test --filter MenuBarStatusPresentationTests` - passed, 1 test.
+- `swift test --filter MenuDisplayModelTests` - passed, 18 tests.
+- `swift build` - passed.
+- `./scripts/swift-quality-gate.sh local` - passed, including Xcode build/test and SwiftPM build/test with 86 Swift tests.
+- `./scripts/compile-and-run.sh` - passed, launched `DerivedData/Build/Products/Debug/Kubebar.app` with PID 27388.
+- UAT contains D-18, D-19, D-20, and R21 mapping rows with explicit `pending-human-verification` status where manual inspection is still required.
+
+## Manual Verification Pending
+
+- Opened-menu state checks for OK, Watch, Bad, and Stale.
+- Keyboard traversal through setup, Finish setup enabled/disabled, refresh enabled/disabled, Edit watchlist, watchlist detail disclosure, warning events, secondary sections, and target-load retry.
+- Long context, namespace, workload, warning summary, and setup picker name checks for middle truncation plus full hover/accessibility fallback.
+
+## Known Stubs
+
+None.
+
+## Threat Flags
+
+None. This plan changed documentation and UAT artifacts only; it added no endpoints, auth paths, file access boundaries, subprocess boundaries, or schema changes.
+
+## User Setup Required
+
+None for automated/doc completion. Human verification is still required for the pending visible menu keyboard traversal rows in `06-UAT.md`.
+
+## Next Phase Readiness
+
+Automated and documentation work is ready for review. The only remaining Phase 06 Plan 03 gap is human sign-off of the visible menu keyboard traversal and long-name checks.
+
+## Self-Check: PASSED
+
+- Summary file exists.
+- UAT file exists.
+- Runtime invariants file exists.
+- Task commits found: `0f486e7`, `d2177a3`.
+- No STATE.md or ROADMAP.md updates were attempted because both files are missing in this worktree.
+
+---
+*Phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation*
+*Completed: 2026-04-21*

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md
@@ -1,0 +1,246 @@
+# Phase 06: Polish Menu Bar Icon States and Keyboard Navigation - Context
+
+**Gathered:** 2026-04-21
+**Status:** Ready for planning
+**Source issue:** https://github.com/nexttylabs/kubebar/issues/6
+
+<domain>
+
+## Phase Boundary
+
+This phase polishes the existing Kubebar menu experience so the app is readable
+from the macOS menu bar and usable without a mouse.
+
+This phase delivers:
+
+- Final menu bar icon treatment for `OK`, `Watch`, `Bad`, and `Stale`.
+- Status presentation that does not rely on color alone.
+- A CodexBar-inspired native menu feel: compact, ordered, and instrument-like,
+  without becoming a dashboard.
+- Consistent truncation for long context, namespace, and workload names.
+- Keyboard navigation coverage for setup, refresh, edit watchlist, details, and
+  secondary sections.
+- Automatic tests where practical plus manual QA coverage for real menu
+  interaction.
+
+This phase does not deliver:
+
+- New top-level health states beyond `OK`, `Watch`, `Bad`, and `Stale`.
+- A full dashboard, unlimited primary menu, or deep troubleshooting surface.
+- `Open in k9s`, shell handoff, or other deeper-debugging features.
+- AppKit `NSStatusItem` migration.
+- Local distribution, notarization, or release packaging.
+- The broader operator-facing QA phase from issue #7.
+
+</domain>
+
+<decisions>
+
+## Implementation Decisions
+
+### Menu Bar Icon States
+
+- **D-01:** Keep the healthy menu bar state as the brand logo. `OK` should use
+  the existing custom `KubebarLogo` in the menu bar.
+- **D-02:** Keep `Watch`, `Bad`, and `Stale` as explicit status symbols.
+- **D-03:** Reuse the current symbol set:
+  `Watch = exclamationmark.triangle`, `Bad = xmark.octagon`, and
+  `Stale = clock.badge.exclamationmark`.
+- **D-04:** When the menu opens, the top status area must explicitly show
+  `OK` for a healthy cluster so the logo is not the only health signal.
+- **D-05:** Preserve distinct accessibility labels for all four states, such as
+  `Kubebar OK`, `Kubebar Watch`, `Kubebar Bad`, and `Kubebar Stale`.
+
+### Non-Color Status Expression
+
+- **D-06:** Warning and failure states must use symbol, status text, and a short
+  reason. They must not rely on color alone.
+- **D-07:** The top status area should show only the single most important
+  reason, such as `2 pods restarting` or `kubectl timed out`.
+- **D-08:** Detailed reasons stay in the watchlist row, tracked item detail,
+  stale banner, or warning event sections. Do not turn the top status area into
+  a multi-line incident summary.
+
+### Menu Reading Experience
+
+- **D-09:** Use CodexBar as a design reference for the menu's product logic:
+  the menu bar icon is the first signal, the opened menu explains it, and the
+  menu behaves like a reliable small instrument.
+- **D-10:** Do not copy CodexBar's provider registry, widgets, update plumbing,
+  keychain/cookie usage providers, CLI subproduct, or AppKit status-item
+  architecture.
+- **D-11:** Keep the menu order focused on status summary plus watchlist first.
+  Warning events and node details remain lower-priority sections.
+- **D-12:** Tighten spacing and typography, but do not compress the menu. The
+  result should feel like native menu grouping, not cards or dashboard panels.
+
+### Long-Name Truncation
+
+- **D-13:** Long context, namespace, and workload names should use middle
+  truncation that preserves the beginning and end of the name.
+- **D-14:** Truncation should prioritize preserving tail differences for
+  workload and resource names, because Kubernetes names often differ at the
+  end.
+- **D-15:** Full untruncated names should remain available through hover
+  tooltip and accessibility text.
+- **D-16:** Avoid multi-line list rows for long names on the primary menu
+  surface. Multi-line names make menu height unstable and weaken quick reading.
+
+### Keyboard Navigation and Verification
+
+- **D-17:** Keyboard navigation must reach setup, refresh, edit watchlist,
+  watchlist detail, warning events, and secondary sections.
+- **D-18:** Verification should combine automatic tests with a manual QA
+  checklist. Existing tests can cover model and state behavior; real menu
+  keyboard behavior needs documented manual QA.
+- **D-19:** QA must cover all four menu states: `OK`, `Watch`, `Bad`, and
+  `Stale`.
+- **D-20:** QA must also cover setup, edit watchlist, and refresh enabled or
+  disabled paths.
+
+### the agent's Discretion
+
+- The planner may choose exact truncation length and helper type names.
+- The planner may choose whether tooltip support lives directly in SwiftUI
+  views or behind a small presentation helper, as long as full names are
+  available without cluttering the menu.
+- The planner may decide which keyboard-navigation behaviors are testable in
+  unit tests versus documented in UAT.
+- The planner may adjust exact copy if it keeps the same status meaning,
+  remains short, and does not weaken watchlist-first reading.
+
+</decisions>
+
+<canonical_refs>
+
+## Canonical References
+
+Downstream agents MUST read these before planning or implementing.
+
+### Product Direction
+
+- `AGENTS.md` - repo rules and Kubebar product guardrails.
+- `https://github.com/nexttylabs/kubebar/issues/6` - source issue for menu bar
+  icon states, reading polish, truncation, keyboard navigation, and acceptance
+  criteria.
+- `docs/plans/2026-04-19-002-kubebar-product-roadmap.md` - lists issue #6 as
+  the polish gate before operator QA and distribution work.
+- `docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md` -
+  defines R1, R13, and R18-R21.
+
+### CodexBar Reference
+
+- `.planning/phases/04-codexbar-inspired-menu-reliability-and-freshness/04-RESEARCH.md`
+  - captures the CodexBar design lessons to adapt: icon as first signal, menu
+  as explanation, local verification, and instrument-like menu behavior.
+- `.planning/phases/04-codexbar-inspired-menu-reliability-and-freshness/04-CONTEXT.md`
+  - locks the earlier decision to adapt CodexBar's useful lessons without
+  copying CodexBar's product or architecture.
+
+### Architecture and Runtime Rules
+
+- `docs/architecture/runtime-invariants.md` - defines icon categories,
+  watchlist-first rules, stale behavior, non-color failure rules, and
+  truncation expectations.
+- `docs/architecture/system-overview.md` - defines app, view model, core, and
+  service ownership.
+- `.planning/codebase/ARCHITECTURE.md` - maps current app layers and data flow.
+- `.planning/codebase/STRUCTURE.md` - maps where menu, models, services, and
+  tests live.
+- `.planning/codebase/TESTING.md` - defines current test shape and quality
+  gate.
+- `.planning/codebase/CONCERNS.md` - records current gaps around UI behavior,
+  keyboard navigation, visual stale states, and menu verification.
+
+### Prior Phase Context
+
+- `.planning/phases/03-complete-first-use-setup-and-watchlist-editing/03-CONTEXT.md`
+  - locks first-use setup and watchlist editing decisions.
+- `.planning/phases/04-codexbar-inspired-menu-reliability-and-freshness/04-CONTEXT.md`
+  - locks freshness, stale-state, refresh control, and CodexBar adaptation
+  boundaries.
+- `.planning/phases/05-expand-kubectl-data-into-actionable-warning-and-workload-reasons/05-CONTEXT.md`
+  - locks warning and workload reason presentation boundaries.
+
+</canonical_refs>
+
+<code_context>
+
+## Existing Code Insights
+
+### Reusable Assets
+
+- `KubebarCore/Models/MenuBarStatusPresentation.swift`: Current menu bar state
+  presentation already maps `OK` to `KubebarLogo` and the other states to
+  status symbols.
+- `Kubebar/KubebarApp.swift`: Builds the `MenuBarExtra` label from
+  `MenuBarStatusPresentation`.
+- `Kubebar/Views/StatusSummaryView.swift`: Top menu area already shows context,
+  state label, and health sentence.
+- `Kubebar/Views/MenuBarRootView.swift`: Existing menu order is status summary,
+  stale banner, counters, watchlist, warning events, node details, refresh
+  controls, and actions.
+- `Kubebar/Views/WatchlistSectionView.swift`: Current watchlist rows already
+  use one-line title and reason labels.
+- `Kubebar/Views/WarningEventsView.swift`: Current warning section already
+  renders short summaries and caps long messages.
+- `KubebarTests/Models/MenuBarStatusPresentationTests.swift`: Existing tests
+  cover state symbols and accessibility labels.
+
+### Established Patterns
+
+- SwiftUI views render `MenuDisplayModel`; they must not decide cluster health
+  directly.
+- `HealthEvaluator` remains the single source of truth for severity and display
+  mapping.
+- The menu stays watchlist-first with only 3-5 primary watchlist rows.
+- `Stale` must remain visually and semantically distinct from `OK`.
+- User-facing status copy should stay short and action-oriented.
+- The full local quality gate is `./scripts/swift-quality-gate.sh local`.
+
+### Integration Points
+
+- Icon state changes belong in `MenuBarStatusPresentation` and its tests.
+- Top status reason changes likely flow through `MenuDisplayModel` and
+  `HealthEvaluator` before `StatusSummaryView` renders them.
+- Truncation behavior should be centralized enough that context, namespace, and
+  workload names stay consistent across summary, watchlist, details, and setup.
+- Keyboard navigation and manual QA coverage should be documented in the phase
+  UAT file once implementation is planned.
+
+</code_context>
+
+<specifics>
+
+## Specific Ideas
+
+- Keep the healthy menu bar quiet and branded, but make `OK` explicit when the
+  menu opens.
+- Use the existing current symbol set rather than spending the phase on icon
+  redesign.
+- The first status line answers "what state is this?" and "what is the most
+  important reason?" without competing with the watchlist.
+- CodexBar is a reference for discipline and instrument-like menu behavior, not
+  a source of new Kubebar product scope.
+- Middle truncation should keep Kubernetes names scannable, especially when
+  resources share a long common prefix.
+- Manual QA should prove real menu keyboard behavior for all four states and
+  setup/edit/refresh paths.
+
+</specifics>
+
+<deferred>
+
+## Deferred Ideas
+
+- Full daily-loop operator QA belongs to GitHub issue #7.
+- AppKit `NSStatusItem` migration remains deferred.
+- Local distribution, notarization, and packaging remain deferred.
+- Deep troubleshooting handoff such as `Open in k9s` remains deferred.
+
+</deferred>
+
+---
+
+*Phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation*
+*Context gathered: 2026-04-21*

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-DISCUSSION-LOG.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-DISCUSSION-LOG.md
@@ -1,0 +1,170 @@
+# Phase 06: Polish Menu Bar Icon States and Keyboard Navigation - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md. This log preserves the alternatives considered.
+
+**Date:** 2026-04-21
+**Phase:** 06-polish-menu-bar-icon-states-and-keyboard-navigation
+**Areas discussed:** Menu bar icon states, Non-color status expression, Menu reading experience, Long-name truncation, Keyboard navigation and verification
+
+---
+
+## Menu Bar Icon States
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| All states use status symbols | `OK` also uses a health symbol; brand logo is not the healthy state. | no |
+| OK uses brand logo, other states use status symbols | Healthy state keeps the brand logo; warning and failure states use explicit symbols. | yes |
+| Brand logo plus status marker | Keep brand logo and add state meaning. | no |
+
+**User's choice:** OK uses the brand logo; Watch, Bad, and Stale use status symbols.
+**Notes:** Preserve the current brand-forward healthy state.
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Reuse current symbols | `Watch = exclamationmark.triangle`, `Bad = xmark.octagon`, `Stale = clock.badge.exclamationmark`. | yes |
+| Use a circle-based set | Use a more uniform symbol family. | no |
+| Choose a stronger new symbol set | Prioritize maximum visual difference. | no |
+
+**User's choice:** Reuse the current symbol set.
+**Notes:** Planning should polish and verify this set rather than reselect icons.
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Opened menu top clearly shows OK | Keep menu bar logo and confirm `OK` in the opened menu. | yes |
+| Show OK text next to the menu bar logo | Make menu bar state text visible at all times. | no |
+| Use checkmark for healthy state | Replace healthy logo with a health symbol. | no |
+
+**User's choice:** Keep the menu bar logo, then show `OK` clearly at the top of the opened menu.
+**Notes:** This avoids making the logo the only healthy-state signal.
+
+---
+
+## Non-Color Status Expression
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Symbol + status text + short reason | State meaning is carried by more than color and includes the top reason. | yes |
+| Symbol + status text | Clear but less explanatory for `Bad` or `Stale`. | no |
+| Symbol-first with weak text | Visually lighter but weaker for accessibility and issue requirements. | no |
+
+**User's choice:** Use symbol, status text, and a short reason.
+**Notes:** Warning and failure states must not rely on color alone.
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Top shows one most important reason | Keep top status fast to read; details remain below. | yes |
+| Top shows 2-3 reasons | More complete but competes with watchlist-first. | no |
+| Top shows state only | Minimal but less useful for bad or stale states. | no |
+
+**User's choice:** Show only the single most important reason at the top.
+**Notes:** Details stay in watchlist/detail, stale banner, and warning sections.
+
+---
+
+## Menu Reading Experience
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Small native utility style | Tighten hierarchy, spacing, and typography without dashboard/card UI. | yes |
+| Stronger visual sections | More separated areas, but risks dashboard feel. | no |
+| More minimal menu | Hide lower-priority information, but weakens completed issue #4 value. | no |
+
+**User's choice:** Reference CodexBar design.
+**Notes:** Use CodexBar as a guide for a compact instrument-like menu: icon as first signal, opened menu as explanation, and native menu restraint. Do not copy CodexBar's provider/widget architecture.
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Status summary + watchlist priority | Keep status and watchlist as the first reading path. | yes |
+| Count priority | Make node, pod, and warning counts more prominent. | no |
+| Exception priority | Move details earlier whenever warning/bad/stale exists. | no |
+
+**User's choice:** Status summary plus watchlist priority.
+**Notes:** Warning events and node details remain lower-priority sections.
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Tighten but do not compress | Reduce extra spacing while keeping native readability. | yes |
+| More compact | Fit more content but risk harder scanning and keyboard focus. | no |
+| More spacious | Easier reading but weaker quick glance. | no |
+
+**User's choice:** Tighten but do not compress.
+**Notes:** Use native menu grouping, not cards.
+
+---
+
+## Long-Name Truncation
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Preserve front and back with middle truncation | Keep environment/namespace context plus resource tail visible. | yes |
+| Truncate only at the end | Simpler, but often hides the meaningful resource suffix. | no |
+| Use multiple lines | Complete text, but unstable menu height. | no |
+
+**User's choice:** Use middle truncation.
+**Notes:** Kubernetes names often need both prefix and suffix to stay scannable.
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Hover tooltip/accessibility full name | Keep visual row short while preserving full value. | yes |
+| Detail area shows full name | More visible, but makes details heavier. | no |
+| No full-name fallback | Simplest, but weak for similar long names. | no |
+
+**User's choice:** Provide full names through hover tooltip and accessibility.
+**Notes:** Do not clutter the primary menu.
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Preserve tail differences | Resource-name suffixes often carry the distinguishing part. | yes |
+| Fixed character-count truncation | Simple, but can cut away the important difference. | no |
+| Solve only in detail | Primary list remains easy to misread. | no |
+
+**User's choice:** Preserve tail differences.
+**Notes:** Truncation should reduce the chance of confusing similar resources.
+
+---
+
+## Keyboard Navigation and Verification
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Cover all major operations and expandable content | Setup, refresh, edit watchlist, details, warnings, and secondary sections are keyboard reachable. | yes |
+| Cover only main buttons and setup | Lighter but incomplete for issue scope. | no |
+| Rely on default accessibility only | Risky for disclosure groups, pickers, and button order. | no |
+
+**User's choice:** Cover all major operations and expandable content.
+**Notes:** Keyboard navigation includes setup, refresh, edit watchlist, watchlist detail, warning events, and secondary sections.
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Automatic tests + manual QA document | Test deterministic state and document real menu keyboard QA. | yes |
+| Automatic tests only | Clean but may miss real menu bar keyboard behavior. | no |
+| Manual QA only | Fast but weak against regressions. | no |
+
+**User's choice:** Use automatic tests plus manual QA documentation.
+**Notes:** Existing test shape can cover state/model behavior; real menu interaction needs UAT.
+
+| Option | Description | Selected |
+| --- | --- | --- |
+| Four states + setup/edit/refresh paths | Cover `OK`, `Watch`, `Bad`, `Stale`, setup, edit watchlist, and refresh enabled/disabled. | yes |
+| Only icon/keyboard scope | Narrower, but misses state-content coupling. | no |
+| Full daily loop | More complete, but belongs closer to issue #7. | no |
+
+**User's choice:** Cover four states plus setup, edit watchlist, and refresh paths.
+**Notes:** Full daily-loop operator QA remains deferred to issue #7.
+
+---
+
+## the agent's Discretion
+
+- Exact truncation length.
+- Exact helper or view names.
+- Which keyboard checks are automated versus documented in UAT.
+- Exact short status wording as long as the meaning stays locked.
+
+## Deferred Ideas
+
+- Full daily-loop operator QA belongs to GitHub issue #7.
+- AppKit `NSStatusItem` migration remains deferred.
+- Local distribution, notarization, and packaging remain deferred.
+- Deep troubleshooting handoff such as `Open in k9s` remains deferred.

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-PATTERNS.md
@@ -1,0 +1,1235 @@
+# Phase 06: Polish Menu Bar Icon States and Keyboard Navigation - Pattern Map
+
+**Mapped:** 2026-04-21
+**Files analyzed:** 15
+**Analogs found:** 15 / 15
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality |
+|-------------------|------|-----------|----------------|---------------|
+| `KubebarCore/Models/MenuBarStatusPresentation.swift` | model | transform | `KubebarCore/Models/MenuBarStatusPresentation.swift` | exact |
+| `Kubebar/KubebarApp.swift` | provider | event-driven | `Kubebar/KubebarApp.swift` | exact |
+| `KubebarCore/Models/MenuDisplayModel.swift` | model | transform | `KubebarCore/Models/MenuDisplayModel.swift` | exact |
+| `KubebarCore/Services/HealthEvaluator.swift` | service | transform | `KubebarCore/Services/HealthEvaluator.swift` | exact |
+| `Kubebar/Views/StatusSummaryView.swift` | component | transform | `Kubebar/Views/StatusSummaryView.swift` | exact |
+| `Kubebar/Views/MenuBarRootView.swift` | component | event-driven | `Kubebar/Views/MenuBarRootView.swift` | exact |
+| `Kubebar/Views/WatchlistSectionView.swift` | component | event-driven | `Kubebar/Views/WatchlistSectionView.swift` | exact |
+| `Kubebar/Views/TrackedItemDetailView.swift` | component | transform | `Kubebar/Views/TrackedItemDetailView.swift` | exact |
+| `Kubebar/Views/WarningEventsView.swift` | component | transform | `Kubebar/Views/WarningEventsView.swift` | exact |
+| `Kubebar/Views/SetupView.swift` | component | event-driven | `Kubebar/Views/SetupView.swift` | exact |
+| `Kubebar/Views/WatchlistPickerView.swift` | component | event-driven | `Kubebar/Views/WatchlistPickerView.swift` | exact |
+| `KubebarTests/Models/MenuBarStatusPresentationTests.swift` | test | transform | `KubebarTests/Models/MenuBarStatusPresentationTests.swift` | exact |
+| `KubebarTests/Models/MenuDisplayModelTests.swift` | test | transform | `KubebarTests/Models/MenuDisplayModelTests.swift` | exact |
+| `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` | test | event-driven | `.planning/phases/05-expand-kubectl-data-into-actionable-warning-and-workload-reasons/05-UAT.md` | role-match |
+| `docs/architecture/runtime-invariants.md` | config | transform | `docs/architecture/runtime-invariants.md` | exact |
+
+## Pattern Assignments
+
+### `KubebarCore/Models/MenuBarStatusPresentation.swift` (model, transform)
+
+**Analog:** `KubebarCore/Models/MenuBarStatusPresentation.swift`
+
+**Imports pattern** (lines 1-7):
+```swift
+import Foundation
+
+public struct MenuBarStatusPresentation: Equatable, Sendable {
+    public enum IconSource: Equatable, Sendable {
+        case system(String)
+        case custom(String)
+    }
+```
+
+**Core four-state icon pattern** (lines 15-25):
+```swift
+public var icon: IconSource {
+    switch state {
+    case .ok:
+        .custom("KubebarLogo")
+    case .watch:
+        .system("exclamationmark.triangle")
+    case .bad:
+        .system("xmark.octagon")
+    case .stale:
+        .system("clock.badge.exclamationmark")
+    }
+}
+```
+
+**Accessibility pattern** (lines 41-43):
+```swift
+public var accessibilityLabel: String {
+    "Kubebar \(state.label)"
+}
+```
+
+**Planner note:** Keep `OK` as `.custom("KubebarLogo")`. Use `symbolName` only when a SwiftUI status summary needs a system symbol for the opened menu; do not change the menu bar `OK` label to a checkmark.
+
+---
+
+### `Kubebar/KubebarApp.swift` (provider, event-driven)
+
+**Analog:** `Kubebar/KubebarApp.swift`
+
+**Imports pattern** (lines 1-2):
+```swift
+import SwiftUI
+import KubebarCore
+```
+
+**MenuBarExtra window shell pattern** (lines 9-33):
+```swift
+MenuBarExtra {
+    MenuBarRootView(
+        display: viewModel.display,
+        setupState: $viewModel.setupState,
+        isShowingSetup: viewModel.isShowingSetup,
+        refreshCadence: viewModel.refreshCadence,
+        isRefreshing: viewModel.isRefreshing,
+        onRefresh: viewModel.refreshNow,
+        onEditWatchlist: viewModel.openSetup,
+        onCompleteSetup: viewModel.completeSetup,
+        onSelectContext: viewModel.selectSetupContext,
+        onSelectRefreshCadence: viewModel.selectRefreshCadence,
+        onRetryTargets: viewModel.retryWatchTargetLoad
+    )
+} label: {
+    let presentation = MenuBarStatusPresentation(state: viewModel.display.state)
+    switch presentation.icon {
+    case let .system(name):
+        Label(presentation.accessibilityLabel, systemImage: name)
+    case let .custom(name):
+        Image(name)
+            .accessibilityLabel(presentation.accessibilityLabel)
+    }
+}
+.menuBarExtraStyle(.window)
+```
+
+**Planner note:** Copy this existing `MenuBarExtra.window` shape. Do not introduce `NSStatusItem`, `NSMenu`, provider registries, keychain/cookie providers, or CLI subproducts.
+
+---
+
+### `KubebarCore/Models/MenuDisplayModel.swift` (model, transform)
+
+**Analog:** `KubebarCore/Models/MenuDisplayModel.swift`
+
+**Display submodel pattern** (lines 9-39):
+```swift
+public struct WarningEventDisplay: Equatable, Sendable, Identifiable {
+    public let id: String
+    public let reason: String
+    public let location: String
+    public let age: String
+    public let occurrenceCount: Int
+    public let message: String?
+
+    public var summary: String {
+        if occurrenceCount > 1 {
+            return "\(reason) x\(occurrenceCount) \(location) \(age)"
+        }
+
+        return "\(reason) \(location) \(age)"
+    }
+```
+
+**Watch item display contract** (lines 76-95):
+```swift
+public struct WatchItemDisplay: Equatable, Sendable, Identifiable {
+    public let id: String
+    public let title: String
+    public let state: ClusterHealthState
+    public let reason: String
+    public let detail: WatchItemDetailDisplay
+
+    public init(
+        id: String,
+        title: String,
+        state: ClusterHealthState,
+        reason: String,
+        detail: WatchItemDetailDisplay? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.state = state
+        self.reason = reason
+        self.detail = detail ?? WatchItemDetailDisplay(stateLabel: state.label, reason: reason)
+    }
+}
+```
+
+**Root display model pattern** (lines 103-137):
+```swift
+public struct MenuDisplayModel: Equatable, Sendable {
+    public let state: ClusterHealthState
+    public let contextName: String
+    public let healthSentence: String
+    public let lastUpdated: String
+    public let counters: MenuCounters
+    public let warningEventSummaries: [WarningEventDisplay]
+    public let sectionNotices: [SectionAvailabilityDisplay]
+    public let visibleWatchItems: [WatchItemDisplay]
+    public let hiddenWatchItemCount: Int
+    public let staleBanner: StaleBannerDisplay?
+
+    public init(
+        state: ClusterHealthState,
+        contextName: String,
+        healthSentence: String,
+        lastUpdated: String,
+        counters: MenuCounters,
+        visibleWatchItems: [WatchItemDisplay],
+        hiddenWatchItemCount: Int,
+        staleBanner: StaleBannerDisplay?,
+        warningEventSummaries: [WarningEventDisplay] = [],
+        sectionNotices: [SectionAvailabilityDisplay] = []
+    ) {
+```
+
+**Planner note:** Add new display-only fields here when the opened menu needs more presentation data, such as `primaryStatusReason` or full untruncated title fields. Do not make SwiftUI views infer health severity.
+
+---
+
+### `KubebarCore/Services/HealthEvaluator.swift` (service, transform)
+
+**Analog:** `KubebarCore/Services/HealthEvaluator.swift`
+
+**Imports and service shape** (lines 1-18):
+```swift
+import Foundation
+
+public struct RefreshFailure: Equatable, Sendable {
+    public let reason: String
+
+    public init(reason: String) {
+        self.reason = reason
+    }
+}
+
+public struct HealthEvaluator: Sendable {
+    private let visibleWatchItemLimit: Int
+    private let warningEventSummaryLimit = 3
+    private let warningMessageLimit = 96
+
+    public init(visibleWatchItemLimit: Int = 5) {
+        self.visibleWatchItemLimit = visibleWatchItemLimit
+    }
+```
+
+**Evaluate entrypoint and stale fallback pattern** (lines 20-56):
+```swift
+public func evaluate(
+    snapshot: ClusterSnapshot?,
+    previousSnapshot: ClusterSnapshot? = nil,
+    failure: RefreshFailure? = nil,
+    now: Date,
+    staleAfterSeconds: Int? = nil
+) -> MenuDisplayModel {
+    if let snapshot {
+        return displayModel(
+            from: snapshot,
+            stateOverride: nil,
+            failureReason: failure?.reason,
+            now: now,
+            staleAfterSeconds: staleAfterSeconds
+        )
+    }
+
+    if let previousSnapshot {
+        return displayModel(
+            from: previousSnapshot,
+            stateOverride: .stale,
+            failureReason: failure?.reason,
+            now: now,
+            staleAfterSeconds: staleAfterSeconds
+        )
+    }
+```
+
+**Display model assembly pattern** (lines 66-91):
+```swift
+let sortedItems = sortByAttention(snapshot.trackedItems)
+let visibleItems = sortedItems.prefix(visibleWatchItemLimit).map { makeDisplayItem($0, now: now) }
+let hiddenCount = max(0, sortedItems.count - visibleItems.count)
+let freshnessReason = staleAgeOutReason(for: snapshot, now: now, staleAfterSeconds: staleAfterSeconds)
+let resolvedState = stateOverride ?? (freshnessReason == nil ? evaluateState(snapshot) : .stale)
+let warningEventSummaries = makeWarningEventSummaries(from: snapshot.warningEventsSection.value ?? [], now: now)
+let sectionNotices = makeSectionNotices(from: snapshot.sectionFailures)
+let lastUpdated = relativeAge(from: snapshot.capturedAt, to: now)
+
+return MenuDisplayModel(
+    state: resolvedState,
+    contextName: snapshot.contextName,
+    healthSentence: healthSentence(for: resolvedState, visibleItems: visibleItems),
+    lastUpdated: lastUpdated,
+    counters: menuCounters(from: snapshot),
+    visibleWatchItems: Array(visibleItems),
+```
+
+**Severity source-of-truth pattern** (lines 103-117):
+```swift
+private func evaluateState(_ snapshot: ClusterSnapshot) -> ClusterHealthState {
+    if snapshot.nodesSection.value.map({ $0.ready < $0.total }) == true ||
+        snapshot.trackedItems.contains(where: { $0.state == .bad }) {
+        return .bad
+    }
+
+    if snapshot.podsSection.value.map({ $0.running < $0.total }) == true ||
+        snapshot.warningEventsSection.value.map({ !$0.isEmpty }) == true ||
+        snapshot.trackedItems.contains(where: { $0.state == .watch }) ||
+        !snapshot.sectionFailures.isEmpty {
+        return .watch
+    }
+
+    return .ok
+}
+```
+
+**Watch item mapping pattern** (lines 151-165):
+```swift
+private func makeDisplayItem(_ item: TrackedItemStatus, now: Date) -> WatchItemDisplay {
+    WatchItemDisplay(
+        id: item.target.displayTitle,
+        title: shortened(item.target.displayTitle),
+        state: item.state,
+        reason: item.reason,
+        detail: WatchItemDetailDisplay(
+            stateLabel: item.state.label,
+            reason: item.reason,
+            affectedPodCount: item.affectedPodCount,
+            examplePodNames: Array(item.examplePodNames.prefix(3)),
+            latestWarning: item.latestWarning.map { makeWarningEventDisplay(from: $0, now: now) }
+        )
+    )
+}
+```
+
+**Current truncation anti-pattern to replace** (lines 296-302):
+```swift
+private func shortened(_ value: String, limit: Int = 42) -> String {
+    guard value.count > limit else {
+        return value
+    }
+
+    return String(value.prefix(limit - 1)) + "…"
+}
+```
+
+**Planner note:** Keep severity, primary reason selection, stale reason, watchlist ordering, and display contracts in `HealthEvaluator`. Replace tail pre-truncation with full-value display fields plus view-level one-line middle truncation.
+
+---
+
+### `Kubebar/Views/StatusSummaryView.swift` (component, transform)
+
+**Analog:** `Kubebar/Views/StatusSummaryView.swift`
+
+**Imports pattern** (lines 1-2):
+```swift
+import SwiftUI
+import KubebarCore
+```
+
+**Render-only status summary pattern** (lines 7-23):
+```swift
+var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+        HStack {
+            Text(display.contextName)
+                .font(.headline)
+                .lineLimit(1)
+
+            Spacer()
+
+            Text(display.state.label)
+                .font(.caption.weight(.semibold))
+        }
+
+        Text(display.healthSentence)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+    }
+}
+```
+
+**Planner note:** Keep this view render-only. For Phase 06, add the opened-menu symbol, explicit `OK`/`Watch`/`Bad`/`Stale` text, one primary reason, middle truncation, tooltip, and accessibility label here using fields supplied by `MenuDisplayModel`.
+
+---
+
+### `Kubebar/Views/MenuBarRootView.swift` (component, event-driven)
+
+**Analog:** `Kubebar/Views/MenuBarRootView.swift`
+
+**Setup vs menu branch pattern** (lines 17-35):
+```swift
+var body: some View {
+    Group {
+        if isShowingSetup {
+            SetupView(
+                state: $setupState,
+                onComplete: onCompleteSetup,
+                onSelectContext: onSelectContext,
+                onRetryTargets: onRetryTargets
+            )
+                .frame(
+                    width: Layout.setupWidth,
+                    height: Layout.setupHeight,
+                    alignment: .topLeading
+                )
+        } else {
+            menuContent
+        }
+    }
+}
+```
+
+**Watchlist-first menu order pattern** (lines 37-50):
+```swift
+private var menuContent: some View {
+    VStack(alignment: .leading, spacing: 14) {
+        StatusSummaryView(display: display)
+        StaleBannerView(banner: display.staleBanner)
+        CompactCountersView(counters: display.counters)
+        WatchlistSectionView(display: display)
+        WarningEventsView(count: display.counters.warningEvents, summaries: display.warningEventSummaries, sectionNotices: display.sectionNotices)
+        NodeDetailsView(summary: display.counters.nodes)
+        Divider()
+        refreshControls
+        actions
+    }
+    .frame(width: 340)
+    .padding(16)
+}
+```
+
+**Native controls and bindings pattern** (lines 53-84):
+```swift
+private var refreshControls: some View {
+    HStack(spacing: 8) {
+        Text("Refresh")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        Picker("Refresh cadence", selection: refreshCadenceBinding) {
+            ForEach(RefreshCadence.allCases) { cadence in
+                Text(cadence.label).tag(cadence)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .frame(width: 96)
+```
+
+```swift
+private var actions: some View {
+    HStack {
+        Button("Retry now", action: onRefresh)
+            .disabled(isRefreshing)
+        Spacer()
+        Button("Edit watchlist", action: onEditWatchlist)
+    }
+}
+```
+
+**Planner note:** Preserve the order: summary, stale signal, counters, watchlist, warning events, node details, refresh, actions. Keyboard work should stay on native controls and targeted shortcuts, not custom key handling.
+
+---
+
+### `Kubebar/Views/WatchlistSectionView.swift` (component, event-driven)
+
+**Analog:** `Kubebar/Views/WatchlistSectionView.swift`
+
+**Watchlist-first disclosure pattern** (lines 7-31):
+```swift
+var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+        Text("Watchlist")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+
+        if display.visibleWatchItems.isEmpty {
+            Text("No tracked workloads yet")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        } else {
+            ForEach(display.visibleWatchItems) { item in
+                DisclosureGroup {
+                    TrackedItemDetailView(item: item)
+                } label: {
+                    WatchlistRowView(item: item)
+                }
+            }
+        }
+```
+
+**One-line row pattern** (lines 36-55):
+```swift
+private struct WatchlistRowView: View {
+    let item: WatchItemDisplay
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.title)
+                    .lineLimit(1)
+                Text(item.reason)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Text(item.state.label)
+                .font(.caption.weight(.semibold))
+        }
+    }
+}
+```
+
+**Planner note:** Keep rows one-line on the primary surface. Add `.truncationMode(.middle)`, `.help(Text(fullValue))`, and `.accessibilityLabel(fullValue)` once full title fields exist.
+
+---
+
+### `Kubebar/Views/TrackedItemDetailView.swift` (component, transform)
+
+**Analog:** `Kubebar/Views/TrackedItemDetailView.swift`
+
+**Detail render pattern** (lines 7-31):
+```swift
+var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+        Text("State: \(item.detail.stateLabel)")
+        Text(item.detail.reason)
+
+        if let affectedPodCount = item.detail.affectedPodCount {
+            Text("Affected pods: \(affectedPodCount)")
+        }
+
+        if !item.detail.examplePodNames.isEmpty {
+            Text("Examples: \(item.detail.examplePodNames.joined(separator: ", "))")
+        }
+
+        if let latestWarning = item.detail.latestWarning {
+            Text("Latest warning: \(latestWarning.summary)")
+
+            if let message = latestWarning.message {
+                Text(message)
+                    .lineLimit(2)
+            }
+        }
+    }
+    .font(.caption)
+    .foregroundStyle(.secondary)
+    .padding(.leading, 6)
+}
+```
+
+**Planner note:** Keep detail short. It may expose full names or tooltips, but it must not become a troubleshooting panel or deep handoff.
+
+---
+
+### `Kubebar/Views/WarningEventsView.swift` (component, transform)
+
+**Analog:** `Kubebar/Views/WarningEventsView.swift`
+
+**Secondary warning section pattern** (lines 9-40):
+```swift
+var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+        Text("Warning events")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+
+        ForEach(sectionNotices) { notice in
+            Text("\(notice.title) unavailable: \(notice.reason)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+
+        if summaries.isEmpty {
+            Text(count == "0" ? "No current warning events" : "\(count) warning events need review")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else {
+            ForEach(summaries) { summary in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(summary.summary)
+                        .lineLimit(1)
+
+                    if let message = summary.message {
+                        Text(message)
+                            .lineLimit(2)
+                    }
+```
+
+**Planner note:** Keep warning events below the watchlist and capped by display data. Add middle truncation/help/accessibility to `summary.summary` or its future split fields without promoting warning events above watchlist rows.
+
+---
+
+### `Kubebar/Views/SetupView.swift` (component, event-driven)
+
+**Analog:** `Kubebar/Views/SetupView.swift`
+
+**Scrollable native setup layout pattern** (lines 22-33):
+```swift
+var body: some View {
+    ScrollView {
+        VStack(alignment: .leading, spacing: 20) {
+            header
+            contextPicker
+            watchlistPicker
+            refreshCadencePicker
+            footer
+        }
+        .padding(20)
+        .frame(maxWidth: 560, alignment: .leading)
+    }
+}
+```
+
+**Context picker pattern** (lines 47-71):
+```swift
+private var contextPicker: some View {
+    VStack(alignment: .leading, spacing: 10) {
+        Text("Cluster context")
+            .font(.headline)
+
+        Text(state.contextHelpText)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        if state.availableContexts.isEmpty {
+            Text("No contexts available.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 12))
+        } else {
+            Picker("Cluster context", selection: selectedContextBinding) {
+                Text("Select a context").tag(Optional<String>.none)
+                ForEach(state.availableContexts, id: \.self) { context in
+                    Text(context).tag(Optional(context))
+                }
+            }
+            .pickerStyle(.menu)
+        }
+```
+
+**Footer action pattern** (lines 101-118):
+```swift
+private var footer: some View {
+    HStack {
+        if let configurationMessage = state.configurationMessage, !configurationMessage.isEmpty {
+            Text(configurationMessage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else {
+            Text(state.watchlistHelpText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+
+        Spacer()
+
+        Button("Finish setup", action: onComplete)
+            .buttonStyle(.borderedProminent)
+            .disabled(!state.isConfigured)
+    }
+}
+```
+
+**Binding pattern** (lines 121-133):
+```swift
+private var selectedContextBinding: Binding<String?> {
+    Binding(
+        get: { state.selectedContext },
+        set: { onSelectContext($0) }
+    )
+}
+
+private var watchlistBinding: Binding<WatchlistSelectionState> {
+    Binding(
+        get: { state.watchlist },
+        set: { state.watchlist = $0 }
+    )
+}
+```
+
+**Planner note:** Apply middle truncation and tooltip/accessibility to context names in the picker. If adding keyboard shortcuts, prefer `.defaultAction` for `Finish setup` and keep standard keyboard traversal for the rest.
+
+---
+
+### `Kubebar/Views/WatchlistPickerView.swift` (component, event-driven)
+
+**Analog:** `Kubebar/Views/WatchlistPickerView.swift`
+
+**State-switch pattern** (lines 26-41):
+```swift
+@ViewBuilder
+private var content: some View {
+    switch loadingState {
+    case .loading:
+        loadingView
+    case let .failed(reason):
+        failureView(reason: reason)
+    case .idle:
+        if state.hasAvailableTargets {
+            namespaceSection
+            workloadSection
+        } else {
+            emptyTargetsView
+        }
+    }
+}
+```
+
+**Native toggle and disclosure pattern** (lines 60-94):
+```swift
+private var namespaceSection: some View {
+    SectionCard(
+        title: "Namespaces",
+        emptyTitle: "No namespaces yet",
+        emptyMessage: "Namespaces keep the watchlist compact when you want whole areas of the cluster on the first screen.",
+        hasItems: !state.availableNamespaces.isEmpty
+    ) {
+        ForEach(state.availableNamespaces, id: \.self) { namespace in
+            Toggle(
+                namespace,
+                isOn: binding(for: .namespace(namespace))
+            )
+        }
+    }
+}
+
+private var workloadSection: some View {
+    SectionCard(
+        title: "Workloads",
+        emptyTitle: "No workloads yet",
+        emptyMessage: "Watch individual workloads when one service needs regular attention.",
+        hasItems: !state.availableWorkloads.isEmpty
+    ) {
+        ForEach(groupedWorkloads, id: \.key) { group in
+            DisclosureGroup(group.key) {
+                ForEach(group.value, id: \.self) { workload in
+                    Toggle(
+                        workload.displayTitle,
+                        isOn: binding(for: workload.target)
+```
+
+**Recovery action pattern** (lines 109-135):
+```swift
+private func failureView(reason: String) -> some View {
+    StateCard {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Could not load watch targets")
+                .font(.subheadline.weight(.medium))
+
+            Text(reason.isEmpty ? "Try loading targets again." : reason)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Button("Retry", action: onRetryTargets)
+        }
+    }
+}
+
+private var emptyTargetsView: some View {
+    StateCard {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("No watch targets found")
+                .font(.subheadline.weight(.medium))
+```
+
+**Binding pattern** (lines 139-149):
+```swift
+private func binding(for target: WatchTarget) -> Binding<Bool> {
+    Binding(
+        get: { state.isSelected(target) },
+        set: { state.setSelected(target, to: $0) }
+    )
+}
+
+private var groupedWorkloads: [(key: String, value: [WatchlistCandidate])] {
+    Dictionary(grouping: state.availableWorkloads, by: { $0.namespace })
+        .sorted { $0.key < $1.key }
+}
+```
+
+**Planner note:** Keyboard coverage should rely on these native controls. Add truncation/help/accessibility to namespace group labels and workload toggle labels; do not replace toggles with custom rows.
+
+---
+
+### `KubebarTests/Models/MenuBarStatusPresentationTests.swift` (test, transform)
+
+**Analog:** `KubebarTests/Models/MenuBarStatusPresentationTests.swift`
+
+**Imports and suite pattern** (lines 1-5):
+```swift
+import Testing
+@testable import KubebarCore
+
+@Suite("Menu bar status presentation")
+struct MenuBarStatusPresentationTests {
+```
+
+**Four-state assertion pattern** (lines 6-17):
+```swift
+@Test("maps health states to distinct symbols and labels")
+func mapsHealthStatesToDistinctSymbolsAndLabels() {
+    #expect(MenuBarStatusPresentation(state: .ok).symbolName == "checkmark.circle")
+    #expect(MenuBarStatusPresentation(state: .watch).symbolName == "exclamationmark.triangle")
+    #expect(MenuBarStatusPresentation(state: .bad).symbolName == "xmark.octagon")
+    #expect(MenuBarStatusPresentation(state: .stale).symbolName == "clock.badge.exclamationmark")
+
+    #expect(MenuBarStatusPresentation(state: .ok).accessibilityLabel == "Kubebar OK")
+    #expect(MenuBarStatusPresentation(state: .watch).accessibilityLabel == "Kubebar Watch")
+    #expect(MenuBarStatusPresentation(state: .bad).accessibilityLabel == "Kubebar Bad")
+    #expect(MenuBarStatusPresentation(state: .stale).accessibilityLabel == "Kubebar Stale")
+}
+```
+
+**Planner note:** Extend this suite to assert `MenuBarStatusPresentation(state: .ok).icon == .custom("KubebarLogo")` and preserve the locked Watch/Bad/Stale symbols.
+
+---
+
+### `KubebarTests/Models/MenuDisplayModelTests.swift` (test, transform)
+
+**Analog:** `KubebarTests/Models/MenuDisplayModelTests.swift`
+
+**Imports and suite pattern** (lines 1-6):
+```swift
+import Foundation
+import Testing
+@testable import KubebarCore
+
+@Suite("Menu display model")
+struct MenuDisplayModelTests {
+```
+
+**Healthy state regression pattern** (lines 7-29):
+```swift
+@Test("healthy snapshots show OK status and compact counters")
+func healthySnapshotShowsOKStatusAndCounters() {
+    let snapshot = ClusterSnapshot(
+        contextName: "prod",
+        nodeSummary: NodeSummary(ready: 3, total: 3),
+        podSummary: PodSummary(running: 12, total: 12),
+        warningEventCount: 0,
+        trackedItems: [
+            TrackedItemStatus(target: .workload(namespace: "api", name: "checkout"), state: .ok, reason: "6/6 pods running")
+        ],
+        capturedAt: Date(timeIntervalSince1970: 100)
+    )
+
+    let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+
+    #expect(display.state == .ok)
+    #expect(display.contextName == "prod")
+    #expect(display.counters.nodes == "3/3")
+    #expect(display.counters.pods == "12/12")
+    #expect(display.counters.warningEvents == "0")
+    #expect(display.healthSentence == "Cluster looks healthy")
+```
+
+**Attention ordering pattern** (lines 31-51):
+```swift
+@Test("bad tracked items become first-screen attention")
+func badTrackedItemsBecomeFirstScreenAttention() {
+    let snapshot = ClusterSnapshot(
+        contextName: "prod",
+        nodeSummary: NodeSummary(ready: 3, total: 3),
+        podSummary: PodSummary(running: 5, total: 6),
+        warningEventCount: 1,
+        trackedItems: [
+            TrackedItemStatus(target: .workload(namespace: "api", name: "checkout"), state: .bad, reason: "1 pod pending"),
+            TrackedItemStatus(target: .namespace("monitoring"), state: .ok, reason: "all watched pods running")
+        ],
+        capturedAt: Date(timeIntervalSince1970: 100)
+    )
+
+    let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+
+    #expect(display.state == .bad)
+    #expect(display.visibleWatchItems.first?.title == "api/checkout")
+    #expect(display.visibleWatchItems.first?.reason == "1 pod pending")
+    #expect(display.healthSentence == "api/checkout needs attention")
+}
+```
+
+**Current truncation test to replace** (lines 73-93):
+```swift
+@Test("long watch item titles truncate consistently")
+func longWatchItemTitlesTruncateConsistently() {
+    let snapshot = ClusterSnapshot(
+        contextName: "prod",
+        nodeSummary: NodeSummary(ready: 3, total: 3),
+        podSummary: PodSummary(running: 1, total: 1),
+        warningEventCount: 0,
+        trackedItems: [
+            TrackedItemStatus(
+                target: .workload(namespace: "production-namespace", name: "checkout-api-with-a-very-long-name"),
+                state: .ok,
+                reason: "ready"
+            )
+        ],
+        capturedAt: Date(timeIntervalSince1970: 100)
+    )
+
+    let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+
+    #expect(display.visibleWatchItems.first?.title == "production-namespace/checkout-api-with-a-…")
+}
+```
+
+**Stale fallback regression pattern** (lines 95-121):
+```swift
+@Test("failed refresh keeps previous data but marks it stale")
+func failedRefreshKeepsPreviousDataButMarksItStale() {
+    let previous = ClusterSnapshot(
+        contextName: "prod",
+        nodeSummary: NodeSummary(ready: 3, total: 3),
+        podSummary: PodSummary(running: 12, total: 12),
+        warningEventCount: 0,
+        trackedItems: [
+            TrackedItemStatus(target: .workload(namespace: "api", name: "checkout"), state: .ok, reason: "6/6 pods running")
+        ],
+        capturedAt: Date(timeIntervalSince1970: 100)
+    )
+
+    let display = HealthEvaluator().evaluate(
+        snapshot: nil,
+        previousSnapshot: previous,
+        failure: RefreshFailure(reason: "kubectl timed out"),
+        now: Date(timeIntervalSince1970: 250)
+    )
+
+    #expect(display.state == .stale)
+    #expect(display.contextName == "prod")
+```
+
+**Warning and partial-section test pattern** (lines 185-205 and 298-314):
+```swift
+@Test("duplicate warning events group into one warning summaries row")
+func duplicateWarningEventsGroupIntoOneWarningSummaryRow() {
+    let snapshot = ClusterSnapshot(
+        contextName: "prod",
+        nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+        podsSection: .available(PodSummary(running: 12, total: 12)),
+        warningEventsSection: .available([
+            warningEvent(reason: "BackOff", observedAt: Date(timeIntervalSince1970: 90), count: 1, message: "older warning"),
+            warningEvent(reason: "BackOff", observedAt: Date(timeIntervalSince1970: 100), count: 3, message: "newest warning")
+        ]),
+        workloadsSection: .available([]),
+        capturedAt: Date(timeIntervalSince1970: 100)
+    )
+
+    let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 220))
+
+    #expect(display.warningEventSummaries.count == 1)
+    #expect(display.warningEventSummaries.first?.occurrenceCount == 4)
+```
+
+```swift
+@Test("unavailable warning events use dash counter and watch state")
+func unavailableWarningEventsUseDashCounterAndWatchState() {
+    let snapshot = ClusterSnapshot(
+        contextName: "prod",
+        nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+        podsSection: .available(PodSummary(running: 12, total: 12)),
+        warningEventsSection: .unavailable(reason: "invalid event JSON"),
+        workloadsSection: .available([]),
+        capturedAt: Date(timeIntervalSince1970: 100)
+    )
+
+    let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 220))
+
+    #expect(display.counters.warningEvents == "-")
+    #expect(display.state == .watch)
+```
+
+**Planner note:** Add deterministic tests for `primaryStatusReason` or equivalent across `OK`, `Watch`, `Bad`, and `Stale`. Replace tail-truncation assertions with full-name preservation and view-level truncation contract assertions.
+
+---
+
+### `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` (test, event-driven)
+
+**Analog:** `.planning/phases/05-expand-kubectl-data-into-actionable-warning-and-workload-reasons/05-UAT.md`
+
+**Front matter and test list pattern** (lines 1-16):
+```markdown
+---
+status: partial
+phase: 05-expand-kubectl-data-into-actionable-warning-and-workload-reasons
+source:
+  - 05-01-SUMMARY.md
+  - 05-02-SUMMARY.md
+  - 05-03-SUMMARY.md
+started: 2026-04-21T09:50:49Z
+updated: 2026-04-21T09:56:29Z
+---
+
+## Current Test
+
+[testing paused - 3 items blocked by current live test conditions]
+
+## Tests
+```
+
+**Per-check result pattern** (lines 18-55):
+```markdown
+### 1. Warning counter remains compact
+expected: In the menu, warning events still appear as a compact counter. The counter should not turn into a long event list or raw kubectl output.
+result: pass
+evidence: "Debug app launched successfully. Live cluster returned warning events, and automated model/view checks preserve compact warning counters without raw kubectl output."
+
+### 2. Warning section shows at most 3 summaries
+expected: The Warning events section shows no more than 3 warning summaries even when the cluster has more warning groups.
+result: pass
+evidence: "Live cluster had more than 3 warning groups. MenuDisplayModelTests verified the three-row cap, and WarningEventsView renders only the prepared summaries."
+```
+
+**Manual tool limitation pattern** (lines 69-75):
+```markdown
+## Computer Use Notes
+
+- Kubebar launched from `DerivedData/Build/Products/Debug/Kubebar.app`.
+- Computer Use could read ordinary app windows such as Finder.
+- Computer Use could not obtain an interactive state for `com.nextty.kubebar`, `SystemUIServer`, or `ControlCenter`, so the menu bar extra itself could not be directly inspected.
+- The live app config watches namespace targets only: `arc-runners` and `dev`.
+- The live cluster had 13 warning events and repeated `FailedScheduling` warnings, which is enough to support warning cap and grouping checks through the existing automated display tests.
+```
+
+**Checklist analog:** `.planning/phases/04-codexbar-inspired-menu-reliability-and-freshness/04-UAT.md` lines 24-46:
+```markdown
+## Checklist
+
+| Test | Expected Result | Status |
+| --- | --- | --- |
+| Launch with `./scripts/compile-and-run.sh` | Kubebar process starts and PID is printed | passed: PID 16286 |
+| Fresh config opens setup | Setup view is readable, not collapsed | pending |
+| Context list loads | Context picker shows available Kubernetes contexts | pending |
+| Select context | Watchlist target area loads namespace/workload choices | pending |
+| Finish setup | Normal menu opens with watchlist-first content | pending |
+```
+
+**Planner note:** Phase 06 UAT must cover all four states, setup, edit watchlist, refresh enabled/disabled, watchlist detail disclosure, warning events, secondary sections, long-name tooltip/accessibility, and Full Keyboard Access. Keep blocked states explicit when live data cannot force a state.
+
+---
+
+### `docs/architecture/runtime-invariants.md` (config, transform)
+
+**Analog:** `docs/architecture/runtime-invariants.md`
+
+**Product and data invariant pattern** (lines 5-31):
+```markdown
+## Product Rules
+
+- The menu bar icon only uses `OK`, `Watch`, `Bad`, or `Stale`.
+- The first screen is watchlist-first.
+- The first screen shows only a small set of tracked items, with overflow
+  pushed behind a secondary entry.
+- Deep troubleshooting stays out of version 1.
+
+## Data Rules
+
+- `MenuDisplayModel` is the only input the menu uses for rendering.
+- `HealthEvaluator` is the single source of truth for severity.
+- `AppConfigStore` owns the saved context and watchlist.
+```
+
+**Watchlist and failure invariant pattern** (lines 49-76):
+```markdown
+## Watchlist Rules
+
+- Watchlist rows stay short and readable.
+- Tracked item names may truncate, but their meaning should still be clear.
+- The watchlist is ordered by attention, not by raw cluster size.
+- An empty watchlist is a real state and must not be treated as a healthy
+  cluster.
+```
+
+```markdown
+## Failure Rules
+
+- Timeout, command failure, malformed JSON, and no previous data are distinct
+  safe reason categories.
+- Timeout uses `kubectl timed out`.
+- Empty or unsafe command failure output uses `kubectl failed`.
+- Malformed section data uses short reasons such as `invalid node JSON`,
+  `invalid pod JSON`, `invalid event JSON`, or `invalid workload JSON`.
+- No previous successful data uses `No previous cluster data`.
+- A refresh failure must never silently clear the last good data.
+- Warning and failure states must not rely on color alone.
+- Stale or failed reads must use distinct icon semantics from `OK`.
+```
+
+**Planner note:** If implementation changes user-visible invariants, update this doc with middle truncation, full-name fallback, explicit opened-menu state text, and keyboard/manual QA expectations. Do not add deep troubleshooting or `Open in k9s`.
+
+## Shared Patterns
+
+### Core Owns Health and Top Reason
+
+**Source:** `docs/architecture/system-overview.md` lines 13-17 and `HealthEvaluator.swift` lines 103-117
+**Apply to:** `MenuDisplayModel`, `HealthEvaluator`, `StatusSummaryView`, tests
+
+```markdown
+5. `KubebarCore/Services/HealthEvaluator.swift` turns the latest snapshot into a
+   `MenuDisplayModel`.
+6. `MenuDisplayModel` is the only shape the menu uses to render the screen.
+```
+
+```swift
+private func evaluateState(_ snapshot: ClusterSnapshot) -> ClusterHealthState {
+    if snapshot.nodesSection.value.map({ $0.ready < $0.total }) == true ||
+        snapshot.trackedItems.contains(where: { $0.state == .bad }) {
+        return .bad
+    }
+```
+
+### Views Render `MenuDisplayModel` Only
+
+**Source:** `docs/architecture/system-overview.md` lines 37-60
+**Apply to:** all SwiftUI menu views
+
+```markdown
+The menu never asks Kubernetes directly. It reads a display model that already
+includes:
+
+- the selected context name,
+- the health sentence,
+- compact node, pod, and warning counts,
+- visible watchlist rows,
+- overflow count for hidden watched items,
+- stale banner content when the last refresh is no longer fresh.
+```
+
+```markdown
+The menu is allowed to show state and actions. It is not allowed to:
+
+- decide cluster health on its own,
+- read raw `kubectl` output,
+- infer the terminal context,
+- expand into a troubleshooting console.
+```
+
+### Watchlist-First Ordering
+
+**Source:** `Kubebar/Views/MenuBarRootView.swift` lines 37-50
+**Apply to:** `MenuBarRootView`, `WatchlistSectionView`, `WarningEventsView`, `NodeDetailsView`
+
+```swift
+VStack(alignment: .leading, spacing: 14) {
+    StatusSummaryView(display: display)
+    StaleBannerView(banner: display.staleBanner)
+    CompactCountersView(counters: display.counters)
+    WatchlistSectionView(display: display)
+    WarningEventsView(count: display.counters.warningEvents, summaries: display.warningEventSummaries, sectionNotices: display.sectionNotices)
+    NodeDetailsView(summary: display.counters.nodes)
+```
+
+### Native Keyboard-Reachable Controls
+
+**Source:** `MenuBarRootView.swift` lines 59-83, `SetupView.swift` lines 92-118, `WatchlistPickerView.swift` lines 83-90 and 119-135
+**Apply to:** refresh, edit watchlist, setup, retry, watchlist picker, details
+
+```swift
+Picker("Refresh cadence", selection: refreshCadenceBinding) {
+    ForEach(RefreshCadence.allCases) { cadence in
+        Text(cadence.label).tag(cadence)
+    }
+}
+.labelsHidden()
+.pickerStyle(.menu)
+```
+
+```swift
+Button("Finish setup", action: onComplete)
+    .buttonStyle(.borderedProminent)
+    .disabled(!state.isConfigured)
+```
+
+```swift
+DisclosureGroup(group.key) {
+    ForEach(group.value, id: \.self) { workload in
+        Toggle(
+            workload.displayTitle,
+            isOn: binding(for: workload.target)
+        )
+    }
+}
+```
+
+### One-Line Text Base Pattern
+
+**Source:** `StatusSummaryView.swift` lines 10-12, `WatchlistSectionView.swift` lines 42-47, `WarningEventsView.swift` lines 28-33
+**Apply to:** context names, namespace names, workload names, warning locations, row reasons
+
+```swift
+Text(display.contextName)
+    .font(.headline)
+    .lineLimit(1)
+```
+
+```swift
+Text(item.title)
+    .lineLimit(1)
+Text(item.reason)
+    .font(.caption)
+    .foregroundStyle(.secondary)
+    .lineLimit(1)
+```
+
+```swift
+Text(summary.summary)
+    .lineLimit(1)
+
+if let message = summary.message {
+    Text(message)
+        .lineLimit(2)
+}
+```
+
+**Research supplement:** No local file currently uses `.truncationMode(.middle)` or `.help(Text(...))`. Apply the SwiftUI pattern from `06-RESEARCH.md` when adding Phase 06 truncation:
+
+```swift
+Text(fullName)
+    .lineLimit(1)
+    .truncationMode(.middle)
+    .help(Text(fullName))
+    .accessibilityLabel(fullName)
+```
+
+### Swift Testing Regression Style
+
+**Source:** `KubebarTests/Models/MenuDisplayModelTests.swift` lines 7-29 and `MenuBarStatusPresentationTests.swift` lines 6-17
+**Apply to:** state icon tests, top reason tests, full-name preservation tests
+
+```swift
+@Test("healthy snapshots show OK status and compact counters")
+func healthySnapshotShowsOKStatusAndCounters() {
+    let snapshot = ClusterSnapshot(
+        contextName: "prod",
+        nodeSummary: NodeSummary(ready: 3, total: 3),
+        podSummary: PodSummary(running: 12, total: 12),
+        warningEventCount: 0,
+```
+
+```swift
+#expect(MenuBarStatusPresentation(state: .ok).accessibilityLabel == "Kubebar OK")
+#expect(MenuBarStatusPresentation(state: .watch).accessibilityLabel == "Kubebar Watch")
+#expect(MenuBarStatusPresentation(state: .bad).accessibilityLabel == "Kubebar Bad")
+#expect(MenuBarStatusPresentation(state: .stale).accessibilityLabel == "Kubebar Stale")
+```
+
+## No Analog Found
+
+All target files have a local analog. The only missing local usage is the exact SwiftUI middle-truncation/help modifier combination; use the `06-RESEARCH.md` SwiftUI docs pattern above and keep the data contract in `MenuDisplayModel`.
+
+## Metadata
+
+**Analog search scope:** `Kubebar/`, `KubebarCore/`, `KubebarTests/`, `docs/architecture/`, `.planning/phases/03-*`, `.planning/phases/04-*`, `.planning/phases/05-*`
+**Files scanned:** 123 Swift, Markdown, asset metadata, and planning files via `rg --files` and targeted `rg`
+**Pattern extraction date:** 2026-04-21
+**Project constraints applied:** watchlist-first, `MenuBarExtra.window`, no AppKit `NSStatusItem` migration, no dashboard sprawl, no deep troubleshooting handoff

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-RESEARCH.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-RESEARCH.md
@@ -1,0 +1,600 @@
+# Phase 06: Polish Menu Bar Icon States and Keyboard Navigation - Research
+
+**Researched:** 2026-04-21
+**Domain:** macOS SwiftUI MenuBarExtra polish, accessibility, truncation, and keyboard QA
+**Confidence:** HIGH overall, MEDIUM for real menu keyboard verification because menu-bar extras are not covered by existing automated UI infrastructure
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+Source: [VERIFIED: .planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md]
+
+### Locked Decisions
+
+#### Menu Bar Icon States
+
+- **D-01:** Keep the healthy menu bar state as the brand logo. `OK` should use
+  the existing custom `KubebarLogo` in the menu bar.
+- **D-02:** Keep `Watch`, `Bad`, and `Stale` as explicit status symbols.
+- **D-03:** Reuse the current symbol set:
+  `Watch = exclamationmark.triangle`, `Bad = xmark.octagon`, and
+  `Stale = clock.badge.exclamationmark`.
+- **D-04:** When the menu opens, the top status area must explicitly show
+  `OK` for a healthy cluster so the logo is not the only health signal.
+- **D-05:** Preserve distinct accessibility labels for all four states, such as
+  `Kubebar OK`, `Kubebar Watch`, `Kubebar Bad`, and `Kubebar Stale`.
+
+#### Non-Color Status Expression
+
+- **D-06:** Warning and failure states must use symbol, status text, and a short
+  reason. They must not rely on color alone.
+- **D-07:** The top status area should show only the single most important
+  reason, such as `2 pods restarting` or `kubectl timed out`.
+- **D-08:** Detailed reasons stay in the watchlist row, tracked item detail,
+  stale banner, or warning event sections. Do not turn the top status area into
+  a multi-line incident summary.
+
+#### Menu Reading Experience
+
+- **D-09:** Use CodexBar as a design reference for the menu's product logic:
+  the menu bar icon is the first signal, the opened menu explains it, and the
+  menu behaves like a reliable small instrument.
+- **D-10:** Do not copy CodexBar's provider registry, widgets, update plumbing,
+  keychain/cookie usage providers, CLI subproduct, or AppKit status-item
+  architecture.
+- **D-11:** Keep the menu order focused on status summary plus watchlist first.
+  Warning events and node details remain lower-priority sections.
+- **D-12:** Tighten spacing and typography, but do not compress the menu. The
+  result should feel like native menu grouping, not cards or dashboard panels.
+
+#### Long-Name Truncation
+
+- **D-13:** Long context, namespace, and workload names should use middle
+  truncation that preserves the beginning and end of the name.
+- **D-14:** Truncation should prioritize preserving tail differences for
+  workload and resource names, because Kubernetes names often differ at the
+  end.
+- **D-15:** Full untruncated names should remain available through hover
+  tooltip and accessibility text.
+- **D-16:** Avoid multi-line list rows for long names on the primary menu
+  surface. Multi-line names make menu height unstable and weaken quick reading.
+
+#### Keyboard Navigation and Verification
+
+- **D-17:** Keyboard navigation must reach setup, refresh, edit watchlist,
+  watchlist detail, warning events, and secondary sections.
+- **D-18:** Verification should combine automatic tests with a manual QA
+  checklist. Existing tests can cover model and state behavior; real menu
+  keyboard behavior needs documented manual QA.
+- **D-19:** QA must cover all four menu states: `OK`, `Watch`, `Bad`, and
+  `Stale`.
+- **D-20:** QA must also cover setup, edit watchlist, and refresh enabled or
+  disabled paths.
+
+### Claude's Discretion
+
+- The planner may choose exact truncation length and helper type names.
+- The planner may choose whether tooltip support lives directly in SwiftUI
+  views or behind a small presentation helper, as long as full names are
+  available without cluttering the menu.
+- The planner may decide which keyboard-navigation behaviors are testable in
+  unit tests versus documented in UAT.
+- The planner may adjust exact copy if it keeps the same status meaning,
+  remains short, and does not weaken watchlist-first reading.
+
+### Deferred Ideas (OUT OF SCOPE)
+
+- Full daily-loop operator QA belongs to GitHub issue #7.
+- AppKit `NSStatusItem` migration remains deferred.
+- Local distribution, notarization, and packaging remain deferred.
+- Deep troubleshooting handoff such as `Open in k9s` remains deferred.
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| R1 | The menu bar icon must communicate one of four states: `OK`, `Watch`, `Bad`, or `Stale`. [VERIFIED: docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md; GitHub issue #6] | Use `ClusterHealthState` plus `MenuBarStatusPresentation`; current code already maps `OK` to `KubebarLogo` and `Watch`/`Bad`/`Stale` to the locked SF Symbols. [VERIFIED: KubebarCore/Models/MenuBarStatusPresentation.swift; Kubebar/KubebarApp.swift] |
+| R13 | Warning and failure states must not rely on color alone. [VERIFIED: docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md; 06-CONTEXT.md] | Add explicit opened-menu symbol, state text, and one top reason from `MenuDisplayModel`; preserve accessibility labels. [VERIFIED: 06-CONTEXT.md; CITED: https://developer.apple.com/documentation/SwiftUI/View-Accessibility via WebSearch] |
+| R18 | The dropdown must feel like a disciplined menu bar utility, not a small dashboard made of cards or widgets. [VERIFIED: docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md] | Keep `StatusSummaryView`, `WatchlistSectionView`, warning events, and node details ordered as the existing menu root does; tighten spacing without adding dashboard panels. [VERIFIED: Kubebar/Views/MenuBarRootView.swift; 06-CONTEXT.md] |
+| R19 | The first screen must prioritize typography, ordering, and spacing over decorative UI. [VERIFIED: docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md] | Apple HIG says menu labels should be clear and succinct and icons should clarify meaning, not decorate. [CITED: https://developer.apple.com/design/human-interface-guidelines/menus via WebSearch] |
+| R20 | Long object names must truncate consistently so the menu remains scannable during daily use. [VERIFIED: docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md] | Replace current tail pre-truncation with full-value display fields plus SwiftUI one-line middle truncation and tooltip/accessibility full names. [VERIFIED: KubebarCore/Services/HealthEvaluator.swift; CITED: https://developer.apple.com/documentation/swiftui/environmentvalues/truncationmode via WebSearch] |
+| R21 | Keyboard navigation must work across top-level rows and submenus. [VERIFIED: docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md; GitHub issue #6] | Use native `Button`, `Picker`, `Toggle`, and `DisclosureGroup` controls; document Full Keyboard Access manual QA because existing tests do not cover menu-bar interaction. [VERIFIED: Kubebar/Views/*.swift; .planning/codebase/TESTING.md; CITED: https://developer.apple.com/design/human-interface-guidelines/keyboards/ via WebSearch] |
+</phase_requirements>
+
+## Project Constraints (from AGENTS.md)
+
+- Kubebar is a native macOS menu bar app for quickly checking Kubernetes health, not a replacement for `k9s`. [VERIFIED: AGENTS.md]
+- Keep the menu bar icon categorical: `OK`, `Watch`, `Bad`, or `Stale`. [VERIFIED: AGENTS.md]
+- Keep the dropdown watchlist-first and cap first-screen watchlist rows at `3-5` items. [VERIFIED: AGENTS.md]
+- Never let stale data look healthy or current. [VERIFIED: AGENTS.md]
+- Keep deep troubleshooting out of version 1. [VERIFIED: AGENTS.md]
+- UI renders `MenuDisplayModel`; views must not decide cluster health directly. [VERIFIED: AGENTS.md; docs/architecture/runtime-invariants.md]
+- `HealthEvaluator` is the single source of truth for severity. [VERIFIED: AGENTS.md; .planning/codebase/ARCHITECTURE.md]
+- External reads must go through injectable boundaries, and the app-owned context is the source of truth. [VERIFIED: AGENTS.md; docs/architecture/system-overview.md]
+- New asynchronous work should prefer `async` / `await`; UI-bound state and side effects should use `@MainActor` where required. [VERIFIED: AGENTS.md]
+- The standard local gate is `./scripts/swift-quality-gate.sh local`; visible-app smoke validation uses `./scripts/compile-and-run.sh`. [VERIFIED: AGENTS.md; scripts/swift-quality-gate.sh; scripts/compile-and-run.sh]
+- No `CLAUDE.md` file was present in this checkout. [VERIFIED: rg --files -g CLAUDE.md]
+- No `.claude/skills` or `.agents/skills` directory was present in this checkout. [VERIFIED: ls .claude/skills; ls .agents/skills]
+
+## Summary
+
+Phase 06 should be planned as a presentation and verification polish phase over the existing SwiftUI `MenuBarExtra.window` app, not as a shell rewrite. [VERIFIED: 06-CONTEXT.md; Kubebar/KubebarApp.swift; CITED: https://developer.apple.com/documentation/SwiftUI/MenuBarExtra via Context7] The locked path is to keep `OK` as the custom `KubebarLogo`, keep `Watch`/`Bad`/`Stale` as explicit SF Symbol states, and make the opened menu explain the compressed menu-bar signal with symbol, state text, and one concise reason. [VERIFIED: 06-CONTEXT.md; KubebarCore/Models/MenuBarStatusPresentation.swift]
+
+The highest-risk planning detail is that current display data is not yet shaped for the phase decisions. [VERIFIED: KubebarCore/Models/MenuDisplayModel.swift; KubebarCore/Services/HealthEvaluator.swift] `HealthEvaluator.shortened(_:)` currently pre-truncates watch item titles at the tail, which conflicts with the locked middle-truncation and full-name fallback decisions. [VERIFIED: KubebarCore/Services/HealthEvaluator.swift; 06-CONTEXT.md] `MenuDisplayModel` also has `healthSentence` but no explicit top-status reason field, so the planner should add a core-owned `primaryStatusReason` or equivalent instead of making `StatusSummaryView` infer the reason. [VERIFIED: KubebarCore/Models/MenuDisplayModel.swift; Kubebar/Views/StatusSummaryView.swift; 06-CONTEXT.md]
+
+**Primary recommendation:** Keep the phase in `MenuBarStatusPresentation`, `MenuDisplayModel`, `HealthEvaluator`, and the existing SwiftUI views; add focused model tests plus a Phase 06 UAT checklist for real keyboard/menu behavior instead of introducing AppKit `NSStatusItem`, dashboard UI, or a new UI automation stack. [VERIFIED: 06-CONTEXT.md; .planning/codebase/TESTING.md; .planning/phases/05-expand-kubectl-data-into-actionable-warning-and-workload-reasons/05-UAT.md]
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|--------------|----------------|-----------|
+| Menu bar icon state | Core Models | macOS App Shell | `ClusterHealthState` and `MenuBarStatusPresentation` own categorical state and accessibility labels; `KubebarApp` only renders the selected icon. [VERIFIED: KubebarCore/Models/ClusterHealthState.swift; KubebarCore/Models/MenuBarStatusPresentation.swift; Kubebar/KubebarApp.swift] |
+| Opened-menu state explanation | Core Models / Services | SwiftUI Views | `HealthEvaluator` should compute the state label and one reason in `MenuDisplayModel`; `StatusSummaryView` should render it without recalculating health. [VERIFIED: AGENTS.md; KubebarCore/Services/HealthEvaluator.swift; Kubebar/Views/StatusSummaryView.swift] |
+| Non-color status expression | SwiftUI Views | Core Models | Views render symbol, text, and reason; core supplies the values and accessibility labels. [VERIFIED: 06-CONTEXT.md; KubebarCore/Models/MenuBarStatusPresentation.swift; CITED: https://developer.apple.com/documentation/SwiftUI/View-Accessibility via Context7] |
+| Native menu reading polish | SwiftUI Views | Core Models | Spacing, ordering, typography, and grouping belong in `MenuBarRootView` and section views; the data contract stays in `MenuDisplayModel`. [VERIFIED: Kubebar/Views/MenuBarRootView.swift; KubebarCore/Models/MenuDisplayModel.swift] |
+| Long-name truncation and full-name fallback | SwiftUI Views | Core Models | Visual truncation belongs in SwiftUI `Text`; full untruncated values should be carried by model fields for tooltip and accessibility text. [VERIFIED: KubebarCore/Services/HealthEvaluator.swift; CITED: https://developer.apple.com/documentation/swiftui/environmentvalues/truncationmode via WebSearch; CITED: https://developer.apple.com/documentation/swiftui/view/help%28_%3A%29 via Context7] |
+| Keyboard reachability | SwiftUI Views | Manual QA | `Button`, `Picker`, `Toggle`, and `DisclosureGroup` are the reachable controls; real menu-bar keyboard traversal is not covered by current unit tests. [VERIFIED: Kubebar/Views/*.swift; .planning/codebase/TESTING.md; CITED: https://developer.apple.com/design/human-interface-guidelines/keyboards/ via WebSearch] |
+| Verification | Tests / UAT Docs | Local scripts | Core behavior belongs in Swift Testing; real menu and keyboard behavior belongs in UAT plus `compile-and-run`. [VERIFIED: .planning/codebase/TESTING.md; scripts/compile-and-run.sh; .planning/phases/05-expand-kubectl-data-into-actionable-warning-and-workload-reasons/05-UAT.md] |
+
+## Standard Stack
+
+### Core
+
+| Library / Tool | Version | Purpose | Why Standard |
+|----------------|---------|---------|--------------|
+| SwiftUI `MenuBarExtra` | Apple SDK; app target macOS 14.0; local toolchain Swift 6.3.1 / Xcode 26.4.1 | Native macOS menu bar extra with window-style content. [VERIFIED: Package.swift; project.yml; swift --version; xcodebuild -version] | Official SwiftUI scene for persistent menu-bar utilities; `.window` supports data-rich content and standard controls. [CITED: https://developer.apple.com/documentation/SwiftUI/MenuBarExtra via Context7] |
+| SwiftUI text/accessibility modifiers | Apple SDK | `.lineLimit(1)`, `.truncationMode(.middle)`, `.help(Text(...))`, `.accessibilityLabel(...)`, and `.keyboardShortcut(...)`. [CITED: Context7 SwiftUI docs; WebSearch Apple docs] | Uses system text layout, help tags/tooltips, accessibility labels, and keyboard shortcut resolution instead of custom behavior. [CITED: https://developer.apple.com/documentation/swiftui/environmentvalues/truncationmode via WebSearch; CITED: https://developer.apple.com/documentation/swiftui/view/help%28_%3A%29 via Context7] |
+| SF Symbols through SwiftUI `Label` / `Image(systemName:)` | Apple SDK | Locked symbols for `Watch`, `Bad`, and `Stale`. [VERIFIED: 06-CONTEXT.md; KubebarCore/Models/MenuBarStatusPresentation.swift] | Keeps status icons native, scalable, and accessible through SwiftUI labels. [VERIFIED: Kubebar/KubebarApp.swift; CITED: https://developer.apple.com/design/human-interface-guidelines/menus via WebSearch] |
+| Swift Testing | Swift 6 project; tests import `Testing` | Model and service regression tests. [VERIFIED: Package.swift; KubebarTests/**/*.swift] | Existing test framework; no XCTest UI target is configured. [VERIFIED: .planning/codebase/TESTING.md; rg --files KubebarTests] |
+
+### Supporting
+
+| Library / Tool | Version | Purpose | When to Use |
+|----------------|---------|---------|-------------|
+| Xcode / `xcodebuild` | Xcode 26.4.1, build 17E202 | Build and test the macOS app target. [VERIFIED: xcodebuild -version; scripts/swift-quality-gate.sh] | Required for the full local gate and any Xcode scheme tests. [VERIFIED: scripts/swift-quality-gate.sh] |
+| Swift Package Manager | Swift driver 1.148.6 / Swift 6.3.1 local | SwiftPM build and test path. [VERIFIED: swift --version; Package.swift] | Used by the full gate after Xcode checks. [VERIFIED: scripts/swift-quality-gate.sh] |
+| XcodeGen | 2.44.1 local | Regenerate `Kubebar.xcodeproj` if `project.yml` or target membership changes. [VERIFIED: xcodegen --version; project.yml] | Only needed if the plan changes targets, sources, or build settings. [VERIFIED: .planning/codebase/STACK.md] |
+| `kubectl` | Client v1.35.3 local | Live app setup/refresh data during manual QA. [VERIFIED: kubectl version --client] | Needed for real cluster UAT; unit tests use fakes and should not shell out to real `kubectl`. [VERIFIED: .planning/codebase/TESTING.md; KubebarTests/Services/*.swift] |
+| `osascript` / `open` | macOS system tools | Visible app smoke launch. [VERIFIED: osascript -e "return 1"; scripts/compile-and-run.sh] | Required by `./scripts/compile-and-run.sh`. [VERIFIED: scripts/compile-and-run.sh] |
+
+### Alternatives Considered
+
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| SwiftUI `MenuBarExtra.window` | AppKit `NSStatusItem` / `NSMenu` | Rejected by locked phase scope; AppKit migration is deferred and would expand architecture risk. [VERIFIED: 06-CONTEXT.md; .planning/phases/04-codexbar-inspired-menu-reliability-and-freshness/04-RESEARCH.md] |
+| SwiftUI `Text.truncationMode(.middle)` with full-value fields | Custom text-measurement truncation | Custom text measurement is unnecessary for this phase; Apple provides middle truncation and tooltip/accessibility APIs. [CITED: https://developer.apple.com/documentation/swiftui/environmentvalues/truncationmode via WebSearch; CITED: Context7 SwiftUI help docs] |
+| Swift Testing plus UAT | New UI automation target | Current repo has no UI test target, and prior menu-bar inspection through Computer Use could not access the menu extra reliably. [VERIFIED: .planning/codebase/TESTING.md; .planning/phases/05-expand-kubectl-data-into-actionable-warning-and-workload-reasons/05-UAT.md] |
+| Existing SF Symbols | Redesign all status icons | User locked the current `Watch`, `Bad`, and `Stale` symbols, and `OK` remains the brand logo. [VERIFIED: 06-CONTEXT.md] |
+
+**Installation:**
+
+```bash
+# No Swift package installation is required for this phase because Package.swift declares no external dependencies.
+# Regenerate the Xcode project only if project.yml changes:
+xcodegen generate
+```
+
+**Version verification:**
+
+```bash
+swift --version
+xcodebuild -version
+xcodegen --version
+kubectl version --client
+```
+
+Version results in this environment: Swift 6.3.1, Xcode 26.4.1, XcodeGen 2.44.1, and kubectl client v1.35.3. [VERIFIED: local command outputs on 2026-04-21]
+
+## Architecture Patterns
+
+### System Architecture Diagram
+
+```mermaid
+flowchart TD
+    A[Refresh or setup state] --> B[HealthEvaluator]
+    B --> C{ClusterHealthState}
+    C -->|OK| D[MenuBarStatusPresentation: KubebarLogo]
+    C -->|Watch| E[MenuBarStatusPresentation: exclamationmark.triangle]
+    C -->|Bad| F[MenuBarStatusPresentation: xmark.octagon]
+    C -->|Stale| G[MenuBarStatusPresentation: clock.badge.exclamationmark]
+    B --> H[MenuDisplayModel]
+    H --> I[StatusSummaryView: symbol + state + one reason]
+    H --> J[WatchlistSectionView: 3-5 rows + details]
+    H --> K[WarningEventsView and NodeDetailsView]
+    H --> L[Refresh/Edit/Setup controls]
+    I --> M[Manual keyboard QA and accessibility checks]
+    J --> M
+    L --> M
+```
+
+The diagram shows the desired Phase 06 flow: core services shape the state and reasons, while SwiftUI renders the menu and controls. [VERIFIED: docs/architecture/system-overview.md; KubebarCore/Services/HealthEvaluator.swift; Kubebar/Views/MenuBarRootView.swift]
+
+### Recommended Project Structure
+
+```text
+KubebarCore/Models/
+├── MenuBarStatusPresentation.swift   # Four-state menu bar icon and accessibility labels
+├── MenuDisplayModel.swift            # Add full names and top status reason fields here
+└── ClusterHealthState.swift          # Keep OK / Watch / Bad / Stale labels
+
+KubebarCore/Services/
+└── HealthEvaluator.swift             # Compute primary reason, watchlist order, truncation-safe display contracts
+
+Kubebar/Views/
+├── StatusSummaryView.swift           # Render opened-menu symbol, state text, and one reason
+├── WatchlistSectionView.swift        # One-line middle truncation, tooltip, accessibility text, details
+├── WarningEventsView.swift           # Secondary section, not promoted above watchlist
+└── SetupView.swift / WatchlistPickerView.swift # Keyboard-reachable setup and edit flow
+
+KubebarTests/Models/
+├── MenuBarStatusPresentationTests.swift
+└── MenuDisplayModelTests.swift
+
+.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/
+└── 06-UAT.md                         # Manual QA for four states and keyboard paths
+```
+
+This structure follows the current target layout and test layout. [VERIFIED: .planning/codebase/STRUCTURE.md; rg --files Kubebar KubebarCore KubebarTests]
+
+### Pattern 1: Core-Owned Four-State Presentation
+
+**What:** Keep state-to-icon and state-to-accessibility mapping in `MenuBarStatusPresentation`; do not duplicate state switches in views. [VERIFIED: KubebarCore/Models/MenuBarStatusPresentation.swift; AGENTS.md]
+
+**When to use:** Any menu bar icon, opened-menu status symbol, or accessibility label change. [VERIFIED: 06-CONTEXT.md]
+
+**Example:**
+
+```swift
+// Source: KubebarCore/Models/MenuBarStatusPresentation.swift
+let presentation = MenuBarStatusPresentation(state: display.state)
+
+switch presentation.icon {
+case let .system(name):
+    Label(presentation.accessibilityLabel, systemImage: name)
+case let .custom(name):
+    Image(name)
+        .accessibilityLabel(presentation.accessibilityLabel)
+}
+```
+
+Planning note: update `MenuBarStatusPresentationTests` to assert `OK` uses `.custom("KubebarLogo")`; the current test only asserts `symbolName == "checkmark.circle"` for `OK`, which does not prove the locked menu-bar logo behavior. [VERIFIED: KubebarTests/Models/MenuBarStatusPresentationTests.swift; KubebarCore/Models/MenuBarStatusPresentation.swift; 06-CONTEXT.md]
+
+### Pattern 2: Status Summary Is a Display Contract, Not View Logic
+
+**What:** Add a display-model field such as `primaryStatusReason` so the opened menu can show symbol, state label, and one reason without recalculating severity in `StatusSummaryView`. [VERIFIED: AGENTS.md; KubebarCore/Models/MenuDisplayModel.swift; 06-CONTEXT.md]
+
+**When to use:** Top status area rendering for `OK`, `Watch`, `Bad`, and `Stale`. [VERIFIED: 06-CONTEXT.md]
+
+**Example:**
+
+```swift
+// Source: recommended pattern based on AGENTS.md and HealthEvaluator ownership
+public struct MenuDisplayModel: Equatable, Sendable {
+    public let state: ClusterHealthState
+    public let contextName: String
+    public let healthSentence: String
+    public let primaryStatusReason: String
+}
+```
+
+Planning note: derive `primaryStatusReason` in `HealthEvaluator` from the highest-priority visible watch item reason, stale banner reason, section failure reason, or warning count. [VERIFIED: KubebarCore/Services/HealthEvaluator.swift; 06-CONTEXT.md]
+
+### Pattern 3: Full Names Stay in the Model, Middle Truncation Stays in SwiftUI
+
+**What:** Preserve the full context, namespace, and workload names in display data, then render with `.lineLimit(1)` and `.truncationMode(.middle)` plus `.help(Text(fullName))` and `.accessibilityLabel(fullName)`. [VERIFIED: 06-CONTEXT.md; CITED: https://developer.apple.com/documentation/swiftui/environmentvalues/truncationmode via WebSearch; CITED: https://developer.apple.com/documentation/swiftui/view/help%28_%3A%29 via Context7]
+
+**When to use:** Status context names, watchlist row titles, tracked item detail names, setup picker labels, and warning-event locations. [VERIFIED: 06-CONTEXT.md; Kubebar/Views/*.swift]
+
+**Example:**
+
+```swift
+// Source: Apple SwiftUI truncation/help/accessibility docs via Context7 and WebSearch
+Text(item.fullTitle)
+    .lineLimit(1)
+    .truncationMode(.middle)
+    .help(Text(item.fullTitle))
+    .accessibilityLabel(item.fullTitle)
+```
+
+Planning note: current `HealthEvaluator.shortened(_:)` performs tail truncation and stores only the shortened title in `WatchItemDisplay.title`; change the contract so tests can prove the full value remains available. [VERIFIED: KubebarCore/Services/HealthEvaluator.swift; KubebarCore/Models/MenuDisplayModel.swift]
+
+### Pattern 4: Keyboard Navigation Through Native Controls
+
+**What:** Keep interactive paths as native SwiftUI controls and add explicit shortcuts only for clear primary actions. [VERIFIED: Kubebar/Views/MenuBarRootView.swift; Kubebar/Views/SetupView.swift; CITED: https://developer.apple.com/documentation/SwiftUI/KeyboardShortcut via Context7]
+
+**When to use:** `Retry now`, `Edit watchlist`, `Finish setup`, setup pickers, watchlist toggles, and disclosure groups. [VERIFIED: 06-CONTEXT.md; Kubebar/Views/*.swift]
+
+**Example:**
+
+```swift
+// Source: Apple SwiftUI KeyboardShortcut docs via Context7
+Button("Finish setup", action: onComplete)
+    .keyboardShortcut(.defaultAction)
+    .disabled(!state.isConfigured)
+```
+
+Planning note: Full Keyboard Access manual QA should be part of `06-UAT.md` because Apple HIG identifies it as the system keyboard-navigation path, and this repo has no UI automation target. [CITED: https://developer.apple.com/design/human-interface-guidelines/keyboards/ via WebSearch; VERIFIED: .planning/codebase/TESTING.md]
+
+### Anti-Patterns to Avoid
+
+- **View-level health decisions:** Do not make `StatusSummaryView` decide which reason is most important; this violates the `HealthEvaluator` ownership rule. [VERIFIED: AGENTS.md; docs/architecture/system-overview.md]
+- **Pre-truncating away full values:** Do not store only an ellipsized title in `MenuDisplayModel`; D-15 requires full names for tooltip and accessibility text. [VERIFIED: 06-CONTEXT.md; KubebarCore/Services/HealthEvaluator.swift]
+- **Color-only or icon-only warning state:** Do not rely on color, the menu bar icon, or the logo alone; warning/failure states require symbol, status text, and short reason. [VERIFIED: 06-CONTEXT.md; docs/architecture/runtime-invariants.md]
+- **Card/dashboard expansion:** Do not convert the primary menu into cards, widgets, or a troubleshooting panel. [VERIFIED: 06-CONTEXT.md; AGENTS.md]
+- **New AppKit shell:** Do not migrate to `NSStatusItem` in this phase. [VERIFIED: 06-CONTEXT.md]
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Menu bar shell | Custom `NSStatusItem` / `NSMenu` migration | Existing SwiftUI `MenuBarExtra.window` | Locked out of scope and already implemented. [VERIFIED: 06-CONTEXT.md; Kubebar/KubebarApp.swift] |
+| Text truncation | Manual text measurement and custom ellipsis rendering | SwiftUI `.lineLimit(1)` plus `.truncationMode(.middle)` | Apple provides middle truncation and line limits. [CITED: https://developer.apple.com/documentation/swiftui/environmentvalues/truncationmode via WebSearch] |
+| Tooltips | Custom hover tracking | SwiftUI `.help(Text(...))` | Apple documents `.help` as accessibility hint plus macOS tooltip/help tag. [CITED: https://developer.apple.com/documentation/swiftui/view/help%28_%3A%29 via Context7] |
+| Accessibility labels | Separate accessibility registry | SwiftUI `.accessibilityLabel(...)` and `MenuBarStatusPresentation.accessibilityLabel` | Existing code already centralizes state labels; SwiftUI provides accessibility modifiers. [VERIFIED: KubebarCore/Models/MenuBarStatusPresentation.swift; CITED: https://developer.apple.com/documentation/SwiftUI/View-Accessibility via WebSearch] |
+| Keyboard traversal | Raw key handlers for normal controls | Native `Button`, `Picker`, `Toggle`, `DisclosureGroup`, and targeted `keyboardShortcut` | Apple recommends standard keyboard behavior and shortcuts; native controls remain the lowest-risk path. [CITED: https://developer.apple.com/design/human-interface-guidelines/keyboards/ via WebSearch; VERIFIED: Kubebar/Views/*.swift] |
+| Four-state QA | Live-cluster-only reproduction | Deterministic model tests plus manual UAT | Live clusters may not naturally produce all four states, and current repo lacks UI automation. [VERIFIED: .planning/codebase/TESTING.md; .planning/phases/05-expand-kubectl-data-into-actionable-warning-and-workload-reasons/05-UAT.md] |
+
+**Key insight:** The phase is about making already-computed product state readable and reachable; custom shells, custom layout engines, and broad automation infrastructure add risk without improving the locked user outcomes. [VERIFIED: 06-CONTEXT.md; docs/architecture/system-overview.md]
+
+## Common Pitfalls
+
+### Pitfall 1: `OK` Logo Without Opened-Menu Meaning
+
+**What goes wrong:** The menu bar shows the brand logo for `OK`, but the opened menu does not explicitly say `OK`. [VERIFIED: 06-CONTEXT.md; Kubebar/Views/StatusSummaryView.swift]
+
+**Why it happens:** `KubebarApp` uses `MenuBarStatusPresentation`, while `StatusSummaryView` only shows `display.state.label` as small text and no opened-menu symbol. [VERIFIED: Kubebar/KubebarApp.swift; Kubebar/Views/StatusSummaryView.swift]
+
+**How to avoid:** Render the same presentation concept in the opened top status area, with state text and one reason. [VERIFIED: 06-CONTEXT.md]
+
+**Warning signs:** Tests assert menu bar symbol names but do not assert the opened summary contains `OK`, `Watch`, `Bad`, or `Stale` with a reason. [VERIFIED: KubebarTests/Models/MenuBarStatusPresentationTests.swift; KubebarTests/Models/MenuDisplayModelTests.swift]
+
+### Pitfall 2: Tail Truncation Hides Kubernetes Suffixes
+
+**What goes wrong:** Similar Kubernetes resource names become indistinguishable because the meaningful suffix disappears. [VERIFIED: 06-CONTEXT.md]
+
+**Why it happens:** Current `HealthEvaluator.shortened(_:)` uses prefix-only truncation. [VERIFIED: KubebarCore/Services/HealthEvaluator.swift]
+
+**How to avoid:** Keep the full value and use middle truncation for visual `Text`, with full tooltip/accessibility fallback. [VERIFIED: 06-CONTEXT.md; CITED: SwiftUI truncation/help docs via Context7/WebSearch]
+
+**Warning signs:** Tests expect values like `production-namespace/checkout-api-with-a-...` instead of preserving the tail. [VERIFIED: KubebarTests/Models/MenuDisplayModelTests.swift]
+
+### Pitfall 3: Manual QA Cannot Force All Four States
+
+**What goes wrong:** UAT only verifies whichever state the current live cluster happens to show. [VERIFIED: .planning/phases/05-expand-kubectl-data-into-actionable-warning-and-workload-reasons/05-UAT.md]
+
+**Why it happens:** The app reads real `kubectl` state, and the repo has no UI test target or built-in fixture mode. [VERIFIED: .planning/codebase/TESTING.md; KubebarCore/Services/KubectlClusterReader.swift]
+
+**How to avoid:** Cover all four states in deterministic model tests and make UAT explicit about which real-menu paths were manually checked; add a debug-only fixture launch path only if visual all-state manual proof is required. [VERIFIED: KubebarTests/Models/MenuDisplayModelTests.swift; 06-CONTEXT.md]
+
+**Warning signs:** `06-UAT.md` says "state covered" without evidence for `OK`, `Watch`, `Bad`, and `Stale`. [VERIFIED: 06-CONTEXT.md]
+
+### Pitfall 4: Keyboard Reachability Assumed From Mouse Usability
+
+**What goes wrong:** Setup, disclosure groups, secondary sections, or refresh controls work with a mouse but are not reachable or usable with keyboard traversal. [VERIFIED: 06-CONTEXT.md; .planning/codebase/CONCERNS.md]
+
+**Why it happens:** Current tests are model/service tests; no UI interaction tests exist. [VERIFIED: .planning/codebase/TESTING.md]
+
+**How to avoid:** Use native controls, add clear default shortcut behavior for primary actions where appropriate, and run a manual Full Keyboard Access checklist. [CITED: https://developer.apple.com/design/human-interface-guidelines/keyboards/ via WebSearch; VERIFIED: Kubebar/Views/*.swift]
+
+**Warning signs:** New content appears as inert `Text`, such as the current `View all tracked` overflow row. [VERIFIED: Kubebar/Views/WatchlistSectionView.swift]
+
+## Code Examples
+
+Verified patterns from official and local sources:
+
+### Opened Status Summary With State, Symbol, and Reason
+
+```swift
+// Source: local MenuBarStatusPresentation + 06-CONTEXT non-color decisions
+let presentation = MenuBarStatusPresentation(state: display.state)
+
+HStack(alignment: .firstTextBaseline, spacing: 8) {
+    presentation.image
+    VStack(alignment: .leading, spacing: 2) {
+        Text(display.state.label)
+            .font(.caption.weight(.semibold))
+        Text(display.primaryStatusReason)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+    }
+}
+.accessibilityLabel("\(presentation.accessibilityLabel), \(display.primaryStatusReason)")
+```
+
+The `presentation.image` helper does not exist today; if added, keep it UI-only or expose only `IconSource` from core so `KubebarCore` remains free of SwiftUI. [VERIFIED: KubebarCore/Models/MenuBarStatusPresentation.swift; .planning/codebase/ARCHITECTURE.md]
+
+### Middle Truncation With Full Tooltip
+
+```swift
+// Source: Apple SwiftUI truncationMode, help, and accessibilityLabel docs
+Text(fullName)
+    .lineLimit(1)
+    .truncationMode(.middle)
+    .help(Text(fullName))
+    .accessibilityLabel(fullName)
+```
+
+Use this for `display.contextName`, watchlist row titles, setup context names, workload names, and warning locations. [VERIFIED: 06-CONTEXT.md; Kubebar/Views/*.swift]
+
+### Native Keyboard Default Action
+
+```swift
+// Source: Apple SwiftUI KeyboardShortcut docs
+Button("Finish setup", action: onComplete)
+    .keyboardShortcut(.defaultAction)
+    .disabled(!state.isConfigured)
+```
+
+Use explicit shortcuts sparingly; Apple HIG says people expect standard keyboard shortcuts to behave consistently. [CITED: https://developer.apple.com/design/human-interface-guidelines/keyboards/ via WebSearch]
+
+### Model Test For Full Name Preservation
+
+```swift
+// Source: existing Swift Testing pattern in KubebarTests/Models/MenuDisplayModelTests.swift
+@Test("long watch item keeps full title while visual title can be truncated")
+func longWatchItemKeepsFullTitle() {
+    let display = HealthEvaluator().evaluate(snapshot: snapshot, now: now)
+
+    #expect(display.visibleWatchItems.first?.fullTitle == "production-namespace/checkout-api-with-a-very-long-name")
+}
+```
+
+Add the actual property name during planning; the required behavior is full value preservation plus middle visual truncation. [VERIFIED: 06-CONTEXT.md; KubebarCore/Models/MenuDisplayModel.swift]
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| AppKit `NSStatusItem` for menu-bar apps | SwiftUI `MenuBarExtra`, with `.window` style for data-rich content | `MenuBarExtra` is documented as available on macOS 13.0+; Kubebar targets macOS 14.0. [CITED: Context7 SwiftUI MenuBarExtra docs; VERIFIED: Package.swift] | Keep the SwiftUI shell; do not migrate to AppKit for this phase. [VERIFIED: 06-CONTEXT.md] |
+| Tail truncation stored in model strings | Full model value plus view-level middle truncation | Locked by Phase 06 decisions on 2026-04-21. [VERIFIED: 06-CONTEXT.md] | Preserves both prefix and suffix, and keeps full values available to help/accessibility. [VERIFIED: 06-CONTEXT.md; CITED: SwiftUI truncation/help docs] |
+| Color or icon as primary state cue | Symbol plus state text plus short reason | Locked by Phase 06 decisions and R13. [VERIFIED: 06-CONTEXT.md; docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md] | Makes `Watch`, `Bad`, and `Stale` understandable without color. [VERIFIED: 06-CONTEXT.md] |
+| Live-only manual validation | Unit tests for deterministic states plus documented UAT for real menu interaction | Existing repo has Swift Testing but no UI automation target. [VERIFIED: .planning/codebase/TESTING.md] | The planner should avoid promising full automated menu keyboard coverage unless it first creates UI test infrastructure. [VERIFIED: .planning/codebase/TESTING.md] |
+
+**Deprecated/outdated:**
+
+- AppKit status-item migration is out of scope for this phase. [VERIFIED: 06-CONTEXT.md]
+- Color-only, logo-only, or icon-only status meaning is insufficient for this phase. [VERIFIED: 06-CONTEXT.md; docs/architecture/runtime-invariants.md]
+- Tail-only pre-truncation is inconsistent with the locked middle-truncation decision. [VERIFIED: KubebarCore/Services/HealthEvaluator.swift; 06-CONTEXT.md]
+
+## Assumptions Log
+
+> List all claims tagged `[ASSUMED]` in this research. The planner and discuss-phase use this section to identify decisions that need user confirmation before execution.
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+
+All claims in this research were verified or cited; no user confirmation is needed before planning. [VERIFIED: source review and documentation lookup completed on 2026-04-21]
+
+## Open Questions
+
+1. **Should visual all-four-state manual QA require a debug-only fixture mode?**
+   - What we know: All four state meanings can be covered in Swift Testing, and the previous UAT noted Computer Use could not directly inspect the menu bar extra. [VERIFIED: KubebarTests/Models/MenuDisplayModelTests.swift; .planning/phases/05-expand-kubectl-data-into-actionable-warning-and-workload-reasons/05-UAT.md]
+   - What's unclear: Whether the user expects manual visual proof for all four states, or accepts deterministic model tests plus live manual checks for the states available in the current cluster. [VERIFIED: 06-CONTEXT.md]
+   - Recommendation: Plan unit tests for all four states and UAT rows for all four states; add a debug-only fixture launch path only if implementation discovers that visual inspection cannot otherwise satisfy D-19. [VERIFIED: 06-CONTEXT.md; .planning/codebase/TESTING.md]
+
+2. **Which explicit keyboard shortcuts should be added, if any?**
+   - What we know: Apple documents standard keyboard shortcuts and recommends respecting standard behavior. [CITED: https://developer.apple.com/design/human-interface-guidelines/keyboards/ via WebSearch]
+   - What's unclear: The exact shortcut set was left to planner discretion. [VERIFIED: 06-CONTEXT.md]
+   - Recommendation: Use `.defaultAction` for `Finish setup` and rely on native keyboard traversal for most controls; add a shortcut for `Retry now` only if manual QA shows the action is not comfortably reachable. [VERIFIED: 06-CONTEXT.md; Kubebar/Views/MenuBarRootView.swift]
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|-------------|-----------|---------|----------|
+| macOS Swift toolchain | `swift build`, `swift test` | yes | Swift 6.3.1 | none needed. [VERIFIED: swift --version] |
+| Xcode / `xcodebuild` | Xcode app build/test gate | yes | Xcode 26.4.1 build 17E202 | none needed. [VERIFIED: xcodebuild -version] |
+| XcodeGen | Regenerate project if target membership changes | yes | 2.44.1 | Avoid target changes or update committed `.xcodeproj` manually if unavailable. [VERIFIED: xcodegen --version; project.yml] |
+| `kubectl` | Real setup/refresh manual QA | yes | Client v1.35.3 | Unit tests use fake command runners; real app UAT needs configured local cluster access. [VERIFIED: kubectl version --client; .planning/codebase/TESTING.md] |
+| `osascript` / `open` | `./scripts/compile-and-run.sh` visible app smoke test | yes | macOS system tools | Manual launch from Finder if script cannot run. [VERIFIED: osascript command; scripts/compile-and-run.sh] |
+| GitHub CLI `gh` | Issue source lookup only | yes | authenticated enough to read issue #6 | Issue content is also captured in `06-CONTEXT.md`. [VERIFIED: gh issue view 6 output; 06-CONTEXT.md] |
+
+**Missing dependencies with no fallback:**
+
+- None found for planning this phase. [VERIFIED: environment audit commands on 2026-04-21]
+
+**Missing dependencies with fallback:**
+
+- No UI automation target exists; use Swift Testing plus manual UAT unless the plan explicitly creates UI test infrastructure. [VERIFIED: .planning/codebase/TESTING.md]
+
+## Validation Architecture
+
+### Test Framework
+
+| Property | Value |
+|----------|-------|
+| Framework | Swift Testing with `@Suite`, `@Test`, and `#expect`. [VERIFIED: .planning/codebase/TESTING.md; KubebarTests/**/*.swift] |
+| Config file | `Package.swift` test target plus `project.yml` Xcode test target. [VERIFIED: Package.swift; project.yml] |
+| Quick run command | `swift test` [VERIFIED: scripts/swift-quality-gate.sh] |
+| Full suite command | `./scripts/swift-quality-gate.sh local` [VERIFIED: AGENTS.md; scripts/swift-quality-gate.sh] |
+| Visible app smoke command | `./scripts/compile-and-run.sh` [VERIFIED: AGENTS.md; scripts/compile-and-run.sh] |
+
+Validation is enabled because `.planning/config.json` is absent and no `workflow.nyquist_validation: false` setting exists. [VERIFIED: ls .planning]
+
+### Phase Requirements -> Test Map
+
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|--------------|
+| R1 | `OK` uses `KubebarLogo`; `Watch`, `Bad`, and `Stale` use locked SF Symbols and accessibility labels. | unit | `swift test --filter MenuBarStatusPresentationTests` | yes, update needed. [VERIFIED: KubebarTests/Models/MenuBarStatusPresentationTests.swift] |
+| R13 | Opened menu has symbol, status text, and one reason without relying on color. | unit + manual | `swift test --filter MenuDisplayModelTests` plus `06-UAT.md` | partial; add model field/test and UAT file. [VERIFIED: KubebarTests/Models/MenuDisplayModelTests.swift; 06-CONTEXT.md] |
+| R18 | Menu remains watchlist-first and not dashboard/card-like. | manual/source review | `./scripts/compile-and-run.sh` plus `06-UAT.md` | no Phase 06 UAT yet. [VERIFIED: find .planning/phases/06...; Kubebar/Views/MenuBarRootView.swift] |
+| R19 | Typography, ordering, and spacing remain readable and native. | manual/source review | `./scripts/compile-and-run.sh` plus `06-UAT.md` | no Phase 06 UAT yet. [VERIFIED: 06-CONTEXT.md; Kubebar/Views/MenuBarRootView.swift] |
+| R20 | Long context, namespace, workload, and warning names use consistent middle truncation and full-name fallback. | unit + manual | `swift test --filter MenuDisplayModelTests` plus `06-UAT.md` | partial; current test asserts tail truncation. [VERIFIED: KubebarTests/Models/MenuDisplayModelTests.swift; KubebarCore/Services/HealthEvaluator.swift] |
+| R21 | Keyboard reaches setup, refresh, edit watchlist, watchlist detail, warning events, and secondary sections. | manual QA, limited source assertions | `./scripts/compile-and-run.sh` plus `06-UAT.md` | no automated UI target; UAT needed. [VERIFIED: .planning/codebase/TESTING.md; 06-CONTEXT.md] |
+
+### Sampling Rate
+
+- **Per task commit:** `swift test` for model/core-only changes; use focused `--filter` runs first when editing a single model or service. [VERIFIED: .planning/codebase/TESTING.md]
+- **Per wave merge:** `./scripts/swift-quality-gate.sh local`. [VERIFIED: AGENTS.md]
+- **Phase gate:** Full gate green plus `06-UAT.md` updated with menu state and keyboard checks. [VERIFIED: 06-CONTEXT.md; prior UAT pattern in 04-UAT.md and 05-UAT.md]
+
+### Wave 0 Gaps
+
+- [ ] `KubebarTests/Models/MenuBarStatusPresentationTests.swift` - update `OK` test to assert `.custom("KubebarLogo")` and preserve four accessibility labels. [VERIFIED: current test file]
+- [ ] `KubebarTests/Models/MenuDisplayModelTests.swift` - add `primaryStatusReason` coverage for `OK`, `Watch`, `Bad`, and `Stale`. [VERIFIED: current model/test shape]
+- [ ] `KubebarTests/Models/MenuDisplayModelTests.swift` or new model test - replace tail-truncation expectation with full-name preservation and middle-truncation contract. [VERIFIED: current test file]
+- [ ] `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` - add manual checklist for four states, setup, edit watchlist, refresh enabled/disabled, disclosure groups, warning events, secondary sections, long-name tooltip/accessibility, and Full Keyboard Access. [VERIFIED: 06-CONTEXT.md; 04-UAT.md; 05-UAT.md]
+- [ ] Optional UI test target - only if the planner rejects manual UAT as sufficient. No target exists today. [VERIFIED: Package.swift; project.yml; .planning/codebase/TESTING.md]
+
+## Security Domain
+
+Security enforcement is treated as enabled because `.planning/config.json` is absent. [VERIFIED: ls .planning]
+
+### Applicable ASVS Categories
+
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|------------------|
+| V2 Authentication | no | Kubebar has no app account/session auth; Kubernetes identity is delegated to local `kubectl`. [VERIFIED: .planning/codebase/INTEGRATIONS.md] |
+| V3 Session Management | no | No app sessions are present. [VERIFIED: .planning/codebase/INTEGRATIONS.md] |
+| V4 Access Control | limited | Do not add deep links or mutation actions; app reads through selected `kubectl` context only. [VERIFIED: AGENTS.md; .planning/codebase/INTEGRATIONS.md] |
+| V5 Input Validation | yes | Treat context, namespace, workload, warning, and error strings as display data only; do not shell-interpolate or expose raw kubectl output in UI. [VERIFIED: docs/architecture/runtime-invariants.md; .planning/codebase/CONCERNS.md] |
+| V6 Cryptography | no | No cryptographic feature is in this phase; do not add secret handling. [VERIFIED: 06-CONTEXT.md; .planning/codebase/INTEGRATIONS.md] |
+
+### Known Threat Patterns for This Stack
+
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| Misleading stale status | Spoofing / Information disclosure by confusion | Keep stale distinct in icon, state text, banner, and top reason. [VERIFIED: docs/architecture/runtime-invariants.md; 06-CONTEXT.md] |
+| Raw command output shown in tooltips or accessibility text | Information disclosure | Full-name fallbacks should use app-owned names, not raw stderr or raw JSON. [VERIFIED: docs/architecture/runtime-invariants.md; .planning/codebase/CONCERNS.md] |
+| Custom keyboard handlers triggering unintended actions | Tampering | Prefer native controls and standard shortcuts; keep destructive/deep actions out of scope. [CITED: Apple HIG keyboards via WebSearch; VERIFIED: 06-CONTEXT.md] |
+| Shell injection through display strings | Tampering | This phase should not add subprocess calls; existing command boundary passes arguments arrays. [VERIFIED: .planning/codebase/ARCHITECTURE.md; KubebarCore/Services/CommandRunner.swift] |
+
+## Sources
+
+### Primary (HIGH confidence)
+
+- `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-CONTEXT.md` - locked decisions, discretion, deferred ideas, and code context. [VERIFIED]
+- GitHub issue #6, `https://github.com/nexttylabs/kubebar/issues/6` - source scope and acceptance criteria via `gh issue view 6`. [VERIFIED]
+- `AGENTS.md` - repo product, architecture, coding, and quality rules. [VERIFIED]
+- `docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md` - R1, R13, R18-R21. [VERIFIED]
+- `docs/plans/2026-04-19-002-kubebar-product-roadmap.md` - issue #6 as polish gate before QA/distribution. [VERIFIED]
+- `docs/architecture/runtime-invariants.md` and `docs/architecture/system-overview.md` - runtime and ownership rules. [VERIFIED]
+- `.planning/codebase/ARCHITECTURE.md`, `.planning/codebase/STRUCTURE.md`, `.planning/codebase/TESTING.md`, `.planning/codebase/CONCERNS.md` - current mapped architecture, structure, testing, and risks. [VERIFIED]
+- Current source files in `Kubebar/`, `KubebarCore/`, and `KubebarTests/`. [VERIFIED]
+- Context7 `/websites/developer_apple_swiftui` - `MenuBarExtra`, `.window` style, `help(_:)`, `accessibilityLabel`, `keyboardShortcut`. [CITED]
+
+### Secondary (MEDIUM confidence)
+
+- Apple Developer Documentation search snippets for `MenuBarExtra`, `KeyboardShortcut`, SwiftUI accessibility modifiers, `truncationMode`, and HIG menus/keyboards. Apple pages are official but browser open returned JavaScript placeholders, so Context7 snippets are preferred where available. [CITED: developer.apple.com via WebSearch]
+- `.planning/phases/04-codexbar-inspired-menu-reliability-and-freshness/04-RESEARCH.md` - prior CodexBar lessons adapted for Kubebar. [VERIFIED]
+- `.planning/phases/04-codexbar-inspired-menu-reliability-and-freshness/04-UAT.md`, `.planning/phases/05-expand-kubectl-data-into-actionable-warning-and-workload-reasons/05-UAT.md`, `.planning/phases/03-complete-first-use-setup-and-watchlist-editing/03-UAT.md` - existing UAT style and menu-bar automation limitations. [VERIFIED]
+
+### Tertiary (LOW confidence)
+
+- None used as authoritative input. [VERIFIED: source selection review]
+
+## Metadata
+
+**Confidence breakdown:**
+
+- Standard stack: HIGH - current repo manifests, local tool versions, and official SwiftUI docs agree. [VERIFIED: Package.swift; project.yml; local commands; Context7]
+- Architecture: HIGH - ownership is locked by AGENTS and architecture docs, and source matches the core/view split. [VERIFIED: AGENTS.md; docs/architecture/system-overview.md; current source]
+- Pitfalls: HIGH for truncation/status/model gaps because they are visible in source; MEDIUM for menu keyboard QA because no automated UI target exists. [VERIFIED: KubebarCore/Services/HealthEvaluator.swift; .planning/codebase/TESTING.md]
+- Security: MEDIUM - phase has low security scope, but tooltip/accessibility changes must avoid raw command output. [VERIFIED: .planning/codebase/CONCERNS.md; docs/architecture/runtime-invariants.md]
+
+**Research date:** 2026-04-21
+**Valid until:** 2026-05-21 for repo-local architecture; re-check Apple docs and local tool versions if planning starts after that date. [VERIFIED: current date and local command outputs]
+
+## RESEARCH COMPLETE

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-REVIEW.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-REVIEW.md
@@ -1,0 +1,54 @@
+---
+phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+reviewed: 2026-04-21T16:32:09Z
+depth: standard
+files_reviewed: 13
+files_reviewed_list:
+  - Kubebar/Views/MenuBarRootView.swift
+  - Kubebar/Views/NodeDetailsView.swift
+  - Kubebar/Views/SetupView.swift
+  - Kubebar/Views/StatusSummaryView.swift
+  - Kubebar/Views/TrackedItemDetailView.swift
+  - Kubebar/Views/WarningEventsView.swift
+  - Kubebar/Views/WatchlistPickerView.swift
+  - Kubebar/Views/WatchlistSectionView.swift
+  - KubebarCore/Models/MenuDisplayModel.swift
+  - KubebarCore/Services/HealthEvaluator.swift
+  - KubebarTests/Models/MenuBarStatusPresentationTests.swift
+  - KubebarTests/Models/MenuDisplayModelTests.swift
+  - docs/architecture/runtime-invariants.md
+findings:
+  critical: 0
+  warning: 0
+  info: 0
+  total: 0
+status: clean
+---
+
+# Phase 06: Code Review Report
+
+**Reviewed:** 2026-04-21T16:32:09Z
+**Depth:** standard
+**Files Reviewed:** 13
+**Status:** clean
+
+## Summary
+
+Reviewed current `HEAD` against `43b1b13` for Phase 06 / issue #6, scoped to menu bar icon states, opened-menu readability, long-name handling, keyboard reachability, and the prior review finding.
+
+The prior `WarningEventsView` finding is resolved. Its focus label now builds one combined summary that includes section notices and visible warning rows together before returning the accessibility label.
+
+All reviewed files meet quality standards. No issues found.
+
+## Verification
+
+- `./scripts/swift-quality-gate.sh local` passed.
+- Xcode build, Xcode test, SwiftPM build, and SwiftPM test passed.
+- Swift tests passed: 86 tests in 15 suites.
+- Existing CoreSimulator version warnings appeared during Xcode commands but did not block the macOS build or tests.
+
+---
+
+_Reviewed: 2026-04-21T16:32:09Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md
@@ -1,0 +1,78 @@
+---
+status: pending-human-verification
+phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+source:
+  - 06-01-SUMMARY.md
+  - 06-02-SUMMARY.md
+started: 2026-04-21T16:13:52Z
+updated: 2026-04-21T16:16:35Z
+---
+
+## Automated Verification
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| `swift test --filter MenuBarStatusPresentationTests` | pass | The Menu bar status presentation suite passed 1 test, covering the four menu bar status labels and icon sources. |
+| `swift test --filter MenuDisplayModelTests` | pass | The Menu display model suite passed 18 tests, including primary status reasons, stale state, warning summaries, watchlist caps, and full-name preservation. |
+| `swift build` | pass | SwiftPM debug build completed successfully. |
+| `./scripts/swift-quality-gate.sh local` | pass | Xcode build, Xcode test, SwiftPM build, and SwiftPM test passed; the full Swift test run reported 86 tests in 15 suites. The CoreSimulator version warning did not block the macOS checks. |
+| `./scripts/compile-and-run.sh` | pass | The visible-app smoke path rebuilt and tested the app, then launched `DerivedData/Build/Products/Debug/Kubebar.app` with PID 27388. |
+
+## Manual Menu State Checks
+
+| State | Status | Expected opened-menu behavior | Evidence |
+| --- | --- | --- | --- |
+| OK | pending-human-verification | Opened menu shows `OK` text, a visible symbol, one short reason, and no color-only meaning. | Requires visible menu inspection. Model tests cover deterministic OK state presentation. |
+| Watch | pending-human-verification | Opened menu shows `Watch` text, a visible symbol, one short reason, and no color-only meaning. | Requires visible menu inspection. Model tests cover deterministic Watch state reasons. |
+| Bad | pending-human-verification | Opened menu shows `Bad` text, a visible symbol, one short reason, and no color-only meaning. | Requires visible menu inspection. Model tests cover deterministic Bad state reasons. |
+| Stale | pending-human-verification | Opened menu shows `Stale` text, a visible symbol, one short reason, and no color-only meaning. | Requires visible menu inspection. Model tests cover deterministic Stale fallback reasons. |
+
+Decision mapping: these rows cover D-18 and D-19. If the live cluster cannot force every state, keep the unavailable state rows as `pending-human-verification` and rely on model tests for deterministic state coverage.
+
+## Manual Keyboard Checks
+
+Enable macOS Full Keyboard Access if Tab traversal skips buttons, pickers, toggles, disclosures, or other non-text controls. Record only app-owned names or redacted observations.
+
+| Path | Status | Expected behavior | Evidence |
+| --- | --- | --- | --- |
+| Setup screen | pending-human-verification | Keyboard traversal reaches setup header, context picker, watchlist picker, refresh cadence picker, and footer actions. | Requires visible menu keyboard traversal. |
+| Finish setup enabled | pending-human-verification | `Finish setup` is reachable and activatable when context and watchlist are configured. | Requires a configured setup state in the visible app. |
+| Finish setup disabled | pending-human-verification | Disabled `Finish setup` remains visible and skipped or announced as disabled by native navigation. | Requires an incomplete setup state in the visible app. |
+| Refresh enabled | pending-human-verification | `Retry now` is reachable and activatable when no refresh is running. | Requires visible menu keyboard traversal. |
+| Refresh disabled | pending-human-verification | Disabled refresh remains visible when refresh is in progress. | Requires a visible in-progress refresh state. |
+| Edit watchlist | pending-human-verification | `Edit watchlist` is reachable and opens setup/watchlist editing through native controls. | Requires visible menu keyboard traversal. |
+| Watchlist detail disclosure | pending-human-verification | Watchlist row disclosures are reachable and can expand/collapse details. | Requires a visible watchlist row. |
+| Warning events | pending-human-verification | Warning event rows or their empty/unavailable state are reachable after the watchlist. | Requires visible menu keyboard traversal. |
+| Node details or secondary sections | pending-human-verification | Node details or another secondary section remains reachable without disrupting watchlist-first order. | Requires visible menu keyboard traversal. |
+| Target-load retry | pending-human-verification | Target loading failure or empty-target retry is reachable and activatable from setup. | Requires a target-load retry state. |
+
+Decision mapping: these rows cover D-17, D-18, D-20, and R21.
+
+## Long Name Checks
+
+| Name type | Status | Expected result | Evidence |
+| --- | --- | --- | --- |
+| Context | pending-human-verification | Long context names use middle truncation that preserves beginning and end; the full value is present in hover help/accessibility. | Requires visible long context name inspection. |
+| Namespace | pending-human-verification | Long namespace names use middle truncation that preserves beginning and end; the full value is present in hover help/accessibility. | Requires visible long namespace name inspection. |
+| Workload | pending-human-verification | Long workload names use middle truncation that preserves beginning and end; the full value is present in hover help/accessibility. | Requires visible long workload name inspection. |
+| Warning summary | pending-human-verification | Long warning summary text uses middle truncation where one-line display is required; the full value is present in hover help/accessibility. | Requires visible warning summary inspection. |
+| Setup picker | pending-human-verification | Long setup picker names use middle truncation that preserves beginning and end; the full value is present in hover help/accessibility. | Requires visible setup picker inspection. |
+
+## Scope Guards
+
+| Guard | Result | Evidence |
+| --- | --- | --- |
+| No AppKit status-item rewrite | pass | Source review kept the existing SwiftUI `MenuBarExtra.window` path and did not add a custom status-item shell. |
+| No packaging or signing scope | pass | This phase added runtime docs and UAT only; no packaging, signing, or release workflow was added. |
+| No k9s handoff | pass | No deeper-debugging handoff action was added. |
+| No dashboard surface | pass | The UAT preserves the native utility menu boundary and does not introduce a dashboard surface. |
+| No command transcript exposure | pass | Runtime rules and UAT evidence require app-owned display strings or redacted observations only. |
+| No added menu automation stack | pass | This phase records manual keyboard verification rather than adding a new automation target. |
+
+## Computer Use Notes
+
+- The visible app smoke command launched Kubebar successfully.
+- Computer Use could not obtain an interactive app state for `com.nextty.kubebar`; it returned Apple event timeout `-10005`.
+- Computer Use could not obtain an interactive state for `SystemUIServer`; it returned Apple event timeout `-10005`.
+- Prior menu-bar extras may not be inspectable through automation; manual keyboard checks are the source of truth when automation cannot inspect SystemUIServer.
+- Manual evidence must avoid raw command transcripts, token-like strings, kubeconfig paths, or full JSON.

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-VALIDATION.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-VALIDATION.md
@@ -1,0 +1,75 @@
+---
+phase: 06
+slug: polish-menu-bar-icon-states-and-keyboard-navigation
+status: draft
+nyquist_compliant: true
+wave_0_complete: false
+created: 2026-04-21
+---
+
+# Phase 06 - Validation Strategy
+
+Per-phase validation contract for feedback sampling during execution.
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| Framework | Swift Testing via the Swift 6 toolchain |
+| Config file | `Package.swift` and `project.yml` |
+| Quick run command | `swift test --filter MenuBarStatusPresentationTests` for icon state work; `swift test --filter MenuDisplayModelTests` for display mapping and truncation work |
+| Full suite command | `./scripts/swift-quality-gate.sh local` |
+| Visible app smoke command | `./scripts/compile-and-run.sh` |
+| Estimated runtime | Focused tests under 30 seconds; full gate depends on local Xcode build time |
+
+## Sampling Rate
+
+- After every task commit: run the focused Swift test matching the touched area.
+- After every plan wave: run `swift test`.
+- Before `$gsd-verify-work`: `./scripts/swift-quality-gate.sh local` must pass.
+- Visible menu confidence: run `./scripts/compile-and-run.sh` before final UAT sign-off.
+- Max feedback latency: one focused test run per task.
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 06-01-01 | 01 | 1 | R1, R13 | T-06-01-01, T-06-01-02 | Four state icons and accessibility labels stay explicit, and opened-menu status has one reason | unit | `swift test --filter MenuBarStatusPresentationTests && swift test --filter MenuDisplayModelTests` | yes | pending |
+| 06-02-01 | 02 | 2 | R18, R19, R20 | T-06-02-01, T-06-02-02 | Long names preserve full values for tooltip/accessibility while visual rows use middle truncation | unit + source review | `swift test --filter MenuDisplayModelTests` | yes | pending |
+| 06-03-01 | 03 | 3 | R21 | T-06-03-01 | Native controls remain keyboard reachable and manual QA records the real menu traversal | manual QA + full gate | `./scripts/swift-quality-gate.sh local && ./scripts/compile-and-run.sh` | no Phase 06 UAT yet | pending |
+
+Status values: pending, green, red, flaky.
+
+## Wave 0 Requirements
+
+- Existing Swift Testing infrastructure covers model and presentation checks.
+- Add missing icon-source assertions in `KubebarTests/Models/MenuBarStatusPresentationTests.swift`.
+- Add `primaryStatusReason` and full-name preservation cases in `KubebarTests/Models/MenuDisplayModelTests.swift`.
+- Add `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` for four states, setup, edit watchlist, refresh enabled/disabled, disclosure groups, warning events, secondary sections, long-name tooltip/accessibility, and Full Keyboard Access.
+- No new test framework installation is needed.
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Real menu keyboard traversal reaches setup, refresh, edit watchlist, watchlist detail, warning events, and secondary sections | R21 | No dedicated UI automation target exists for the macOS menu bar extra | Run `./scripts/compile-and-run.sh`, enable Full Keyboard Access if needed, open Kubebar, and tab through all listed controls and expandable rows |
+| Opened menu keeps a native utility feel rather than card/dashboard layout | R18, R19 | The repo has no visual snapshot test target | Run `./scripts/compile-and-run.sh` and compare the opened menu against the `06-UAT.md` checklist |
+| Tooltip/accessibility full-name fallback is present for long context, namespace, workload, and warning names | R20 | Hover and assistive output are not covered by existing unit tests | Use long fixture/config names when possible; inspect hover help and accessibility labels during visible app QA |
+
+## Threat Model References
+
+- T-06-01-01 misleading healthy icon: `OK` uses the brand logo in the menu bar, so the opened menu must explicitly show `OK`.
+- T-06-01-02 color-only failure signal: `Watch`, `Bad`, and `Stale` must use symbol, status text, and one reason.
+- T-06-02-01 truncated-name ambiguity: tail-only truncation can hide Kubernetes suffix differences.
+- T-06-02-02 raw output disclosure: tooltip/accessibility full names must use app-owned context/resource names, not raw `kubectl` output.
+- T-06-03-01 mouse-only workflow: setup, refresh, edit, detail, warning, and secondary sections can work by mouse while failing keyboard traversal.
+
+## Validation Sign-Off
+
+- [x] All planned areas have an automated verify command or documented manual QA.
+- [x] Sampling continuity: no 3 consecutive tasks without automated verify or UAT.
+- [x] Existing Swift Testing infrastructure covers model-level phase behavior.
+- [x] No watch-mode flags.
+- [x] `nyquist_compliant: true` set in frontmatter.
+
+**Approval:** approved 2026-04-21

--- a/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-VERIFICATION.md
+++ b/.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-VERIFICATION.md
@@ -1,0 +1,151 @@
+---
+phase: 06-polish-menu-bar-icon-states-and-keyboard-navigation
+verified: 2026-04-21T16:36:54Z
+status: human_needed
+score: 6/6 must-haves verified
+overrides_applied: 0
+human_verification:
+  - test: "Opened menu state checks for OK, Watch, Bad, and Stale"
+    expected: "The opened menu shows state text, a visible symbol, one short reason, and no color-only meaning for each state that can be exercised live."
+    why_human: "The menu-bar extra could not be inspected reliably through automation; the UAT records Computer Use timeouts."
+  - test: "Keyboard traversal through the visible menu"
+    expected: "Full Keyboard Access can reach setup, Finish setup enabled and disabled, Retry now enabled and disabled, Edit watchlist, watchlist detail disclosures, warning events, secondary sections, and target-load retry."
+    why_human: "Native SwiftUI controls and shortcuts exist in source, but actual macOS menu focus traversal requires visible-app testing."
+  - test: "Long-name visual fallback checks"
+    expected: "Long context, namespace, workload, warning summary, and setup picker names use middle truncation and expose full values through hover help or accessibility."
+    why_human: "Source modifiers are present, but final visual truncation and assistive behavior depend on macOS rendering."
+  - test: "Menu reading comfort and scope guard check"
+    expected: "The first visible menu remains summary, stale signal, counters, watchlist, warning events, node details, refresh, and actions, without dashboard-style expansion."
+    why_human: "Visual reading comfort is a human-only judgment even when source order is verified."
+---
+
+# Phase 06: Polish Menu Bar Icon States and Keyboard Navigation Verification Report
+
+**Phase Goal:** Make the app readable from the menu bar and usable without a mouse.
+**Verified:** 2026-04-21T16:36:54Z
+**Status:** human_needed
+**Re-verification:** No - initial verification
+
+## Goal Achievement
+
+Automated and source-level verification passed. The phase cannot be marked `passed` because the visible macOS menu and keyboard traversal remain pending in `06-UAT.md`.
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|---|---|---|
+| 1 | The menu bar has exactly four categorical states, and OK uses the custom logo in the menu bar. | VERIFIED | `ClusterHealthState` has only `ok`, `watch`, `bad`, and `stale`; `MenuBarStatusPresentation` maps OK to `.custom("KubebarLogo")` and the other states to locked SF Symbols; `KubebarApp` renders `presentation.icon`. |
+| 2 | The opened menu renders state text, a visible symbol, and one reason. | VERIFIED (source), HUMAN NEEDED (visible menu) | `StatusSummaryView` renders `presentation.symbolName`, `display.state.label`, and `display.primaryStatusReason`; model tests cover OK, Watch, Bad, and Stale reason cases. Visible menu rows remain pending in UAT. |
+| 3 | Long names preserve full values and use middle truncation with fallback text. | VERIFIED (source), HUMAN NEEDED (visual/accessibility) | `HealthEvaluator` stores `item.target.displayTitle` as `WatchItemDisplay.title`; summary, watchlist, detail, warning, setup, and picker views use `.lineLimit(1)`, `.truncationMode(.middle)`, `.help(Text(...))`, and `.accessibilityLabel(...)`. |
+| 4 | Keyboard reachability uses native controls and focusable sections. | VERIFIED (source), HUMAN NEEDED (real traversal) | Refresh, edit, setup completion, target retry, toggles, pickers, and disclosure groups are native SwiftUI controls with standard shortcuts where planned. UAT keeps real traversal pending. |
+| 5 | UAT captures remaining human-only checks honestly. | VERIFIED | `06-UAT.md` is `pending-human-verification`, lists OK/Watch/Bad/Stale, keyboard paths, long-name checks, Full Keyboard Access guidance, and Computer Use inspection limits. |
+| 6 | No Phase 06 scope creep into AppKit status item work, dashboard, k9s handoff, distribution, notarization, or new UI automation. | VERIFIED | Scope scan of Phase 06 source files found no `NSStatusItem`, `NSMenu`, `Open in k9s`, packaging/signing work, dashboard feature, custom key handling, or new menu automation stack. |
+
+**Score:** 6/6 source and automated must-haves verified; human menu traversal still required.
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|---|---|---|---|
+| `KubebarCore/Models/MenuBarStatusPresentation.swift` | Four-state icon and accessibility presentation | VERIFIED | OK maps to `KubebarLogo`; Watch/Bad/Stale map to the locked SF Symbols; accessibility labels are tested. |
+| `KubebarCore/Models/MenuDisplayModel.swift` | Core display model exposes `primaryStatusReason` | VERIFIED | Field and initializer default are present and consumed by views. |
+| `KubebarCore/Services/HealthEvaluator.swift` | Core computes one reason and preserves full watch titles | VERIFIED | `primaryStatusReason(for:...)` selects one reason; `makeDisplayItem` uses `item.target.displayTitle`. |
+| `Kubebar/Views/StatusSummaryView.swift` | Opened menu status summary | VERIFIED | Renders context, symbol, state label, and primary reason, with middle truncation and accessibility label. |
+| `Kubebar/Views/MenuBarRootView.swift` | Watchlist-first order and native refresh/edit actions | VERIFIED | Order is summary, stale signal, counters, watchlist, warning events, node details, refresh, actions; buttons include shortcuts/help. |
+| `Kubebar/Views/WatchlistSectionView.swift` | One-line watchlist rows and disclosure details | VERIFIED | Rows use native `DisclosureGroup`; titles use middle truncation and full help/accessibility fallback. |
+| `Kubebar/Views/TrackedItemDetailView.swift` | Detail text preserves full fallback where needed | VERIFIED | Examples, latest warning summary, and warning message include help/accessibility. |
+| `Kubebar/Views/WarningEventsView.swift` | Warning section long-name fallback | VERIFIED | Section notices and warning summaries use middle truncation/help/accessibility; combined accessibility summary includes notices and rows. |
+| `Kubebar/Views/SetupView.swift` | Setup controls remain native and keyboard reachable | VERIFIED | Context and cadence are native pickers; Finish setup has default keyboard action and disabled state. |
+| `Kubebar/Views/WatchlistPickerView.swift` | Edit watchlist controls remain native | VERIFIED | Namespace/workload choices use native toggles; workloads use `DisclosureGroup`; target retry has shortcut/help. |
+| `docs/architecture/runtime-invariants.md` | Phase 06 runtime rules documented | VERIFIED | Documents OK logo/opened OK text, symbol/text/reason, middle truncation, full fallback, and keyboard rules. |
+| `.planning/phases/06-polish-menu-bar-icon-states-and-keyboard-navigation/06-UAT.md` | Automated and manual UAT evidence | VERIFIED | Automated checks are recorded as pass; manual menu, keyboard, and long-name checks remain explicitly pending. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|---|---|---|---|---|
+| `HealthEvaluator` | `MenuDisplayModel.primaryStatusReason` | `MenuDisplayModel(... primaryStatusReason: ...)` | WIRED | Reason is computed in core and passed into the display model. |
+| `MenuDisplayModel.primaryStatusReason` | `StatusSummaryView` | `Text(display.primaryStatusReason)` | WIRED | SwiftUI renders the core-owned reason without deriving severity. |
+| `MenuBarStatusPresentation.icon` | menu bar label | `KubebarApp` switch over `presentation.icon` | WIRED | OK uses custom image; other states use SF Symbol labels. |
+| `WatchTarget.displayTitle` | watchlist row title | `WatchItemDisplay.title` then `Text(item.title)` | WIRED | Full names flow from core into view-level middle truncation and fallback text. |
+| `MenuBarRootView` | native menu shell | existing `MenuBarExtra(...).menuBarExtraStyle(.window)` | WIRED | No AppKit status item rewrite was introduced. |
+| `06-UAT.md` | remaining manual checks | pending-human-verification rows | WIRED | UAT maps D-17, D-18, D-19, D-20, and R21 to exact manual checks. |
+
+### Data-Flow Trace (Level 4)
+
+| Artifact | Data Variable | Source | Produces Real Data | Status |
+|---|---|---|---|---|
+| `StatusSummaryView` | `display.primaryStatusReason` | `MenuBarViewModel.display` populated by `HealthEvaluator` / `RefreshCoordinator` | Yes | FLOWING |
+| `KubebarApp` menu label | `viewModel.display.state` | `MenuBarViewModel.display`, initialized and refreshed from app config / cluster reads | Yes | FLOWING |
+| `WatchlistSectionView` | `display.visibleWatchItems` | `HealthEvaluator.makeDisplayItem` from snapshot tracked item data | Yes | FLOWING |
+| `WarningEventsView` | `display.warningEventSummaries` and `display.sectionNotices` | `HealthEvaluator` from warning event section and section failures | Yes | FLOWING |
+| `SetupView` / `WatchlistPickerView` | `setupState` and available targets | `MenuBarViewModel.runtimeState`, context catalog, and watch target catalog | Yes | FLOWING |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|---|---|---|---|
+| Four icon-state presentation tests | `swift test --filter MenuBarStatusPresentationTests` | 1 Swift Testing test passed | PASS |
+| Display model status/truncation tests | `swift test --filter MenuDisplayModelTests` | 18 Swift Testing tests passed | PASS |
+| SwiftPM build | `swift build` | Build completed successfully | PASS |
+| Full repo gate | `./scripts/swift-quality-gate.sh local` | Xcode build/test and SwiftPM build/test passed; 86 tests in 15 suites passed. CoreSimulator version warning was non-blocking. | PASS |
+| Visible app smoke | `./scripts/compile-and-run.sh` | Not rerun by verifier to avoid launching/killing the visible app; UAT records a prior pass and still leaves menu traversal pending. | SKIPPED |
+
+### Requirements Coverage
+
+`gsd-sdk` and `.planning/REQUIREMENTS.md` are not available in this checkout, so requirement coverage was mapped from plan frontmatter and `docs/brainstorms/2026-04-19-kubebar-watchlist-first-requirements.md`.
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|---|---|---|---|---|
+| R1 | 06-01, 06-03 | Menu bar icon communicates OK, Watch, Bad, or Stale | VERIFIED | Four-state enum, presentation mapping, app label wiring, and tests. |
+| R13 | 06-01, 06-02, 06-03 | Warning/failure states do not rely on color alone | VERIFIED (source), HUMAN NEEDED (visible menu) | Opened menu renders symbol, state text, and reason; UAT leaves live state inspection pending. |
+| R18 | 06-02, 06-03 | Dropdown remains disciplined menu utility, not dashboard | VERIFIED (source), HUMAN NEEDED (visual feel) | Main menu order is preserved and no dashboard feature was added; visual judgment remains manual. |
+| R19 | 06-02, 06-03 | First screen prioritizes typography, ordering, and spacing | VERIFIED (source), HUMAN NEEDED (visual feel) | Source order and compact section structure are intact; final readability remains manual. |
+| R20 | 06-01, 06-02, 06-03 | Long object names truncate consistently | VERIFIED (source), HUMAN NEEDED (visual/accessibility) | Full names preserved in core and middle truncation/help/accessibility modifiers are present in views. |
+| R21 | 06-02, 06-03 | Keyboard navigation works across top-level rows and submenus | VERIFIED (source), HUMAN NEEDED (real traversal) | Native controls/shortcuts exist; UAT lists exact Full Keyboard Access traversal checks still pending. |
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|---|---|---|---|---|
+| None | - | No blocking stub, placeholder, custom key-handler, AppKit status item, k9s handoff, distribution/notarization, or dashboard feature found in Phase 06 source files. | - | - |
+
+Notes:
+- Default `nil` and empty-array initializer values in model constructors are source-compatible defaults, not user-visible stubs.
+- No-op closure defaults in SwiftUI view initializers are preview/test convenience defaults, not runtime handler stubs; `KubebarApp` wires real handlers.
+- `WatchlistPickerView` uses card-named private grouping helpers for setup/edit content, but no dashboard route, dashboard action, or dashboard surface was introduced, and the primary menu root remains uncarded and watchlist-first.
+
+### Human Verification Required
+
+#### 1. Opened Menu State Checks
+
+**Test:** Launch the app, open the Kubebar menu, and verify OK, Watch, Bad, and Stale when each state can be exercised live.
+**Expected:** State text, visible symbol, and one short reason are present; color is not the only meaning.
+**Why human:** Automation could not inspect the menu-bar extra reliably.
+
+#### 2. Keyboard Traversal
+
+**Test:** Enable macOS Full Keyboard Access if needed, then traverse setup, Finish setup enabled/disabled, Retry now enabled/disabled, Edit watchlist, watchlist detail disclosures, warning events, secondary sections, and target-load retry.
+**Expected:** Each path is reachable and usable through native keyboard navigation.
+**Why human:** Source proves native controls exist; actual macOS menu focus behavior requires visible-app testing.
+
+#### 3. Long-Name Rendering
+
+**Test:** Use long context, namespace, workload, warning summary, and setup picker names.
+**Expected:** Visible text uses middle truncation that preserves beginning and end, with full value available through hover help or accessibility.
+**Why human:** Rendering and assistive exposure depend on live macOS behavior.
+
+#### 4. Visual Reading Comfort
+
+**Test:** Inspect the first visible menu.
+**Expected:** It remains ordered as summary, stale signal, counters, watchlist, warning events, node details, refresh, and actions, without feeling like a dashboard.
+**Why human:** Reading comfort and visual scope are judgment-based.
+
+### Gaps Summary
+
+No code or documentation gaps were found. The remaining work is human verification of the visible menu and keyboard traversal already documented in `06-UAT.md`.
+
+---
+
+_Verified: 2026-04-21T16:36:54Z_
+_Verifier: Codex (gsd-verifier)_

--- a/Kubebar/Views/MenuBarRootView.swift
+++ b/Kubebar/Views/MenuBarRootView.swift
@@ -77,9 +77,13 @@ struct MenuBarRootView: View {
     private var actions: some View {
         HStack {
             Button("Retry now", action: onRefresh)
+                .keyboardShortcut("r", modifiers: .command)
+                .help(Text(isRefreshing ? "Refresh in progress" : "Refresh now"))
                 .disabled(isRefreshing)
             Spacer()
             Button("Edit watchlist", action: onEditWatchlist)
+                .keyboardShortcut("e", modifiers: .command)
+                .help(Text("Edit watchlist"))
         }
     }
 

--- a/Kubebar/Views/NodeDetailsView.swift
+++ b/Kubebar/Views/NodeDetailsView.swift
@@ -13,5 +13,8 @@ struct NodeDetailsView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Node details, \(summary) nodes ready")
+        .focusable()
     }
 }

--- a/Kubebar/Views/SetupView.swift
+++ b/Kubebar/Views/SetupView.swift
@@ -64,7 +64,12 @@ struct SetupView: View {
                 Picker("Cluster context", selection: selectedContextBinding) {
                     Text("Select a context").tag(Optional<String>.none)
                     ForEach(state.availableContexts, id: \.self) { context in
-                        Text(context).tag(Optional(context))
+                        Text(context)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .help(Text(context))
+                            .accessibilityLabel(context)
+                            .tag(Optional(context))
                     }
                 }
                 .pickerStyle(.menu)

--- a/Kubebar/Views/SetupView.swift
+++ b/Kubebar/Views/SetupView.swift
@@ -119,6 +119,7 @@ struct SetupView: View {
 
             Button("Finish setup", action: onComplete)
                 .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
                 .disabled(!state.isConfigured)
         }
     }

--- a/Kubebar/Views/StatusSummaryView.swift
+++ b/Kubebar/Views/StatusSummaryView.swift
@@ -4,22 +4,30 @@ import KubebarCore
 struct StatusSummaryView: View {
     let display: MenuDisplayModel
 
+    private var presentation: MenuBarStatusPresentation {
+        MenuBarStatusPresentation(state: display.state)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text(display.contextName)
-                    .font(.headline)
-                    .lineLimit(1)
+            Text(display.contextName)
+                .font(.headline)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .help(Text(display.contextName))
+                .accessibilityLabel(display.contextName)
 
-                Spacer()
-
+            HStack(spacing: 6) {
+                Image(systemName: presentation.symbolName)
                 Text(display.state.label)
-                    .font(.caption.weight(.semibold))
+                    .fontWeight(.semibold)
+                Text(display.primaryStatusReason)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
-
-            Text(display.healthSentence)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+            .font(.subheadline)
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(presentation.accessibilityLabel), \(display.primaryStatusReason), context \(display.contextName)")
     }
 }

--- a/Kubebar/Views/TrackedItemDetailView.swift
+++ b/Kubebar/Views/TrackedItemDetailView.swift
@@ -14,15 +14,27 @@ struct TrackedItemDetailView: View {
             }
 
             if !item.detail.examplePodNames.isEmpty {
-                Text("Examples: \(item.detail.examplePodNames.joined(separator: ", "))")
+                let examples = "Examples: \(item.detail.examplePodNames.joined(separator: ", "))"
+                Text(examples)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(Text(examples))
+                    .accessibilityLabel(examples)
             }
 
             if let latestWarning = item.detail.latestWarning {
-                Text("Latest warning: \(latestWarning.summary)")
+                let latestWarningSummary = "Latest warning: \(latestWarning.summary)"
+                Text(latestWarningSummary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(Text(latestWarningSummary))
+                    .accessibilityLabel(latestWarningSummary)
 
                 if let message = latestWarning.message {
                     Text(message)
                         .lineLimit(2)
+                        .help(Text(message))
+                        .accessibilityLabel(message)
                 }
             }
         }

--- a/Kubebar/Views/WarningEventsView.swift
+++ b/Kubebar/Views/WarningEventsView.swift
@@ -13,9 +13,14 @@ struct WarningEventsView: View {
                 .foregroundStyle(.secondary)
 
             ForEach(sectionNotices) { notice in
-                Text("\(notice.title) unavailable: \(notice.reason)")
+                let noticeText = "\(notice.title) unavailable: \(notice.reason)"
+                Text(noticeText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(Text(noticeText))
+                    .accessibilityLabel(noticeText)
             }
 
             if summaries.isEmpty {
@@ -27,10 +32,15 @@ struct WarningEventsView: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(summary.summary)
                             .lineLimit(1)
+                            .truncationMode(.middle)
+                            .help(Text(summary.summary))
+                            .accessibilityLabel(summary.summary)
 
                         if let message = summary.message {
                             Text(message)
                                 .lineLimit(2)
+                                .help(Text(message))
+                                .accessibilityLabel(message)
                         }
                     }
                     .font(.caption)

--- a/Kubebar/Views/WarningEventsView.swift
+++ b/Kubebar/Views/WarningEventsView.swift
@@ -23,8 +23,8 @@ struct WarningEventsView: View {
                     .accessibilityLabel(noticeText)
             }
 
-            if summaries.isEmpty {
-                Text(count == "0" ? "No current warning events" : "\(count) warning events need review")
+            if summaries.isEmpty, let emptySummaryText {
+                Text(emptySummaryText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } else {
@@ -48,9 +48,22 @@ struct WarningEventsView: View {
                 }
             }
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilitySummary)
         .focusable()
+    }
+
+    private var emptySummaryText: String? {
+        switch count {
+        case "0":
+            return "No current warning events"
+        case "1":
+            return "1 warning event needs review"
+        case "-":
+            return sectionNotices.isEmpty ? "Warning event count unavailable" : nil
+        default:
+            return "\(count) warning events need review"
+        }
     }
 
     private var accessibilitySummary: String {
@@ -58,8 +71,9 @@ struct WarningEventsView: View {
         parts += sectionNotices.map { "\($0.title) unavailable: \($0.reason)" }
 
         if summaries.isEmpty {
-            let text = count == "0" ? "No current warning events" : "\(count) warning events need review"
-            parts.append(text)
+            if let emptySummaryText {
+                parts.append(emptySummaryText)
+            }
             return parts.joined(separator: ", ")
         }
 

--- a/Kubebar/Views/WarningEventsView.swift
+++ b/Kubebar/Views/WarningEventsView.swift
@@ -54,22 +54,21 @@ struct WarningEventsView: View {
     }
 
     private var accessibilitySummary: String {
-        if !sectionNotices.isEmpty {
-            let notices = sectionNotices.map { "\($0.title) unavailable: \($0.reason)" }
-            return (["Warning events"] + notices).joined(separator: ", ")
-        }
+        var parts = ["Warning events"]
+        parts += sectionNotices.map { "\($0.title) unavailable: \($0.reason)" }
 
         if summaries.isEmpty {
             let text = count == "0" ? "No current warning events" : "\(count) warning events need review"
-            return "Warning events, \(text)"
+            parts.append(text)
+            return parts.joined(separator: ", ")
         }
 
-        let rows = summaries.map { summary in
+        parts += summaries.map { summary in
             if let message = summary.message {
                 return "\(summary.summary), \(message)"
             }
             return summary.summary
         }
-        return (["Warning events"] + rows).joined(separator: ", ")
+        return parts.joined(separator: ", ")
     }
 }

--- a/Kubebar/Views/WarningEventsView.swift
+++ b/Kubebar/Views/WarningEventsView.swift
@@ -48,5 +48,28 @@ struct WarningEventsView: View {
                 }
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilitySummary)
+        .focusable()
+    }
+
+    private var accessibilitySummary: String {
+        if !sectionNotices.isEmpty {
+            let notices = sectionNotices.map { "\($0.title) unavailable: \($0.reason)" }
+            return (["Warning events"] + notices).joined(separator: ", ")
+        }
+
+        if summaries.isEmpty {
+            let text = count == "0" ? "No current warning events" : "\(count) warning events need review"
+            return "Warning events, \(text)"
+        }
+
+        let rows = summaries.map { summary in
+            if let message = summary.message {
+                return "\(summary.summary), \(message)"
+            }
+            return summary.summary
+        }
+        return (["Warning events"] + rows).joined(separator: ", ")
     }
 }

--- a/Kubebar/Views/WatchlistPickerView.swift
+++ b/Kubebar/Views/WatchlistPickerView.swift
@@ -84,23 +84,26 @@ struct WatchlistPickerView: View {
             hasItems: !state.availableWorkloads.isEmpty
         ) {
             ForEach(groupedWorkloads, id: \.key) { group in
-                DisclosureGroup {
-                    ForEach(group.value, id: \.self) { workload in
-                        Toggle(isOn: binding(for: workload.target)) {
-                            Text(workload.displayTitle)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                                .help(Text(workload.displayTitle))
-                                .accessibilityLabel(workload.displayTitle)
+                DisclosureGroup(
+                    content: {
+                        ForEach(group.value, id: \.self) { workload in
+                            Toggle(isOn: binding(for: workload.target)) {
+                                Text(workload.displayTitle)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                    .help(Text(workload.displayTitle))
+                                    .accessibilityLabel(workload.displayTitle)
+                            }
                         }
+                    },
+                    label: {
+                        Text(group.key)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .help(Text(group.key))
+                            .accessibilityLabel(group.key)
                     }
-                } label: {
-                    Text(group.key)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .help(Text(group.key))
-                        .accessibilityLabel(group.key)
-                }
+                )
             }
         }
     }
@@ -129,6 +132,8 @@ struct WatchlistPickerView: View {
                     .foregroundStyle(.secondary)
 
                 Button("Retry", action: onRetryTargets)
+                    .keyboardShortcut("r", modifiers: .command)
+                    .help(Text("Retry loading watch targets"))
             }
         }
     }
@@ -144,6 +149,8 @@ struct WatchlistPickerView: View {
                     .foregroundStyle(.secondary)
 
                 Button("Retry", action: onRetryTargets)
+                    .keyboardShortcut("r", modifiers: .command)
+                    .help(Text("Retry loading watch targets"))
             }
         }
     }

--- a/Kubebar/Views/WatchlistPickerView.swift
+++ b/Kubebar/Views/WatchlistPickerView.swift
@@ -65,10 +65,13 @@ struct WatchlistPickerView: View {
             hasItems: !state.availableNamespaces.isEmpty
         ) {
             ForEach(state.availableNamespaces, id: \.self) { namespace in
-                Toggle(
-                    namespace,
-                    isOn: binding(for: .namespace(namespace))
-                )
+                Toggle(isOn: binding(for: .namespace(namespace))) {
+                    Text(namespace)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .help(Text(namespace))
+                        .accessibilityLabel(namespace)
+                }
             }
         }
     }
@@ -81,13 +84,22 @@ struct WatchlistPickerView: View {
             hasItems: !state.availableWorkloads.isEmpty
         ) {
             ForEach(groupedWorkloads, id: \.key) { group in
-                DisclosureGroup(group.key) {
+                DisclosureGroup {
                     ForEach(group.value, id: \.self) { workload in
-                        Toggle(
-                            workload.displayTitle,
-                            isOn: binding(for: workload.target)
-                        )
+                        Toggle(isOn: binding(for: workload.target)) {
+                            Text(workload.displayTitle)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .help(Text(workload.displayTitle))
+                                .accessibilityLabel(workload.displayTitle)
+                        }
                     }
+                } label: {
+                    Text(group.key)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .help(Text(group.key))
+                        .accessibilityLabel(group.key)
                 }
             }
         }

--- a/Kubebar/Views/WatchlistSectionView.swift
+++ b/Kubebar/Views/WatchlistSectionView.swift
@@ -41,6 +41,9 @@ private struct WatchlistRowView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.title)
                     .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(Text(item.title))
+                    .accessibilityLabel(item.title)
                 Text(item.reason)
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/Kubebar/Views/WatchlistSectionView.swift
+++ b/Kubebar/Views/WatchlistSectionView.swift
@@ -16,11 +16,14 @@ struct WatchlistSectionView: View {
                     .foregroundStyle(.secondary)
             } else {
                 ForEach(display.visibleWatchItems) { item in
-                    DisclosureGroup {
-                        TrackedItemDetailView(item: item)
-                    } label: {
-                        WatchlistRowView(item: item)
-                    }
+                    DisclosureGroup(
+                        content: {
+                            TrackedItemDetailView(item: item)
+                        },
+                        label: {
+                            WatchlistRowView(item: item)
+                        }
+                    )
                 }
             }
 

--- a/KubebarCore/Models/MenuDisplayModel.swift
+++ b/KubebarCore/Models/MenuDisplayModel.swift
@@ -104,6 +104,7 @@ public struct MenuDisplayModel: Equatable, Sendable {
     public let state: ClusterHealthState
     public let contextName: String
     public let healthSentence: String
+    public let primaryStatusReason: String
     public let lastUpdated: String
     public let counters: MenuCounters
     public let warningEventSummaries: [WarningEventDisplay]
@@ -116,6 +117,7 @@ public struct MenuDisplayModel: Equatable, Sendable {
         state: ClusterHealthState,
         contextName: String,
         healthSentence: String,
+        primaryStatusReason: String? = nil,
         lastUpdated: String,
         counters: MenuCounters,
         visibleWatchItems: [WatchItemDisplay],
@@ -127,6 +129,7 @@ public struct MenuDisplayModel: Equatable, Sendable {
         self.state = state
         self.contextName = contextName
         self.healthSentence = healthSentence
+        self.primaryStatusReason = primaryStatusReason ?? healthSentence
         self.lastUpdated = lastUpdated
         self.counters = counters
         self.warningEventSummaries = warningEventSummaries

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -78,10 +78,10 @@ public struct HealthEvaluator: Sendable {
             state: resolvedState,
             contextName: snapshot.contextName,
             healthSentence: healthSentence(for: resolvedState, visibleItems: visibleItems),
-            primaryStatusReason: primaryStatusReason(for: resolvedState, snapshot: snapshot, visibleItems: Array(visibleItems), warningEventSummaries: warningEventSummaries, sectionNotices: sectionNotices, staleReason: staleReason),
+            primaryStatusReason: primaryStatusReason(for: resolvedState, snapshot: snapshot, visibleItems: visibleItems, sectionNotices: sectionNotices, staleReason: staleReason),
             lastUpdated: lastUpdated,
             counters: menuCounters(from: snapshot),
-            visibleWatchItems: Array(visibleItems),
+            visibleWatchItems: visibleItems,
             hiddenWatchItemCount: hiddenCount,
             staleBanner: staleBanner(
                 for: resolvedState,
@@ -265,7 +265,7 @@ public struct HealthEvaluator: Sendable {
         }
     }
 
-    private func primaryStatusReason(for state: ClusterHealthState, snapshot: ClusterSnapshot, visibleItems: [WatchItemDisplay], warningEventSummaries: [WarningEventDisplay], sectionNotices: [SectionAvailabilityDisplay], staleReason: String?) -> String {
+    private func primaryStatusReason(for state: ClusterHealthState, snapshot: ClusterSnapshot, visibleItems: [WatchItemDisplay], sectionNotices: [SectionAvailabilityDisplay], staleReason: String?) -> String {
         switch state {
         case .ok:
             return "Cluster looks healthy"
@@ -275,11 +275,11 @@ public struct HealthEvaluator: Sendable {
             }
 
             if let nodeDeficit = nodeDeficit(from: snapshot), nodeDeficit > 0 {
-                return "\(nodeDeficit) nodes not ready"
+                return countLabel(nodeDeficit, singular: "node", plural: "nodes", suffix: "not ready")
             }
 
             if let podDeficit = podDeficit(from: snapshot), podDeficit > 0 {
-                return "\(podDeficit) pods not running"
+                return countLabel(podDeficit, singular: "pod", plural: "pods", suffix: "not running")
             }
 
             return "Cluster needs attention"
@@ -293,17 +293,23 @@ public struct HealthEvaluator: Sendable {
             }
 
             if snapshot.warningEventCount > 0 {
-                return "\(snapshot.warningEventCount) warning events"
+                return countLabel(snapshot.warningEventCount, singular: "warning event", plural: "warning events")
             }
 
             if let podDeficit = podDeficit(from: snapshot), podDeficit > 0 {
-                return "\(podDeficit) pods not running"
+                return countLabel(podDeficit, singular: "pod", plural: "pods", suffix: "not running")
             }
 
             return "Cluster has warnings"
         case .stale:
             return staleReason ?? "Last cluster status is stale"
         }
+    }
+
+    private func countLabel(_ count: Int, singular: String, plural: String, suffix: String? = nil) -> String {
+        let noun = count == 1 ? singular : plural
+        let suffixText = suffix.map { " \($0)" } ?? ""
+        return "\(count) \(noun)\(suffixText)"
     }
 
     private func nodeDeficit(from snapshot: ClusterSnapshot) -> Int? {

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -48,6 +48,7 @@ public struct HealthEvaluator: Sendable {
             state: .stale,
             contextName: "Not configured",
             healthSentence: "Cluster status is unavailable",
+            primaryStatusReason: failure?.reason ?? "No previous cluster data",
             lastUpdated: "never",
             counters: MenuCounters(nodes: "-", pods: "-", warningEvents: "-"),
             visibleWatchItems: [],
@@ -70,12 +71,14 @@ public struct HealthEvaluator: Sendable {
         let resolvedState = stateOverride ?? (freshnessReason == nil ? evaluateState(snapshot) : .stale)
         let warningEventSummaries = makeWarningEventSummaries(from: snapshot.warningEventsSection.value ?? [], now: now)
         let sectionNotices = makeSectionNotices(from: snapshot.sectionFailures)
+        let staleReason = failureReason ?? freshnessReason
         let lastUpdated = relativeAge(from: snapshot.capturedAt, to: now)
 
         return MenuDisplayModel(
             state: resolvedState,
             contextName: snapshot.contextName,
             healthSentence: healthSentence(for: resolvedState, visibleItems: visibleItems),
+            primaryStatusReason: primaryStatusReason(for: resolvedState, snapshot: snapshot, visibleItems: Array(visibleItems), warningEventSummaries: warningEventSummaries, sectionNotices: sectionNotices, staleReason: staleReason),
             lastUpdated: lastUpdated,
             counters: menuCounters(from: snapshot),
             visibleWatchItems: Array(visibleItems),
@@ -83,7 +86,7 @@ public struct HealthEvaluator: Sendable {
             staleBanner: staleBanner(
                 for: resolvedState,
                 snapshot: snapshot,
-                failureReason: failureReason ?? freshnessReason,
+                failureReason: staleReason,
                 now: now
             ),
             warningEventSummaries: warningEventSummaries,
@@ -260,6 +263,55 @@ public struct HealthEvaluator: Sendable {
         case .stale:
             return "Last cluster status is stale"
         }
+    }
+
+    private func primaryStatusReason(for state: ClusterHealthState, snapshot: ClusterSnapshot, visibleItems: [WatchItemDisplay], warningEventSummaries: [WarningEventDisplay], sectionNotices: [SectionAvailabilityDisplay], staleReason: String?) -> String {
+        switch state {
+        case .ok:
+            return "Cluster looks healthy"
+        case .bad:
+            if let reason = visibleItems.first(where: { $0.state == .bad })?.reason {
+                return reason
+            }
+
+            if let nodeDeficit = nodeDeficit(from: snapshot), nodeDeficit > 0 {
+                return "\(nodeDeficit) nodes not ready"
+            }
+
+            if let podDeficit = podDeficit(from: snapshot), podDeficit > 0 {
+                return "\(podDeficit) pods not running"
+            }
+
+            return "Cluster needs attention"
+        case .watch:
+            if let reason = visibleItems.first(where: { $0.state == .watch })?.reason {
+                return reason
+            }
+
+            if let sectionReason = sectionNotices.first?.reason {
+                return sectionReason
+            }
+
+            if snapshot.warningEventCount > 0 {
+                return "\(snapshot.warningEventCount) warning events"
+            }
+
+            if let podDeficit = podDeficit(from: snapshot), podDeficit > 0 {
+                return "\(podDeficit) pods not running"
+            }
+
+            return "Cluster has warnings"
+        case .stale:
+            return staleReason ?? "Last cluster status is stale"
+        }
+    }
+
+    private func nodeDeficit(from snapshot: ClusterSnapshot) -> Int? {
+        snapshot.nodesSection.value.map { max(0, $0.total - $0.ready) }
+    }
+
+    private func podDeficit(from snapshot: ClusterSnapshot) -> Int? {
+        snapshot.podsSection.value.map { max(0, $0.total - $0.running) }
     }
 
     private func staleBanner(

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -154,7 +154,7 @@ public struct HealthEvaluator: Sendable {
     private func makeDisplayItem(_ item: TrackedItemStatus, now: Date) -> WatchItemDisplay {
         WatchItemDisplay(
             id: item.target.displayTitle,
-            title: shortened(item.target.displayTitle),
+            title: item.target.displayTitle,
             state: item.state,
             reason: item.reason,
             detail: WatchItemDetailDisplay(
@@ -343,14 +343,6 @@ public struct HealthEvaluator: Sendable {
         }
 
         return "\(minutes / 60)h ago"
-    }
-
-    private func shortened(_ value: String, limit: Int = 42) -> String {
-        guard value.count > limit else {
-            return value
-        }
-
-        return String(value.prefix(limit - 1)) + "…"
     }
 
     private func shortenedWarningMessage(_ value: String?) -> String? {

--- a/KubebarTests/Models/MenuBarStatusPresentationTests.swift
+++ b/KubebarTests/Models/MenuBarStatusPresentationTests.swift
@@ -5,6 +5,11 @@ import Testing
 struct MenuBarStatusPresentationTests {
     @Test("maps health states to distinct symbols and labels")
     func mapsHealthStatesToDistinctSymbolsAndLabels() {
+        #expect(MenuBarStatusPresentation(state: .ok).icon == .custom("KubebarLogo"))
+        #expect(MenuBarStatusPresentation(state: .watch).icon == .system("exclamationmark.triangle"))
+        #expect(MenuBarStatusPresentation(state: .bad).icon == .system("xmark.octagon"))
+        #expect(MenuBarStatusPresentation(state: .stale).icon == .system("clock.badge.exclamationmark"))
+
         #expect(MenuBarStatusPresentation(state: .ok).symbolName == "checkmark.circle")
         #expect(MenuBarStatusPresentation(state: .watch).symbolName == "exclamationmark.triangle")
         #expect(MenuBarStatusPresentation(state: .bad).symbolName == "xmark.octagon")

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -25,6 +25,7 @@ struct MenuDisplayModelTests {
         #expect(display.counters.pods == "12/12")
         #expect(display.counters.warningEvents == "0")
         #expect(display.healthSentence == "Cluster looks healthy")
+        #expect(display.primaryStatusReason == "Cluster looks healthy")
         #expect(display.lastUpdated == "20s ago")
     }
 
@@ -48,6 +49,26 @@ struct MenuDisplayModelTests {
         #expect(display.visibleWatchItems.first?.title == "api/checkout")
         #expect(display.visibleWatchItems.first?.reason == "1 pod pending")
         #expect(display.healthSentence == "api/checkout needs attention")
+        #expect(display.primaryStatusReason == "1 pod pending")
+    }
+
+    @Test("warning events provide primary status reason")
+    func warningEventsProvidePrimaryStatusReason() {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 12, total: 12)),
+            warningEventsSection: .available([
+                warningEvent(reason: "BackOff", observedAt: Date(timeIntervalSince1970: 100), count: 2)
+            ]),
+            workloadsSection: .available([]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+
+        #expect(display.state == .watch)
+        #expect(display.primaryStatusReason == "2 warning events")
     }
 
     @Test("first screen caps watchlist and reports overflow")
@@ -117,6 +138,7 @@ struct MenuDisplayModelTests {
         #expect(display.lastUpdated == "2m ago")
         #expect(display.staleBanner?.lastUpdated == "2m ago")
         #expect(display.staleBanner?.reason == "kubectl timed out")
+        #expect(display.primaryStatusReason == "kubectl timed out")
         #expect(display.visibleWatchItems.first?.title == "api/checkout")
     }
 
@@ -310,6 +332,7 @@ struct MenuDisplayModelTests {
 
         #expect(display.counters.warningEvents == "-")
         #expect(display.state == .watch)
+        #expect(display.primaryStatusReason == "invalid event JSON")
         #expect(display.sectionNotices.contains { $0.title == "Warning events" && $0.reason == "invalid event JSON" })
     }
 

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -198,6 +198,7 @@ struct MenuDisplayModelTests {
         #expect(display.visibleWatchItems.first?.title == "api/checkout")
         #expect(display.lastUpdated == "2m ago")
         #expect(display.staleBanner?.reason == "Last refresh is too old")
+        #expect(display.primaryStatusReason == "Last refresh is too old")
     }
 
     @Test("watch item detail defaults to row reason")

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -71,6 +71,59 @@ struct MenuDisplayModelTests {
         #expect(display.primaryStatusReason == "2 warning events")
     }
 
+    @Test("single not ready node uses singular primary status reason")
+    func singleNotReadyNodeUsesSingularPrimaryStatusReason() {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 2, total: 3)),
+            podsSection: .available(PodSummary(running: 12, total: 12)),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+
+        #expect(display.state == .bad)
+        #expect(display.primaryStatusReason == "1 node not ready")
+    }
+
+    @Test("single not running pod uses singular primary status reason")
+    func singleNotRunningPodUsesSingularPrimaryStatusReason() {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 11, total: 12)),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+
+        #expect(display.state == .watch)
+        #expect(display.primaryStatusReason == "1 pod not running")
+    }
+
+    @Test("single warning event uses singular primary status reason")
+    func singleWarningEventUsesSingularPrimaryStatusReason() {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 12, total: 12)),
+            warningEventsSection: .available([
+                warningEvent(reason: "BackOff", observedAt: Date(timeIntervalSince1970: 100), count: 1)
+            ]),
+            workloadsSection: .available([]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+
+        #expect(display.state == .watch)
+        #expect(display.primaryStatusReason == "1 warning event")
+    }
+
     @Test("first screen caps watchlist and reports overflow")
     func firstScreenCapsWatchlistAndReportsOverflow() {
         let items = (1...7).map { index in

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -91,8 +91,8 @@ struct MenuDisplayModelTests {
         #expect(display.hiddenWatchItemCount == 2)
     }
 
-    @Test("long watch item titles truncate consistently")
-    func longWatchItemTitlesTruncateConsistently() {
+    @Test("long watch item titles stay full for middle truncation")
+    func longWatchItemTitlesStayFullForMiddleTruncation() {
         let snapshot = ClusterSnapshot(
             contextName: "prod",
             nodeSummary: NodeSummary(ready: 3, total: 3),
@@ -110,7 +110,38 @@ struct MenuDisplayModelTests {
 
         let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
 
-        #expect(display.visibleWatchItems.first?.title == "production-namespace/checkout-api-with-a-…")
+        #expect(display.visibleWatchItems.first?.title == "production-namespace/checkout-api-with-a-very-long-name")
+    }
+
+    @Test("similar long watch item titles keep suffix differences")
+    func similarLongWatchItemTitlesKeepSuffixDifferences() {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodeSummary: NodeSummary(ready: 3, total: 3),
+            podSummary: PodSummary(running: 2, total: 2),
+            warningEventCount: 0,
+            trackedItems: [
+                TrackedItemStatus(
+                    target: .workload(namespace: "production-namespace", name: "checkout-api-with-shared-long-prefix-api"),
+                    state: .ok,
+                    reason: "ready"
+                ),
+                TrackedItemStatus(
+                    target: .workload(namespace: "production-namespace", name: "checkout-worker-with-shared-long-prefix-worker"),
+                    state: .ok,
+                    reason: "ready"
+                )
+            ],
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+        let titles = display.visibleWatchItems.map(\.title)
+
+        #expect(titles == [
+            "production-namespace/checkout-api-with-shared-long-prefix-api",
+            "production-namespace/checkout-worker-with-shared-long-prefix-worker"
+        ])
     }
 
     @Test("failed refresh keeps previous data but marks it stale")

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -5,6 +5,7 @@ These are the rules Kubebar must keep true at runtime.
 ## Product Rules
 
 - The menu bar icon only uses `OK`, `Watch`, `Bad`, or `Stale`.
+- `OK` uses the brand logo in the menu bar, but the opened menu must explicitly show OK text.
 - The first screen is watchlist-first.
 - The first screen shows only a small set of tracked items, with overflow
   pushed behind a secondary entry.
@@ -26,8 +27,11 @@ These are the rules Kubebar must keep true at runtime.
   and show only reason, location, age, count, and short message.
 - Partial section failures must be visible as unavailable and must not make
   unavailable data look healthy.
-- Menu views must not show raw kubectl output.
+- Menu views must not show unprocessed command transcripts.
 - Kubebar keeps config and displayed cluster status local to the app.
+- Context, namespace, workload, and warning names stay app-owned display
+  strings; tooltips and accessibility labels must not expose command
+  transcripts or JSON.
 
 ## Freshness Rules
 
@@ -49,7 +53,10 @@ These are the rules Kubebar must keep true at runtime.
 ## Watchlist Rules
 
 - Watchlist rows stay short and readable.
-- Tracked item names may truncate, but their meaning should still be clear.
+- Long context, namespace, workload, and warning names use one-line middle
+  truncation in views, preserving full names for tooltip and accessibility text.
+- Primary watchlist rows stay one line; detailed reasons stay in watchlist
+  detail, stale banner, warning event, or section notice areas.
 - The watchlist is ordered by attention, not by raw cluster size.
 - An empty watchlist is a real state and must not be treated as a healthy
   cluster.
@@ -62,6 +69,16 @@ These are the rules Kubebar must keep true at runtime.
 - Tracked item details are limited to state, reason, affected pod count, 1-3
   example pod names, and latest related warning.
 
+## Keyboard Rules
+
+- Setup, refresh, edit watchlist, watchlist detail, warning events, and
+  secondary sections must be reachable through native macOS keyboard
+  navigation.
+- Refresh and setup completion must keep enabled and disabled states visible
+  and testable.
+- Keyboard support uses native SwiftUI controls and shortcuts, not custom app
+  shell handling.
+
 ## Failure Rules
 
 - Timeout, command failure, malformed JSON, and no previous data are distinct
@@ -73,4 +90,6 @@ These are the rules Kubebar must keep true at runtime.
 - No previous successful data uses `No previous cluster data`.
 - A refresh failure must never silently clear the last good data.
 - Warning and failure states must not rely on color alone.
+- Watch, Bad, and Stale must be expressed with symbol, state text, and one
+  short reason; color alone is not enough.
 - Stale or failed reads must use distinct icon semantics from `OK`.


### PR DESCRIPTION
## Summary
- Clarify the four menu bar states with explicit opened-menu text, symbols, and reasons
- Preserve full watch target names while adding middle truncation and full tooltip/accessibility fallback
- Add native keyboard reachability for refresh, setup, watchlist editing, and secondary sections
- Update runtime invariants, UAT, verification, and review artifacts for issue #6

## Testing
- `swift test --filter MenuBarStatusPresentationTests`
- `swift test --filter MenuDisplayModelTests`
- `swift build`
- `./scripts/swift-quality-gate.sh local`
- Local visible-app smoke launch completed; manual menu traversal remains recorded in UAT as pending human verification