### PR TITLE
Fix kubectl lookup for Homebrew installs

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,13 @@
+# Kubebar State
+
+Last activity: 2026-04-22 - Completed quick task 260422-fk1: 修复kubectl no such file or directory问题，kubectl使用brew安装
+
+### Blockers/Concerns
+
+None currently recorded.
+
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Directory |
+|---|-------------|------|--------|-----------|
+| 260422-fk1 | 修复kubectl no such file or directory问题，kubectl使用brew安装 | 2026-04-22 | 804a0ce | [260422-fk1-kubectl-no-such-file-or-directory-kubect](./quick/260422-fk1-kubectl-no-such-file-or-directory-kubect/) |

--- a/.planning/quick/260422-fk1-kubectl-no-such-file-or-directory-kubect/260422-fk1-CONTEXT.md
+++ b/.planning/quick/260422-fk1-kubectl-no-such-file-or-directory-kubect/260422-fk1-CONTEXT.md
@@ -1,0 +1,45 @@
+# Quick Task 260422-fk1: 修复kubectl no such file or directory问题，kubectl使用brew安装 - Context
+
+**Gathered:** 2026-04-22
+**Status:** Ready for planning
+
+<domain>
+## Task Boundary
+
+修复 Kubebar app 内执行 `kubectl` 时出现 `no such file or directory` 的问题。`kubectl` 已通过 Homebrew 安装。
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Executable lookup
+- Treat this as an app runtime PATH issue. The app should be able to find Homebrew-installed `kubectl` when launched from Finder or Login Items, without requiring a shell-launched environment.
+
+### Homebrew compatibility
+- Include both Apple Silicon and Intel Homebrew bin directories in the command runner search path: `/opt/homebrew/bin` and `/usr/local/bin`.
+
+### Product behavior
+- Keep existing stale and failure handling. If `kubectl` still fails, Kubebar should keep reporting a safe failure reason instead of showing stale data as healthy.
+
+### Agent discretion
+- Keep the change at the injectable command boundary and cover it with focused tests.
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- Preserve the existing `CommandRequest(executable: "kubectl", ...)` call sites.
+- Ensure subprocesses inherit a PATH that includes the existing environment plus Homebrew and system defaults.
+
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+- `AGENTS.md`
+- `docs/architecture/runtime-invariants.md`
+- `docs/architecture/system-overview.md`
+
+</canonical_refs>

--- a/.planning/quick/260422-fk1-kubectl-no-such-file-or-directory-kubect/260422-fk1-PLAN.md
+++ b/.planning/quick/260422-fk1-kubectl-no-such-file-or-directory-kubect/260422-fk1-PLAN.md
@@ -1,0 +1,24 @@
+---
+id: 260422-fk1
+status: ready
+description: 修复kubectl no such file or directory问题，kubectl使用brew安装
+---
+
+# Quick Task 260422-fk1 Plan
+
+## Task 1: Make Homebrew kubectl discoverable from the app
+
+files:
+- `KubebarCore/Services/CommandRunner.swift`
+- `KubebarTests/Services/CommandRunnerTests.swift`
+
+action:
+- Update `ProcessCommandRunner` so subprocesses receive a stable PATH that keeps the inherited PATH and appends common Homebrew and system executable directories.
+- Add focused tests proving PATH composition includes Homebrew locations and a command available only through the injected search path can be launched by name.
+
+verify:
+- `swift test --filter CommandRunnerTests`
+- `./scripts/swift-quality-gate.sh local`
+
+done:
+- Finder-launched app behavior no longer depends on the user's shell PATH for Homebrew-installed `kubectl`.

--- a/.planning/quick/260422-fk1-kubectl-no-such-file-or-directory-kubect/260422-fk1-SUMMARY.md
+++ b/.planning/quick/260422-fk1-kubectl-no-such-file-or-directory-kubect/260422-fk1-SUMMARY.md
@@ -1,0 +1,30 @@
+---
+status: complete
+quick_id: 260422-fk1
+date: 2026-04-22
+commit: 804a0ce
+---
+
+# Quick Task 260422-fk1 Summary
+
+## Result
+
+Fixed the app runtime `kubectl` lookup path for Homebrew installs.
+
+## Changes
+
+- `ProcessCommandRunner` now gives launched commands a stable PATH that preserves the inherited PATH and appends Homebrew and system executable directories.
+- Added coverage for Homebrew PATH composition, duplicate path handling, and launching a command available only through the additional search path.
+
+## Verification
+
+- `swift test --filter CommandRunnerTests` passed with 5 tests.
+- `./scripts/swift-quality-gate.sh local` passed:
+  - Xcode build
+  - Xcode tests
+  - Swift build
+  - Swift tests with 92 tests
+
+## Notes
+
+- `.planning/ROADMAP.md` and `.planning/STATE.md` were absent in this worktree when the task started. Existing `docs/plans` and `.planning/phases` were used as the project context; `.planning/STATE.md` was created for quick-task tracking.

--- a/KubebarCore/Services/CommandRunner.swift
+++ b/KubebarCore/Services/CommandRunner.swift
@@ -46,7 +46,24 @@ public enum CommandRunnerError: Error, Equatable, Sendable {
 }
 
 public final class ProcessCommandRunner: CommandRunning, @unchecked Sendable {
-    public init() {}
+    static let defaultExecutableSearchPaths = [
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin"
+    ]
+
+    private let additionalExecutableSearchPaths: [String]
+
+    public convenience init() {
+        self.init(additionalExecutableSearchPaths: Self.defaultExecutableSearchPaths)
+    }
+
+    init(additionalExecutableSearchPaths: [String]) {
+        self.additionalExecutableSearchPaths = additionalExecutableSearchPaths
+    }
 
     public func run(_ request: CommandRequest) throws -> CommandResult {
         let process = Process()
@@ -59,6 +76,10 @@ public final class ProcessCommandRunner: CommandRunning, @unchecked Sendable {
 
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = [request.executable] + request.arguments
+        process.environment = Self.launchEnvironment(
+            base: ProcessInfo.processInfo.environment,
+            additionalExecutableSearchPaths: additionalExecutableSearchPaths
+        )
         process.standardOutput = stdout
         process.standardError = stderr
 
@@ -109,6 +130,28 @@ public final class ProcessCommandRunner: CommandRunning, @unchecked Sendable {
             stderr: String(data: stderrData.data, encoding: .utf8) ?? "",
             exitCode: process.terminationStatus
         )
+    }
+
+    static func launchEnvironment(
+        base: [String: String],
+        additionalExecutableSearchPaths: [String] = defaultExecutableSearchPaths
+    ) -> [String: String] {
+        var environment = base
+        let inheritedSearchPaths = base["PATH"]?.split(separator: ":").map(String.init) ?? []
+        var seenSearchPaths = Set<String>()
+        var searchPaths: [String] = []
+
+        for path in inheritedSearchPaths + additionalExecutableSearchPaths {
+            let normalizedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedPath.isEmpty, seenSearchPaths.insert(normalizedPath).inserted else {
+                continue
+            }
+
+            searchPaths.append(normalizedPath)
+        }
+
+        environment["PATH"] = searchPaths.joined(separator: ":")
+        return environment
     }
 }
 

--- a/KubebarTests/Services/CommandRunnerTests.swift
+++ b/KubebarTests/Services/CommandRunnerTests.swift
@@ -4,6 +4,48 @@ import Testing
 
 @Suite("Process command runner")
 struct CommandRunnerTests {
+    @Test("launch environment keeps inherited PATH and appends Homebrew paths")
+    func launchEnvironmentKeepsInheritedPathAndAppendsHomebrewPaths() {
+        let environment = ProcessCommandRunner.launchEnvironment(base: ["PATH": "/usr/bin:/bin"])
+
+        #expect(environment["PATH"] == "/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/usr/sbin:/sbin")
+    }
+
+    @Test("launch environment removes duplicate search paths")
+    func launchEnvironmentRemovesDuplicateSearchPaths() {
+        let environment = ProcessCommandRunner.launchEnvironment(
+            base: ["PATH": "/opt/homebrew/bin:/usr/bin:/opt/homebrew/bin"]
+        )
+
+        #expect(environment["PATH"] == "/opt/homebrew/bin:/usr/bin:/usr/local/bin:/bin:/usr/sbin:/sbin")
+    }
+
+    @Test("runs executable discovered through additional search path")
+    func runsExecutableDiscoveredThroughAdditionalSearchPath() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let executable = directory.appendingPathComponent("kubebar-command-runner-path-test")
+        try """
+        #!/bin/sh
+        printf additional-path
+        """.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let runner = ProcessCommandRunner(additionalExecutableSearchPaths: [directory.path])
+
+        let result = try runner.run(
+            CommandRequest(executable: executable.lastPathComponent, arguments: [], timeoutSeconds: 5)
+        )
+
+        #expect(result.exitCode == 0)
+        #expect(result.stdout == "additional-path")
+    }
+
     @Test("drains large stdout and stderr while command is running")
     func drainsLargeStdoutAndStderrWhileCommandIsRunning() throws {
         let runner = ProcessCommandRunner()


### PR DESCRIPTION
## Summary
- Preserve the inherited PATH when launching subprocesses and append common Homebrew and system search paths so Finder-launched Kubebar can find `kubectl`
- Add focused tests covering PATH composition, duplicate handling, and executable discovery through the injected search path
- Record the quick task in `.planning/STATE.md` and the quick task artifacts

## Testing
- `swift test --filter CommandRunnerTests`
- `./scripts/swift-quality-gate.sh local`