### PR TITLE
Fix completed job pod readiness and QA coverage

### DIFF
--- a/Kubebar/Views/StatusSummaryView.swift
+++ b/Kubebar/Views/StatusSummaryView.swift
@@ -29,7 +29,7 @@ struct StatusSummaryView: View {
                     .truncationMode(.middle)
             }
             .font(.subheadline)
-            .help(Text(display.overview.statusText))
+            .help(Text(display.overview.statusHelpText))
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(display.overview.statusAccessibilityLabel)

--- a/KubebarCore/Models/ClusterSnapshot.swift
+++ b/KubebarCore/Models/ClusterSnapshot.swift
@@ -233,6 +233,7 @@ public struct ClusterSnapshot: Equatable, Sendable {
     public let warningEventsSection: SnapshotSection<[WarningEventRecord]>
     public let workloadsSection: SnapshotSection<[TrackedItemStatus]>
     public let sectionFailures: [SnapshotSectionFailure]
+    public let hasCompletedWatchedPods: Bool
 
     public init(
         contextName: String,
@@ -243,6 +244,7 @@ public struct ClusterSnapshot: Equatable, Sendable {
         nodeDetailsSection: SnapshotSection<[NodeDetail]> = .available([]),
         podDetailsSection: SnapshotSection<[PodDetail]> = .available([]),
         metricsSection: SnapshotSection<ClusterMetricsSummary> = .unavailable(reason: "Metrics unavailable"),
+        hasCompletedWatchedPods: Bool = false,
         capturedAt: Date
     ) {
         self.contextName = contextName
@@ -259,6 +261,7 @@ public struct ClusterSnapshot: Equatable, Sendable {
         self.warningEventsSection = .available([])
         self.workloadsSection = .available(trackedItems)
         self.sectionFailures = []
+        self.hasCompletedWatchedPods = hasCompletedWatchedPods
     }
 
     public init(
@@ -270,6 +273,7 @@ public struct ClusterSnapshot: Equatable, Sendable {
         metricsSection: SnapshotSection<ClusterMetricsSummary> = .unavailable(reason: "Metrics unavailable"),
         warningEventsSection: SnapshotSection<[WarningEventRecord]>,
         workloadsSection: SnapshotSection<[TrackedItemStatus]>,
+        hasCompletedWatchedPods: Bool = false,
         capturedAt: Date
     ) {
         let nodeSummary = nodesSection.value ?? NodeSummary(ready: 0, total: 0)
@@ -298,6 +302,7 @@ public struct ClusterSnapshot: Equatable, Sendable {
             warningEventsSection: warningEventsSection,
             workloadsSection: workloadsSection
         )
+        self.hasCompletedWatchedPods = hasCompletedWatchedPods
     }
 
     private static func makeNodeDetailsSection(from nodesSection: SnapshotSection<NodeSummary>) -> SnapshotSection<[NodeDetail]> {

--- a/KubebarCore/Models/MenuDisplayModel.swift
+++ b/KubebarCore/Models/MenuDisplayModel.swift
@@ -369,6 +369,7 @@ public struct OverviewCardDisplay: Equatable, Sendable, Identifiable {
 
 public struct OverviewDisplay: Equatable, Sendable {
     public let statusText: String
+    public let statusHelpText: String
     public let statusAccessibilityLabel: String
     public let cards: [OverviewCardDisplay]
     public let recentWarnings: [WarningEventDisplay]
@@ -378,6 +379,7 @@ public struct OverviewDisplay: Equatable, Sendable {
 
     public init(
         statusText: String,
+        statusHelpText: String? = nil,
         statusAccessibilityLabel: String,
         cards: [OverviewCardDisplay],
         recentWarnings: [WarningEventDisplay],
@@ -386,6 +388,7 @@ public struct OverviewDisplay: Equatable, Sendable {
         recentWarningsUnavailableMessage: String? = nil
     ) {
         self.statusText = statusText
+        self.statusHelpText = statusHelpText ?? statusText
         self.statusAccessibilityLabel = statusAccessibilityLabel
         self.cards = cards
         self.recentWarnings = recentWarnings
@@ -468,6 +471,7 @@ public struct MenuDisplayModel: Equatable, Sendable {
     ) -> OverviewDisplay {
         OverviewDisplay(
             statusText: primaryStatusReason,
+            statusHelpText: primaryStatusReason,
             statusAccessibilityLabel: "\(state.label), \(primaryStatusReason), context \(contextName)",
             cards: [
                 OverviewCardDisplay(

--- a/KubebarCore/QA/MenuStateFixtureCatalog.swift
+++ b/KubebarCore/QA/MenuStateFixtureCatalog.swift
@@ -65,6 +65,7 @@ public enum MenuStateFixtureCatalog {
                 id: state,
                 display: evaluator.evaluate(snapshot: watchSnapshot(), now: now),
                 expectedBehavior: "Overview shows Watch with a pinned BackOff warning row."
+                    + " Hovering the top status explains the restarting qa-api Pod."
                     + " Pods tab shows the watched Pod first with yellow dot, 0/1, and gray issue text.",
                 limitations: "Requires visible menu inspection to confirm reason-first warning copy, pinned marker, and card readability."
             )
@@ -73,6 +74,7 @@ public enum MenuStateFixtureCatalog {
                 id: state,
                 display: evaluator.evaluate(snapshot: badSnapshot(), now: now),
                 expectedBehavior: "Overview shows Bad and prioritizes the broken tracked target in the top row."
+                    + " Hovering the top status names the affected qa-payments Pods."
                     + " Pods tab shows failed Pods first with red dots and issue text.",
                 limitations: "Requires visible menu inspection to confirm top-row priority and card state."
             )
@@ -85,7 +87,8 @@ public enum MenuStateFixtureCatalog {
                     failure: RefreshFailure(reason: "Refresh failed; showing last known status."),
                     now: now
                 ),
-                expectedBehavior: "Overview shows Stale while preserving the last known top row and four cards with stale marking.",
+                expectedBehavior: "Overview shows Stale while preserving the last known top row and four cards with stale marking."
+                    + " Hovering the top status explains the failed refresh reason.",
                 limitations: "Requires visible menu inspection to confirm stale data is not presented as current."
             )
         case .staleAgeOut:
@@ -134,6 +137,7 @@ public enum MenuStateFixtureCatalog {
                 id: state,
                 display: evaluator.evaluate(snapshot: metricsUnavailableSnapshot(), now: now),
                 expectedBehavior: "Overview keeps OK cluster status while CPU and Memory cards show unavailable metrics."
+                    + " Hovering the top status explains that metrics are unavailable."
                     + " Pods tab still shows watched Pods.",
                 limitations: "Requires visible menu inspection to confirm unavailable metrics are distinct from normal current values."
             )
@@ -142,8 +146,9 @@ public enum MenuStateFixtureCatalog {
                 id: state,
                 display: evaluator.evaluate(snapshot: warningHeavySnapshot(), now: now),
                 expectedBehavior: "Overview shows capped Recent Warnings with the pinned tracked warning first, repeat count visible, message secondary, and overflow left for Events."
+                    + " Hovering the top status exposes the pinned tracked warning detail."
                     + " Events tab scrolls above the footer, the footer remains visible with refresh/settings/quit only, and Pods tab keeps attention rows before ready rows.",
-                limitations: "Requires visible menu inspection to confirm warning rows stay clear, overflow keeps the footer reachable, and the tab bar has balanced spacing."
+                limitations: "Requires visible menu inspection to confirm warning rows stay clear, overflow keeps the footer reachable, the top row and four cards remain visible, and the tab bar has balanced spacing."
             )
         }
     }

--- a/KubebarCore/QA/MenuStateFixtureCatalog.swift
+++ b/KubebarCore/QA/MenuStateFixtureCatalog.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum MenuQAState: String, CaseIterable, Sendable {
     case healthy
+    case completedJobs = "completed-jobs"
     case watch
     case bad
     case staleRefreshFailure = "stale-refresh-failure"
@@ -59,6 +60,15 @@ public enum MenuStateFixtureCatalog {
                 expectedBehavior: "Overview shows OK with a top status row, four cards, and neutral Recent Warnings."
                     + " Pods tab groups watched Pods by namespace with ready counts.",
                 limitations: "Requires visible menu inspection to confirm the top row, four-card grid, and capped warning area."
+            )
+        case .completedJobs:
+            return makeFixture(
+                id: state,
+                display: evaluator.evaluate(snapshot: completedJobsSnapshot(), now: now),
+                setupState: completedJobsSetupState(),
+                expectedBehavior: "Overview shows OK when the watched scope has only completed Job Pods."
+                    + " Pods tab has no active Pod rows and says completed jobs are OK.",
+                limitations: "Requires visible menu inspection to confirm completed Job Pods do not appear as unready active rows."
             )
         case .watch:
             return makeFixture(
@@ -208,6 +218,27 @@ public enum MenuStateFixtureCatalog {
                     reason: "3/3 watched pods running"
                 )
             ]),
+            capturedAt: capturedAt
+        )
+    }
+
+    private static func completedJobsSnapshot() -> ClusterSnapshot {
+        ClusterSnapshot(
+            contextName: "QA fixture",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            nodeDetailsSection: .available(healthyNodeDetails()),
+            podsSection: .available(PodSummary(ready: 0, running: 0, total: 0)),
+            podDetailsSection: .available([]),
+            metricsSection: .available(metricsSummary()),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([
+                TrackedItemStatus(
+                    target: .namespace("qa-jobs"),
+                    state: .ok,
+                    reason: "completed jobs are OK"
+                )
+            ]),
+            hasCompletedWatchedPods: true,
             capturedAt: capturedAt
         )
     }
@@ -567,6 +598,18 @@ public enum MenuStateFixtureCatalog {
             selectedContext: nil,
             availableContexts: ["QA fixture", "QA standby"],
             watchlist: WatchlistSelectionState(availableNamespaces: []),
+            refreshCadence: .oneMinute
+        )
+    }
+
+    private static func completedJobsSetupState() -> SetupFlowState {
+        SetupFlowState(
+            selectedContext: "QA fixture",
+            availableContexts: ["QA fixture", "QA standby"],
+            watchlist: WatchlistSelectionState(
+                availableNamespaces: ["qa-api", "qa-jobs", "qa-monitoring"],
+                selectedTargets: [.namespace("qa-jobs")]
+            ),
             refreshCadence: .oneMinute
         )
     }

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -124,6 +124,8 @@ public struct HealthEvaluator: Sendable {
                 from: snapshot,
                 state: resolvedState,
                 primaryStatusReason: primaryStatusReason,
+                lastUpdated: lastUpdated,
+                visibleItems: Array(visibleItems),
                 sectionNotices: sectionNotices,
                 warningRows: overviewWarnings,
                 totalWarningRows: overviewWarningRows.count
@@ -202,13 +204,32 @@ public struct HealthEvaluator: Sendable {
         from snapshot: ClusterSnapshot,
         state: ClusterHealthState,
         primaryStatusReason: String,
+        lastUpdated: String,
+        visibleItems: [WatchItemDisplay],
         sectionNotices: [SectionAvailabilityDisplay],
         warningRows: [WarningEventDisplay],
         totalWarningRows: Int
     ) -> OverviewDisplay {
-        OverviewDisplay(
+        let statusHelpText = primaryStatusHelpText(
+            for: state,
+            snapshot: snapshot,
+            visibleItems: visibleItems,
+            sectionNotices: sectionNotices,
+            staleReason: state == .stale ? primaryStatusReason : nil,
+            lastUpdated: lastUpdated,
+            warningRows: warningRows,
+            fallback: primaryStatusReason
+        )
+
+        return OverviewDisplay(
             statusText: primaryStatusReason,
-            statusAccessibilityLabel: "\(state.label), \(primaryStatusReason), context \(snapshot.contextName)",
+            statusHelpText: statusHelpText,
+            statusAccessibilityLabel: statusAccessibilityLabel(
+                state: state,
+                statusText: primaryStatusReason,
+                statusHelpText: statusHelpText,
+                contextName: snapshot.contextName
+            ),
             cards: [
                 nodeOverviewCard(from: snapshot, state: state),
                 podOverviewCard(from: snapshot, state: state),
@@ -231,7 +252,13 @@ public struct HealthEvaluator: Sendable {
     private func unavailableOverview(contextName: String, reason: String) -> OverviewDisplay {
         OverviewDisplay(
             statusText: reason,
-            statusAccessibilityLabel: "Stale, \(reason), context \(contextName)",
+            statusHelpText: reason,
+            statusAccessibilityLabel: statusAccessibilityLabel(
+                state: .stale,
+                statusText: reason,
+                statusHelpText: reason,
+                contextName: contextName
+            ),
             cards: [
                 unavailableOverviewCard(id: "nodes", title: "Nodes", systemImageName: "server.rack", reason: reason),
                 unavailableOverviewCard(id: "pods", title: "Pods", systemImageName: "shippingbox", reason: reason),
@@ -958,6 +985,118 @@ public struct HealthEvaluator: Sendable {
         case .stale:
             return staleReason ?? "Status is stale"
         }
+    }
+
+    private func primaryStatusHelpText(
+        for state: ClusterHealthState,
+        snapshot: ClusterSnapshot,
+        visibleItems: [WatchItemDisplay],
+        sectionNotices: [SectionAvailabilityDisplay],
+        staleReason: String?,
+        lastUpdated: String,
+        warningRows: [WarningEventDisplay],
+        fallback: String
+    ) -> String {
+        switch state {
+        case .ok:
+            if snapshot.metricsSection.value == nil {
+                let reason = sanitizedSectionReason(snapshot.metricsSection.unavailableReason ?? "Metrics unavailable")
+                return "Metrics unavailable: \(reason)"
+            }
+
+            return fallback
+        case .bad:
+            if let item = visibleItems.first(where: { $0.state == .bad }) {
+                return watchItemStatusHelpText(item)
+            }
+
+            if let nodeDeficit = nodeDeficit(from: snapshot), nodeDeficit > 0 {
+                return firstNotReadyNodeHelpText(from: snapshot) ?? fallback
+            }
+
+            if let podDeficit = podDeficit(from: snapshot), podDeficit > 0 {
+                return firstAttentionPodHelpText(from: snapshot) ?? fallback
+            }
+
+            return fallback
+        case .watch:
+            if let item = visibleItems.first(where: { $0.state == .watch }) {
+                return watchItemStatusHelpText(item)
+            }
+
+            if let podDeficit = podDeficit(from: snapshot), podDeficit > 0 {
+                return firstAttentionPodHelpText(from: snapshot) ?? fallback
+            }
+
+            if let warning = warningRows.first {
+                return warning.helpText
+            }
+
+            if let notice = sectionNotices.first {
+                return "\(notice.title) unavailable: \(notice.reason)"
+            }
+
+            return fallback
+        case .stale:
+            let reason = staleReason ?? "Status is stale"
+            return "\(reason), last updated \(lastUpdated)"
+        }
+    }
+
+    private func statusAccessibilityLabel(
+        state: ClusterHealthState,
+        statusText: String,
+        statusHelpText: String,
+        contextName: String
+    ) -> String {
+        var parts = [state.label]
+
+        if statusHelpText == statusText || statusHelpText.hasPrefix("\(statusText),") || statusHelpText.hasPrefix("\(statusText):") {
+            parts.append(statusHelpText)
+        } else {
+            parts.append(statusText)
+            parts.append(statusHelpText)
+        }
+
+        parts.append("context \(contextName)")
+        return parts.joined(separator: ", ")
+    }
+
+    private func watchItemStatusHelpText(_ item: WatchItemDisplay) -> String {
+        var parts = ["\(item.title): \(item.detail.reason)"]
+
+        if let affectedPodCount = item.detail.affectedPodCount {
+            parts.append(countLabel(affectedPodCount, singular: "affected pod", plural: "affected pods"))
+        }
+
+        if !item.detail.examplePodNames.isEmpty {
+            parts.append("examples \(item.detail.examplePodNames.joined(separator: ", "))")
+        }
+
+        if let latestWarning = item.detail.latestWarning {
+            parts.append("latest warning \(latestWarning.helpText)")
+        }
+
+        return parts.joined(separator: ", ")
+    }
+
+    private func firstNotReadyNodeHelpText(from snapshot: ClusterSnapshot) -> String? {
+        makeNodeRows(from: snapshot)
+            .first { $0.readiness == .notReady }?
+            .helpText
+    }
+
+    private func firstAttentionPodHelpText(from snapshot: ClusterSnapshot) -> String? {
+        guard let podDetails = snapshot.podDetailsSection.value else {
+            return nil
+        }
+
+        return makePodSections(from: podDetails)
+            .lazy
+            .compactMap { section in
+                section.rows.first { $0.state != .ready }?.helpText
+            }
+            .first
     }
 
     private func countLabel(_ count: Int, singular: String, plural: String, suffix: String? = nil) -> String {

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -546,6 +546,10 @@ public struct HealthEvaluator: Sendable {
 
     private func podTabEmptyMessage(from snapshot: ClusterSnapshot, podDetails: [PodDetail]?) -> String {
         if let podDetails, podDetails.isEmpty, !snapshot.trackedItems.isEmpty {
+            if snapshot.hasCompletedWatchedPods {
+                return "No active pods; completed jobs are OK"
+            }
+
             return "No watched pods found"
         }
 

--- a/KubebarCore/Services/KubectlClusterReader.swift
+++ b/KubebarCore/Services/KubectlClusterReader.swift
@@ -468,7 +468,7 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
         guard !matchingPods.isEmpty else {
             return TrackedItemStatus(
                 target: target,
-                state: .watch,
+                state: .ok,
                 reason: "no matching pods",
                 latestWarning: latestWarning
             )

--- a/KubebarCore/Services/KubectlClusterReader.swift
+++ b/KubebarCore/Services/KubectlClusterReader.swift
@@ -33,6 +33,11 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
             workloadSelectorsSection: workloadSelectorsSection,
             watchTargets: watchTargets
         )
+        let hasCompletedWatchedPods = containsCompletedWatchedPods(
+            podRecordsSection: podRecordsSection,
+            workloadSelectorsSection: workloadSelectorsSection,
+            watchTargets: watchTargets
+        )
         let workloadsSection = trackedItemsSection(
             podRecordsSection: podRecordsSection,
             workloadSelectorsSection: workloadSelectorsSection,
@@ -59,6 +64,7 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
             metricsSection: metricsSection,
             warningEventsSection: warningEventsSection,
             workloadsSection: workloadsSection,
+            hasCompletedWatchedPods: hasCompletedWatchedPods,
             capturedAt: now
         )
     }
@@ -155,10 +161,12 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
     }
 
     private func makePodSummary(from pods: [PodRecord]) -> PodSummary {
-        PodSummary(
-            ready: pods.filter { !$0.isNotReady }.count,
-            running: pods.filter(\.isRunning).count,
-            total: pods.count
+        let activePods = pods.filter(\.isActive)
+
+        return PodSummary(
+            ready: activePods.filter { !$0.isNotReady }.count,
+            running: activePods.filter(\.isRunning).count,
+            total: activePods.count
         )
     }
 
@@ -269,7 +277,7 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
         var details: [PodDetail] = []
 
         for target in watchTargets {
-            for pod in pods where pod.matches(target: target, workloadSelectors: workloadSelectors) {
+            for pod in pods where pod.isActive && pod.matches(target: target, workloadSelectors: workloadSelectors) {
                 let id = "\(pod.metadata.namespace)/\(pod.metadata.name)"
                 guard seenPodIDs.insert(id).inserted else {
                     continue
@@ -280,6 +288,25 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
         }
 
         return .available(details)
+    }
+
+    private func containsCompletedWatchedPods(
+        podRecordsSection: SnapshotSection<[PodRecord]>,
+        workloadSelectorsSection: SnapshotSection<[WorkloadIdentity: [String: String]]>,
+        watchTargets: [WatchTarget]
+    ) -> Bool {
+        guard
+            let pods = podRecordsSection.value,
+            let workloadSelectors = workloadSelectorsSection.value
+        else {
+            return false
+        }
+
+        return watchTargets.contains { target in
+            pods.contains { pod in
+                pod.isSuccessfullyCompleted && pod.matches(target: target, workloadSelectors: workloadSelectors)
+            }
+        }
     }
 
     private func sumNodeQuantity(_ nodes: [NodeRecord], resource: String, scale: ResourceQuantityScale) -> Int64? {
@@ -464,17 +491,18 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
             pod.matches(target: target, workloadSelectors: workloadSelectors)
         }
         let latestWarning = latestRelatedWarning(for: target, matchingPods: matchingPods, warningEvents: warningEvents)
+        let activePods = matchingPods.filter(\.isActive)
 
-        guard !matchingPods.isEmpty else {
+        guard !activePods.isEmpty else {
             return TrackedItemStatus(
                 target: target,
                 state: .ok,
-                reason: "no matching pods",
+                reason: matchingPods.contains(where: \.isSuccessfullyCompleted) ? "completed jobs are OK" : "no matching pods",
                 latestWarning: latestWarning
             )
         }
 
-        let failedPods = matchingPods.filter(\.isFailed)
+        let failedPods = activePods.filter(\.isFailed)
         if !failedPods.isEmpty {
             return TrackedItemStatus(
                 target: target,
@@ -486,7 +514,7 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
             )
         }
 
-        let restartingPods = matchingPods.filter(\.isRestarting)
+        let restartingPods = activePods.filter(\.isRestarting)
         if !restartingPods.isEmpty {
             return TrackedItemStatus(
                 target: target,
@@ -498,7 +526,7 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
             )
         }
 
-        let notReadyPods = matchingPods.filter(\.isNotReady)
+        let notReadyPods = activePods.filter(\.isNotReady)
         if !notReadyPods.isEmpty {
             return TrackedItemStatus(
                 target: target,
@@ -519,11 +547,11 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
             )
         }
 
-        let running = matchingPods.filter(\.isRunning).count
-        let reason = "\(running)/\(matchingPods.count) pods running"
+        let running = activePods.filter(\.isRunning).count
+        let reason = "\(running)/\(activePods.count) pods running"
         return TrackedItemStatus(
             target: target,
-            state: running == matchingPods.count ? .ok : .bad,
+            state: running == activePods.count ? .ok : .bad,
             reason: reason
         )
     }
@@ -956,6 +984,18 @@ private struct PodRecord: Decodable, Equatable, Sendable {
         status.phase == "Unknown"
     }
 
+    var isActive: Bool {
+        !isSuccessfullyCompleted
+    }
+
+    var isSuccessfullyCompleted: Bool {
+        if isFailed || isPending || isUnknown || currentWaitingState != nil || hasFailedTerminatedContainer {
+            return false
+        }
+
+        return status.phase == "Succeeded" || allContainersTerminatedCompleted
+    }
+
     var readyContainerCount: Int? {
         guard let containerStatuses = status.containerStatuses, !containerStatuses.isEmpty else {
             return nil
@@ -982,6 +1022,35 @@ private struct PodRecord: Decodable, Equatable, Sendable {
 
     var currentTerminatedState: ContainerStateTerminated? {
         status.containerStatuses?.compactMap { $0.state?.terminated }.first
+    }
+
+    var allContainersTerminatedCompleted: Bool {
+        guard let containerStatuses = status.containerStatuses, !containerStatuses.isEmpty else {
+            return false
+        }
+
+        return containerStatuses.allSatisfy { containerStatus in
+            normalizedReason(containerStatus.state?.terminated?.reason) == "completed"
+        }
+    }
+
+    var hasFailedTerminatedContainer: Bool {
+        status.containerStatuses?.contains { containerStatus in
+            guard let reason = normalizedReason(containerStatus.state?.terminated?.reason) else {
+                return false
+            }
+
+            return reason != "completed"
+        } ?? false
+    }
+
+    private func normalizedReason(_ value: String?) -> String? {
+        let text = value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let text, !text.isEmpty else {
+            return nil
+        }
+
+        return text
     }
 
     var notReadyCondition: PodCondition? {

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -30,6 +30,7 @@ struct MenuDisplayModelTests {
         #expect(display.counters.warningEvents == "0")
         #expect(display.healthSentence == "All tracked items OK")
         #expect(display.primaryStatusReason == "All tracked items OK")
+        #expect(display.overview.statusHelpText == "All tracked items OK")
         #expect(display.lastUpdated == "20s ago")
         #expect(display.overview.cards.map(\.id) == ["nodes", "pods", "cpu", "memory"])
         #expect(display.overview.cards.map(\.value) == ["3/3", "12/12", "21%", "17%"])
@@ -98,6 +99,42 @@ struct MenuDisplayModelTests {
         #expect(display.primaryStatusReason == "1 pod pending")
     }
 
+    @Test("tracked item status help includes expanded detail")
+    func trackedItemStatusHelpIncludesExpandedDetail() {
+        let latestWarning = warningEvent(
+            reason: "BackOff",
+            observedAt: Date(timeIntervalSince1970: 100),
+            count: 2,
+            message: "newest warning"
+        )
+        let item = TrackedItemStatus(
+            target: .workload(namespace: "api", name: "checkout"),
+            state: .bad,
+            reason: "2 pods restarting",
+            affectedPodCount: 2,
+            examplePodNames: ["checkout-a", "checkout-b"],
+            latestWarning: latestWarning
+        )
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 10, total: 12)),
+            metricsSection: .available(metricsSummary()),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([item]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 220))
+
+        #expect(display.overview.statusText == "2 pods restarting")
+        #expect(display.overview.statusHelpText.contains("api/checkout: 2 pods restarting"))
+        #expect(display.overview.statusHelpText.contains("2 affected pods"))
+        #expect(display.overview.statusHelpText.contains("examples checkout-a, checkout-b"))
+        #expect(display.overview.statusHelpText.contains("latest warning BackOff api/pod/checkout 2m ago x2, newest warning"))
+        #expect(display.overview.statusAccessibilityLabel.contains(display.overview.statusHelpText))
+    }
+
     @Test("warning events provide primary status reason")
     func warningEventsProvidePrimaryStatusReason() {
         let snapshot = ClusterSnapshot(
@@ -105,7 +142,12 @@ struct MenuDisplayModelTests {
             nodesSection: .available(NodeSummary(ready: 3, total: 3)),
             podsSection: .available(PodSummary(running: 12, total: 12)),
             warningEventsSection: .available([
-                warningEvent(reason: "BackOff", observedAt: Date(timeIntervalSince1970: 100), count: 2)
+                warningEvent(
+                    reason: "BackOff",
+                    observedAt: Date(timeIntervalSince1970: 100),
+                    count: 2,
+                    message: "newest warning"
+                )
             ]),
             workloadsSection: .available([]),
             capturedAt: Date(timeIntervalSince1970: 100)
@@ -115,6 +157,7 @@ struct MenuDisplayModelTests {
 
         #expect(display.state == .watch)
         #expect(display.primaryStatusReason == "2 warning events")
+        #expect(display.overview.statusHelpText == "BackOff api/pod/checkout 20s ago x2, newest warning")
     }
 
     @Test("single not ready node uses singular primary status reason")
@@ -134,6 +177,33 @@ struct MenuDisplayModelTests {
         #expect(display.primaryStatusReason == "1 node not ready")
     }
 
+    @Test("node status help includes node condition detail")
+    func nodeStatusHelpIncludesNodeConditionDetail() {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 2, total: 3)),
+            nodeDetailsSection: .available([
+                nodeDetail(
+                    name: "worker-a",
+                    isReady: false,
+                    issueReason: "KubeletNotReady",
+                    issueMessage: "container runtime is down"
+                )
+            ]),
+            podsSection: .available(PodSummary(running: 12, total: 12)),
+            metricsSection: .available(metricsSummary()),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+
+        #expect(display.primaryStatusReason == "1 node not ready")
+        #expect(display.overview.statusHelpText == "worker-a, Not Ready, CPU 25%, Memory 25%, KubeletNotReady: container runtime is down")
+        #expect(display.overview.statusAccessibilityLabel.contains("KubeletNotReady: container runtime is down"))
+    }
+
     @Test("single not ready pod uses singular primary status reason")
     func singleNotReadyPodUsesSingularPrimaryStatusReason() {
         let snapshot = ClusterSnapshot(
@@ -149,6 +219,36 @@ struct MenuDisplayModelTests {
 
         #expect(display.state == .watch)
         #expect(display.primaryStatusReason == "1 pod not ready")
+    }
+
+    @Test("pod status help includes pod condition detail")
+    func podStatusHelpIncludesPodConditionDetail() {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(ready: 11, running: 12, total: 12)),
+            podDetailsSection: .available([
+                podDetail(
+                    namespace: "api",
+                    name: "checkout",
+                    readyContainerCount: 0,
+                    totalContainerCount: 1,
+                    notReadyConditionReason: "ContainersNotReady",
+                    notReadyConditionMessage: "containers with unready status",
+                    isNotReady: true
+                )
+            ]),
+            metricsSection: .available(metricsSummary()),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+
+        #expect(display.primaryStatusReason == "1 pod not ready")
+        #expect(display.overview.statusHelpText == "api/checkout, Watch, 0/1 containers ready, ContainersNotReady: containers with unready status")
+        #expect(display.overview.statusAccessibilityLabel.contains("ContainersNotReady: containers with unready status"))
     }
 
     @Test("metrics unavailable does not change otherwise OK state")
@@ -167,6 +267,8 @@ struct MenuDisplayModelTests {
 
         #expect(display.state == .ok)
         #expect(display.primaryStatusReason == "Metrics unavailable")
+        #expect(display.overview.statusHelpText == "Metrics unavailable: metrics API unavailable")
+        #expect(display.overview.statusAccessibilityLabel.contains("metrics API unavailable"))
         #expect(display.overview.cards.first(where: { $0.id == "cpu" })?.state == .unavailable)
         #expect(display.overview.cards.first(where: { $0.id == "memory" })?.detail == "metrics API unavailable")
     }
@@ -523,6 +625,8 @@ struct MenuDisplayModelTests {
         #expect(display.staleBanner?.lastUpdated == "2m ago")
         #expect(display.staleBanner?.reason == "kubectl timed out")
         #expect(display.primaryStatusReason == "kubectl timed out")
+        #expect(display.overview.statusHelpText == "kubectl timed out, last updated 2m ago")
+        #expect(display.overview.statusAccessibilityLabel.contains("kubectl timed out, last updated 2m ago"))
         #expect(display.visibleWatchItems.first?.title == "api/checkout")
     }
 
@@ -555,6 +659,7 @@ struct MenuDisplayModelTests {
         #expect(display.lastUpdated == "2m ago")
         #expect(display.staleBanner?.reason == "Last refresh is too old")
         #expect(display.primaryStatusReason == "Last refresh is too old")
+        #expect(display.overview.statusHelpText == "Last refresh is too old, last updated 2m ago")
     }
 
     @Test("watch item detail defaults to row reason")
@@ -850,6 +955,7 @@ struct MenuDisplayModelTests {
         #expect(display.counters.warningEvents == "-")
         #expect(display.state == .watch)
         #expect(display.primaryStatusReason == "invalid event JSON")
+        #expect(display.overview.statusHelpText == "Warning events unavailable: invalid event JSON")
         #expect(display.sectionNotices.contains { $0.title == "Warning events" && $0.reason == "invalid event JSON" })
         #expect(display.overview.recentWarningsUnavailableMessage == "Warning events unavailable: invalid event JSON")
         #expect(display.overview.recentWarningsEmptyMessage == "Warning event count unavailable")

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -477,6 +477,30 @@ struct MenuDisplayModelTests {
         #expect(emptyDisplay.podTab.emptyMessage == "No watched pods found")
     }
 
+    @Test("completed only watched pods stay healthy with completed empty message")
+    func completedOnlyWatchedPodsStayHealthyWithCompletedEmptyMessage() {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(ready: 0, running: 0, total: 0)),
+            podDetailsSection: .available([]),
+            metricsSection: .available(metricsSummary()),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([
+                TrackedItemStatus(target: .namespace("jobs"), state: .ok, reason: "completed jobs are OK")
+            ]),
+            hasCompletedWatchedPods: true,
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+
+        #expect(display.state == .ok)
+        #expect(display.primaryStatusReason == "All tracked items OK")
+        #expect(display.podTab.sections.isEmpty)
+        #expect(display.podTab.emptyMessage == "No active pods; completed jobs are OK")
+    }
+
     @Test("single warning event uses singular primary status reason")
     func singleWarningEventUsesSingularPrimaryStatusReason() {
         let snapshot = ClusterSnapshot(

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -441,8 +441,8 @@ struct MenuDisplayModelTests {
         #expect(row.issueText == nil)
     }
 
-    @Test("pod tab distinguishes unavailable and empty watched pods")
-    func podTabDistinguishesUnavailableAndEmptyWatchedPods() {
+    @Test("pod tab treats empty watched pods as healthy and distinct from unavailable")
+    func podTabTreatsEmptyWatchedPodsAsHealthyAndDistinctFromUnavailable() {
         let unavailable = ClusterSnapshot(
             contextName: "prod",
             nodesSection: .available(NodeSummary(ready: 3, total: 3)),
@@ -456,9 +456,10 @@ struct MenuDisplayModelTests {
             nodesSection: .available(NodeSummary(ready: 3, total: 3)),
             podsSection: .available(PodSummary(ready: 0, running: 0, total: 0)),
             podDetailsSection: .available([]),
+            metricsSection: .available(metricsSummary()),
             warningEventsSection: .available([]),
             workloadsSection: .available([
-                TrackedItemStatus(target: .namespace("api"), state: .watch, reason: "no matching pods")
+                TrackedItemStatus(target: .namespace("api"), state: .ok, reason: "no matching pods")
             ]),
             capturedAt: Date(timeIntervalSince1970: 100)
         )
@@ -467,8 +468,10 @@ struct MenuDisplayModelTests {
         let emptyDisplay = HealthEvaluator().evaluate(snapshot: empty, now: Date(timeIntervalSince1970: 120))
 
         #expect(unavailableDisplay.podTab.unavailableMessage == "Pod data unavailable: invalid pod JSON")
-        #expect(emptyDisplay.state == .watch)
-        #expect(emptyDisplay.primaryStatusReason == "no matching pods")
+        #expect(emptyDisplay.state == .ok)
+        #expect(emptyDisplay.primaryStatusReason == "All tracked items OK")
+        #expect(emptyDisplay.visibleWatchItems.first?.state == .ok)
+        #expect(emptyDisplay.visibleWatchItems.first?.reason == "no matching pods")
         #expect(emptyDisplay.podTab.unavailableMessage == nil)
         #expect(emptyDisplay.podTab.sections.isEmpty)
         #expect(emptyDisplay.podTab.emptyMessage == "No watched pods found")

--- a/KubebarTests/QA/MenuStateFixtureCatalogTests.swift
+++ b/KubebarTests/QA/MenuStateFixtureCatalogTests.swift
@@ -19,6 +19,7 @@ struct MenuStateFixtureCatalogTests {
     @Test("required fixtures map to locked display states")
     func requiredFixturesMapToLockedDisplayStates() {
         let healthy = MenuStateFixtureCatalog.fixture(for: .healthy)
+        let completedJobs = MenuStateFixtureCatalog.fixture(for: .completedJobs)
         let watch = MenuStateFixtureCatalog.fixture(for: .watch)
         let bad = MenuStateFixtureCatalog.fixture(for: .bad)
         let staleRefreshFailure = MenuStateFixtureCatalog.fixture(for: .staleRefreshFailure)
@@ -30,6 +31,13 @@ struct MenuStateFixtureCatalogTests {
         #expect(healthy.display.state == .ok)
         #expect(healthy.display.podTab.summary == "3/3 watched pods ready")
         #expect(healthy.display.podTab.sections.map(\.namespace) == ["qa-api", "qa-monitoring"])
+        #expect(completedJobs.display.state == .ok)
+        #expect(completedJobs.display.primaryStatusReason == "All tracked items OK")
+        #expect(completedJobs.display.visibleWatchItems.first?.reason == "completed jobs are OK")
+        #expect(completedJobs.display.overview.cards.first(where: { $0.id == "pods" })?.value == "0/0")
+        #expect(completedJobs.display.podTab.summary == "0/0 watched pods ready")
+        #expect(completedJobs.display.podTab.sections.isEmpty)
+        #expect(completedJobs.display.podTab.emptyMessage == "No active pods; completed jobs are OK")
         #expect(watch.display.state == .watch)
         #expect(watch.display.podTab.sections.first?.namespace == "qa-api")
         #expect(watch.display.podTab.sections.first?.rows.first?.state == .watch)
@@ -112,8 +120,10 @@ struct MenuStateFixtureCatalogTests {
     @Test("fixture lookup uses raw value names")
     func fixtureLookupUsesRawValueNames() throws {
         let fixture = try #require(MenuStateFixtureCatalog.fixture(named: "stale-refresh-failure"))
+        let completedJobs = try #require(MenuStateFixtureCatalog.fixture(named: "completed-jobs"))
 
         #expect(fixture.id == .staleRefreshFailure)
+        #expect(completedJobs.id == .completedJobs)
         #expect(MenuStateFixtureCatalog.fixture(named: "missing") == nil)
     }
 

--- a/KubebarTests/QA/MenuStateFixtureCatalogTests.swift
+++ b/KubebarTests/QA/MenuStateFixtureCatalogTests.swift
@@ -63,6 +63,26 @@ struct MenuStateFixtureCatalogTests {
         #expect(warningHeavy.expectedBehavior.contains("refresh/settings/quit only"))
     }
 
+    @Test("overview status help exposes detailed safe context")
+    func overviewStatusHelpExposesDetailedSafeContext() {
+        let watch = MenuStateFixtureCatalog.fixture(for: .watch)
+        let bad = MenuStateFixtureCatalog.fixture(for: .bad)
+        let staleRefreshFailure = MenuStateFixtureCatalog.fixture(for: .staleRefreshFailure)
+        let metricsUnavailable = MenuStateFixtureCatalog.fixture(for: .metricsUnavailable)
+        let warningHeavy = MenuStateFixtureCatalog.fixture(for: .warningHeavy)
+
+        #expect(watch.display.overview.statusText == "1 pod restarting")
+        #expect(watch.display.overview.statusHelpText.contains("qa-api: 1 pod restarting"))
+        #expect(watch.display.overview.statusHelpText.contains("latest warning BackOff qa-api/pod/qa-checkout-7f9"))
+        #expect(watch.display.overview.statusAccessibilityLabel.contains(watch.display.overview.statusHelpText))
+        #expect(bad.display.overview.statusHelpText.contains("qa-payments: 2 pods unavailable"))
+        #expect(bad.display.overview.statusHelpText.contains("examples qa-payments-api-0, qa-payments-worker-1"))
+        #expect(staleRefreshFailure.display.overview.statusHelpText.contains("Refresh failed; showing last known status."))
+        #expect(staleRefreshFailure.display.overview.statusHelpText.contains("last updated 2m ago"))
+        #expect(metricsUnavailable.display.overview.statusHelpText == "Metrics unavailable: metrics API unavailable")
+        #expect(warningHeavy.display.overview.statusHelpText.contains("latest warning BackOff qa-api/pod/qa-checkout-7f9"))
+    }
+
     @Test("watch fixture exposes reason first warning details")
     func watchFixtureExposesReasonFirstWarningDetails() {
         let fixture = MenuStateFixtureCatalog.fixture(for: .watch)
@@ -120,6 +140,8 @@ struct MenuStateFixtureCatalogTests {
                     fixture.followUpRisk,
                     fixture.display.healthSentence,
                     fixture.display.primaryStatusReason,
+                    fixture.display.overview.statusHelpText,
+                    fixture.display.overview.statusAccessibilityLabel,
                     fixture.display.staleBanner?.reason ?? ""
                 ].joined(separator: "\n")
             }

--- a/KubebarTests/Services/KubectlClusterReaderTests.swift
+++ b/KubebarTests/Services/KubectlClusterReaderTests.swift
@@ -389,6 +389,57 @@ struct KubectlClusterReaderTests {
         #expect(item?.examplePodNames == [])
     }
 
+    @Test("completed job pods are excluded from active summaries and rows")
+    func completedJobPodsAreExcludedFromActiveSummariesAndRows() throws {
+        let snapshot = try readSnapshot(
+            pods: activeAndCompletedJobPodsJSON,
+            warningEvents: emptyListJSON,
+            watchTargets: [.namespace("api")]
+        )
+        let item = snapshot.trackedItems.first
+        let details = try #require(snapshot.podDetailsSection.value)
+
+        #expect(snapshot.podsSection.value == PodSummary(ready: 1, running: 1, total: 1))
+        #expect(snapshot.hasCompletedWatchedPods == true)
+        #expect(details.map(\.name) == ["checkout-active"])
+        #expect(item?.state == .ok)
+        #expect(item?.reason == "1/1 pods running")
+    }
+
+    @Test("completed only watched scope stays healthy")
+    func completedOnlyWatchedScopeStaysHealthy() throws {
+        let snapshot = try readSnapshot(
+            pods: completedOnlyJobPodsJSON,
+            warningEvents: emptyListJSON,
+            watchTargets: [.namespace("jobs")]
+        )
+        let item = snapshot.trackedItems.first
+        let details = try #require(snapshot.podDetailsSection.value)
+
+        #expect(snapshot.podsSection.value == PodSummary(ready: 0, running: 0, total: 0))
+        #expect(snapshot.hasCompletedWatchedPods == true)
+        #expect(details.isEmpty)
+        #expect(item?.state == .ok)
+        #expect(item?.reason == "completed jobs are OK")
+    }
+
+    @Test("failed job pods remain bad")
+    func failedJobPodsRemainBad() throws {
+        let snapshot = try readSnapshot(
+            pods: failedJobPodsJSON,
+            warningEvents: emptyListJSON,
+            watchTargets: [.namespace("jobs")]
+        )
+        let item = snapshot.trackedItems.first
+        let details = try #require(snapshot.podDetailsSection.value)
+
+        #expect(snapshot.podsSection.value == PodSummary(ready: 0, running: 0, total: 1))
+        #expect(snapshot.hasCompletedWatchedPods == false)
+        #expect(details.map(\.name) == ["report-failed"])
+        #expect(item?.state == .bad)
+        #expect(item?.reason == "1 pod failed")
+    }
+
     @Test("failed pods outrank restarting and not ready pods")
     func failedPodsOutrankRestartingAndNotReadyPods() throws {
         let snapshot = try readSnapshot(
@@ -954,6 +1005,75 @@ private let healthyCheckoutPodsJSON = """
         "conditions": [{"type": "Ready", "status": "True"}],
         "containerStatuses": [
           {"ready": true, "restartCount": 0}
+        ]
+      }
+    }
+  ]
+}
+"""
+
+private let activeAndCompletedJobPodsJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "api", "name": "checkout-active"},
+      "status": {
+        "phase": "Running",
+        "conditions": [{"type": "Ready", "status": "True"}],
+        "containerStatuses": [
+          {"ready": true, "restartCount": 0}
+        ]
+      }
+    },
+    {
+      "metadata": {"namespace": "api", "name": "report-complete"},
+      "status": {
+        "phase": "Succeeded",
+        "conditions": [{"type": "Ready", "status": "False"}],
+        "containerStatuses": [
+          {"ready": false, "restartCount": 0, "state": {"terminated": {"reason": "Completed"}}}
+        ]
+      }
+    }
+  ]
+}
+"""
+
+private let completedOnlyJobPodsJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "jobs", "name": "report-succeeded"},
+      "status": {
+        "phase": "Succeeded",
+        "conditions": [{"type": "Ready", "status": "False"}],
+        "containerStatuses": [
+          {"ready": false, "restartCount": 0, "state": {"terminated": {"reason": "Completed"}}}
+        ]
+      }
+    },
+    {
+      "metadata": {"namespace": "jobs", "name": "cleanup-completed"},
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {"ready": false, "restartCount": 0, "state": {"terminated": {"reason": "Completed"}}}
+        ]
+      }
+    }
+  ]
+}
+"""
+
+private let failedJobPodsJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "jobs", "name": "report-failed"},
+      "status": {
+        "phase": "Failed",
+        "containerStatuses": [
+          {"ready": false, "restartCount": 0, "state": {"terminated": {"reason": "Error"}}}
         ]
       }
     }

--- a/KubebarTests/Services/KubectlClusterReaderTests.swift
+++ b/KubebarTests/Services/KubectlClusterReaderTests.swift
@@ -374,8 +374,8 @@ struct KubectlClusterReaderTests {
         #expect(!runner.requests.contains { $0.arguments.contains(forbiddenResource) })
     }
 
-    @Test("missing workload produces no matching pods")
-    func missingWorkloadProducesNoMatchingPods() throws {
+    @Test("missing workload produces healthy no matching pods")
+    func missingWorkloadProducesHealthyNoMatchingPods() throws {
         let snapshot = try readSnapshot(
             pods: emptyListJSON,
             warningEvents: emptyListJSON,
@@ -383,7 +383,7 @@ struct KubectlClusterReaderTests {
         )
         let item = snapshot.trackedItems.first
 
-        #expect(item?.state == .watch)
+        #expect(item?.state == .ok)
         #expect(item?.reason == "no matching pods")
         #expect(item?.affectedPodCount == nil)
         #expect(item?.examplePodNames == [])

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -57,6 +57,13 @@ These are the rules Kubebar must keep true at runtime.
   values must not be rendered as `0`.
 - Historical restart count alone must not make a Pod item Bad. Current failed,
   waiting, or crash-looping state may make a Pod item Bad.
+- Successfully completed Job Pods are not active readiness failures. They do
+  not reduce active Pod ready/all counts, do not appear as active Pod rows by
+  default, and do not move the menu to `Watch` or `Bad` by themselves.
+- A watched target with only successfully completed Job Pods stays `OK` and
+  uses `No active pods; completed jobs are OK` in the Pods tab empty state.
+- Failed Job Pods remain failures; only successful completion gets the
+  completed treatment.
 - A watched target with no matching Pods is a normal OK condition with a clear
   row reason, not a Watch or Bad Pod failure.
 - Kubebar does not query Kubernetes Secrets.

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -11,6 +11,8 @@ These are the rules Kubebar must keep true at runtime.
   ordering.
 - The first screen shows the top status row, Nodes card, Pods card, CPU card,
   Memory card, and capped `Recent Warnings`; warning overflow belongs in Events.
+- The Overview top status row keeps visible text short. Hover/help and
+  accessibility text must carry the concrete status reason when one is known.
 - The menu must stay within the visible screen height. Long tab content scrolls
   inside the menu instead of pushing the menu off screen.
 - The menu footer stays visible at the bottom of the menu. Long Events, Pods,
@@ -145,4 +147,7 @@ These are the rules Kubebar must keep true at runtime.
 - Warning and failure states must not rely on color alone.
 - Watch, Bad, and Stale must be expressed with symbol, state text, and one
   short reason; color alone is not enough.
+- Overview status help must explain the same condition as the short status
+  reason, using safe display text for tracked-object, node, Pod, warning,
+  unavailable-data, or stale-refresh detail.
 - Stale or failed reads must use distinct icon semantics from `OK`.

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -57,8 +57,8 @@ These are the rules Kubebar must keep true at runtime.
   values must not be rendered as `0`.
 - Historical restart count alone must not make a Pod item Bad. Current failed,
   waiting, or crash-looping state may make a Pod item Bad.
-- A watched target with no matching Pods is a visible Watch condition, not a
-  Bad Pod failure.
+- A watched target with no matching Pods is a normal OK condition with a clear
+  row reason, not a Watch or Bad Pod failure.
 - Kubebar does not query Kubernetes Secrets.
 - Events warning summaries are capped at 3. Overview `Recent Warnings` is capped
   at 2 visible rows by default so it cannot push the top status row or cards out

--- a/docs/brainstorms/2026-04-22-kubebar-overview-design-requirements.md
+++ b/docs/brainstorms/2026-04-22-kubebar-overview-design-requirements.md
@@ -50,6 +50,10 @@ Overview
 **Language and warnings**
 - R14. Overview must remove the `Watching` label and long health-description sentences such as "Cluster looks healthy" or "needs watching".
 - R15. Overview must still provide a readable one-line top-row health description for scanability and accessibility, paired with the health-state icon.
+- R15a. When the user hovers over the top-row cluster status description, the help text must include the most specific known reason for the current status, not only repeat the shortened visible status text.
+- R15b. The hover detail should include relevant concrete failure context when available, such as affected tracked object, node readiness reason and message, pod condition or container reason and message, warning event detail, section-unavailable reason, or stale refresh reason.
+- R15c. Hover detail must stay safe for a menu-bar surface: do not expose raw command output, tokens, file paths, or noisy kubectl transcripts; use the same sanitized operator-facing reasons used elsewhere in the display.
+- R15d. The same detailed status information exposed on hover must also be available through accessibility text so the detail is not mouse-only.
 - R16. Overview must show warning events under the section title `Recent Warnings`.
 - R17. Recent warning rows must show the warning reason, affected object, and age in a compact format.
 - R18. When there are no warning events, the empty state must stay neutral and must not become a health claim.
@@ -75,6 +79,9 @@ Overview
 - Pods show `<ready count>/<all count>` on Overview without opening the Pods tab.
 - CPU and memory values are traceable to `kubectl` data or clearly marked unavailable.
 - Overview no longer contains `Watching` or long health prose such as "Cluster looks healthy" or "needs watching".
+- Hovering the top cluster/status description shows detailed concrete status context, for example the exact failing object or underlying node/pod/warning/stale reason when that data exists.
+- The hover detail is more informative than the visible one-line status text, but it remains sanitized and safe to display.
+- The detailed hover status is also available to accessibility users.
 - Warning events appear as `Recent Warnings`.
 - Each recent warning row answers, in order: what happened, where it happened, how recent it is, whether it repeated, and the latest useful message.
 - Tracked-object warnings are recognizable without using `Watching` language.
@@ -98,6 +105,7 @@ Overview
 - **Recent warnings replaces the single notice pattern:** A list of recent warning rows is more useful than one generic Overview notice for the visual direction.
 - **Warning rows lead with cause, then scope:** Operators scan warnings to find the failure mode first, then confirm which object is affected. Reason-first rows should still show object and namespace clearly enough to avoid ambiguity.
 - **Message text is secondary context:** Kubernetes event messages can be noisy or long. They should help when useful, but they should not bury reason, object, age, or repeat count.
+- **Visible status stays short; hover carries detail:** The top-row status should remain a scan-friendly one-liner, while hover/help and accessibility text carry the concrete diagnostic context needed to understand why the cluster is not OK.
 - **Kubectl remains the data boundary:** CPU, memory, nodes, pods, and warnings should all be derived from `kubectl`-backed reads so Kubebar continues to use the operator's existing cluster access.
 
 ## Alternatives Considered

--- a/docs/brainstorms/2026-04-22-kubebar-pod-item-menu-ui-requirements.md
+++ b/docs/brainstorms/2026-04-22-kubebar-pod-item-menu-ui-requirements.md
@@ -14,6 +14,11 @@ scannable Pod item list rather than only a watchlist-style summary. The design
 must stay compact enough for a menu bar app and must not become a full
 Kubernetes dashboard.
 
+Completed Job Pods create a special case for readiness. They are no longer
+expected to become Ready because their work already finished successfully, so
+Kubebar should not count them as unready active Pods or use them to push the
+cluster into Watch or Bad.
+
 ## Visual Aid
 
 ```text
@@ -73,6 +78,22 @@ Color intent:
 - R14. Dot color must not be the only status signal; hover/help and
   accessibility text must include the status in words.
 
+**Completed Job Pods**
+- R14a. A successfully completed Job Pod must be treated as a normal completed
+  outcome, not as an unready active Pod.
+- R14b. Completed Job Pods must not reduce active Pod ready/all counts in the
+  Pods tab summary or Overview Pods card.
+- R14c. Completed Job Pods must not move the menu state to Watch or Bad by
+  themselves.
+- R14d. If the watched scope contains only completed Job Pods and no active
+  Pods, Kubebar should remain OK and show `No active pods; completed jobs are
+  OK` rather than a readiness warning.
+- R14e. Failed Job Pods remain Bad. Only successful completion gets the normal
+  completed treatment.
+- R14f. The default Pods tab should not list completed Job Pods as active Pod
+  rows. If a later design surfaces completed Pods, they need a separate neutral
+  completed presentation rather than reusing Ready, Watch, or Bad.
+
 **Error and secondary text**
 - R15. A Pod with an error, warning, or not-ready reason must show a short
   secondary line below the Pod name.
@@ -111,6 +132,8 @@ Color intent:
 - A user can spot failed or partially ready Pods before reading every row.
 - Ready count / all count is visible on every Pod row and cannot be confused
   with the overall tab summary.
+- Completed Job Pods do not appear as unready active Pods and do not create a
+  false Watch or Bad state.
 - Error information is present without making the menu feel like a log viewer.
 - Namespace grouping improves scanning without hiding Pods.
 - Stale or unavailable Pod data is visibly not current.
@@ -121,6 +144,7 @@ Color intent:
 - This change does not add Pod logs, events drilldown, shell commands, or links
   into external tools.
 - This change does not change menu bar health categories.
+- This change does not add a historical Job dashboard or completed-run history.
 - This change does not replace the Overview, Nodes, or Events tabs.
 - This change does not require Prometheus, Grafana, or any external monitoring
   dependency.
@@ -132,6 +156,8 @@ Color intent:
   mental map.
 - **Show ready/all on each Pod row:** The row should expose readiness locally,
   not only in the tab summary.
+- **Exclude completed Job Pods from active readiness:** Successful completion is
+  a terminal normal outcome, not an active readiness failure.
 - **Use dots plus text support:** Dots make the list scannable, while
   accessibility and hover text prevent color-only meaning.
 - **Keep error text shallow:** The row should explain the visible problem, but
@@ -144,9 +170,13 @@ Color intent:
 | Keep current watchlist-style rows and add ready/all | Smallest visual change | Does not satisfy direct Pod item browsing or namespace grouping |
 | Group all visible Pods by namespace | Best match for the requested UI and easiest to scan | Needs careful ordering and scroll behavior for large clusters |
 | Collapse each namespace by default | Reduces height for large clusters | Hides problems unless attention groups auto-expand, adding behavior complexity |
+| Count completed Job Pods as ready | Keeps totals simple | Misleads because completed Pods are not actively ready |
+| Show completed Job Pods as a separate neutral state | Preserves more history | Adds UI complexity and historical Job semantics to a glanceable menu |
 
 Recommended option: group all visible Pods by namespace. It best matches the
-requested design while keeping the interaction simple.
+requested design while keeping the interaction simple. For completed Job Pods,
+exclude them from active readiness by default so successful completion does not
+look like a health problem.
 
 ## Dependencies / Assumptions
 
@@ -156,6 +186,9 @@ requested design while keeping the interaction simple.
   after decoding, or whether the display model needs a Pod item shape.
 - The watched namespace scope should remain the default display scope unless
   the product later adds an explicit "all namespaces" mode.
+- Planning should treat Kubernetes `Succeeded` phase and successful
+  `Completed` container termination as signals for completed Job Pods, while
+  preserving failed Job Pods as Bad.
 
 ## Outstanding Questions
 

--- a/docs/plans/2026-04-22-005-fix-no-matching-pods-health-plan.md
+++ b/docs/plans/2026-04-22-005-fix-no-matching-pods-health-plan.md
@@ -1,41 +1,39 @@
 ---
-title: fix: Reclassify no matching Pods health
+title: fix: Treat no matching Pods as normal
 type: fix
 status: completed
 date: 2026-04-22
 ---
 
-# fix: Reclassify no matching Pods health
+# fix: Treat no matching Pods as normal
 
 ## Overview
 
-Change Kubebar so a watched namespace or workload with no matching Pods is not
-classified as `Bad`. The app should still make the condition visible, but it
-should not treat "no matching pods" as the same class of failure as failed,
-restarting, or crash-looping Pods.
+Change Kubebar so a watched namespace or workload with no matching Pods is
+classified as `OK`. The row can still explain "no matching pods", but the app
+should not treat that condition as a cluster warning or failure.
 
 ## Problem Frame
 
-`KubectlClusterReader` currently returns a watched item with state `Bad` when a
-watch target has no matching Pods. `HealthEvaluator` then promotes any bad
-tracked item to a `Bad` cluster status. That makes an empty watched scope look
-like a failing cluster even though no failed Pod exists. This conflicts with
-the product rule that `Bad` should represent actual attention-worthy failure,
-while empty or unavailable data should be visibly distinct.
+`KubectlClusterReader` previously returned a watched item with a non-OK state
+when a watch target had no matching Pods. `HealthEvaluator` then surfaced the
+condition as cluster attention. That made an empty watched scope look
+actionable even though no failed Pod exists. The current product rule treats
+that empty scope as normal.
 
 ## Requirements Trace
 
-- R1. A watch target with no matching Pods must not make the cluster state
-  `Bad`.
-- R2. The watch target should still remain visible with a clear
+- R1. A watch target with no matching Pods must keep the cluster state `OK`
+  when no other warning or failure exists.
+- R2. The watch target may still remain visible with a clear
   "no matching pods" reason.
 - R3. Actual failed, restarting, or crash-looping Pods must still produce
   `Bad`.
 - R4. Pending, unknown, not-ready, and warning-like Pod states must continue to
   produce `Watch`.
 - R5. The Pods tab empty state must remain distinct from unavailable Pod data.
-- R6. Runtime documentation must state that no matching Pods is a visible
-  watch condition, not a bad Pod failure.
+- R6. Runtime documentation must state that no matching Pods is a normal OK
+  condition, not a Watch or Bad Pod failure.
 
 ## Scope Boundaries
 
@@ -53,8 +51,8 @@ while empty or unavailable data should be visibly distinct.
 - `AGENTS.md` requires `HealthEvaluator` to be the single source of truth for
   severity and stale or unavailable data to never look falsely healthy.
 - `KubebarCore/Services/KubectlClusterReader.swift` creates
-  `TrackedItemStatus` values for watch targets and currently assigns `Bad` to
-  no matching Pods.
+  `TrackedItemStatus` values for watch targets and assigns the state for no
+  matching Pods.
 - `KubebarCore/Services/HealthEvaluator.swift` promotes any tracked item with
   state `Bad` to a bad cluster state.
 - `KubebarTests/Services/KubectlClusterReaderTests.swift` has coverage for no
@@ -78,8 +76,8 @@ while empty or unavailable data should be visibly distinct.
 
 ## Key Technical Decisions
 
-- **Classify no matching Pods as `Watch`:** This keeps the condition visible
-  without using the failure severity reserved for actual bad Pods or bad nodes.
+- **Classify no matching Pods as `OK`:** This keeps an empty watched scope from
+  becoming cluster attention while preserving the row reason.
 - **Keep the reason string stable:** Preserve "no matching pods" so existing UI
   copy and operator meaning remain clear.
 - **Avoid fake affected Pod counts:** No matching Pods should not report `0`
@@ -87,15 +85,14 @@ while empty or unavailable data should be visibly distinct.
   if a related warning exists.
 - **Add regression coverage at both source and display layers:** The reader
   test proves the tracked item state, while the display test proves the cluster
-  state is not promoted to `Bad`.
+  state stays `OK`.
 
 ## Open Questions
 
 ### Resolved During Planning
 
-- **Should no matching Pods be `OK` or `Watch`?** Use `Watch`. The target is in
-  the user's watchlist and the missing match is still useful to notice, but it
-  is not a hard failure.
+- **Should no matching Pods be `OK` or `Watch`?** Use `OK`. The user clarified
+  that no matching Pods is normal, not an attention state.
 
 ### Deferred to Implementation
 
@@ -106,7 +103,7 @@ while empty or unavailable data should be visibly distinct.
 
 - [x] **Unit 1: Reclassify no matching Pods at the tracked-item source**
 
-**Goal:** Make no matching Pods produce a visible non-bad tracked item.
+**Goal:** Make no matching Pods produce a normal tracked item.
 
 **Requirements:** R1, R2, R3, R4
 
@@ -117,7 +114,7 @@ while empty or unavailable data should be visibly distinct.
 - Test: `KubebarTests/Services/KubectlClusterReaderTests.swift`
 
 **Approach:**
-- Change the no matching Pods branch so it returns `Watch` instead of `Bad`.
+- Change the no matching Pods branch so it returns `OK`.
 - Preserve the "no matching pods" reason.
 - Remove the fake `affectedPodCount: 0` value unless a test reveals existing UI
   needs it for a specific reason.
@@ -131,18 +128,18 @@ while empty or unavailable data should be visibly distinct.
 
 **Test scenarios:**
 - Happy path: workload target with zero matching Pods -> tracked item state is
-  `Watch`, reason is "no matching pods", and example Pod names are empty.
+  `OK`, reason is "no matching pods", and example Pod names are empty.
 - Regression: failed Pods still return `Bad`.
 - Regression: restarting Pods still return `Bad`.
 - Regression: pending or unknown Pods still return `Watch`.
 
 **Verification:**
-- No matching Pods no longer originate as a bad tracked item.
+- No matching Pods no longer originate as an attention tracked item.
 - Existing failure-state tests continue to pass.
 
 - [x] **Unit 2: Lock display-level health behavior**
 
-**Goal:** Ensure the full display model does not report a bad cluster solely
+**Goal:** Ensure the full display model does not report a non-OK cluster solely
 because a watched target has no matching Pods.
 
 **Requirements:** R1, R2, R5
@@ -156,8 +153,8 @@ because a watched target has no matching Pods.
 - Extend the existing Pods tab empty-state coverage or add a nearby focused test
   using a snapshot with no Pod details and a tracked item reason of
   "no matching pods".
-- Assert the display state is `Watch`, not `Bad`.
-- Assert the primary status reason stays useful and the Pods tab remains empty,
+- Assert the display state is `OK`, not `Watch` or `Bad`.
+- Assert the watched item reason stays useful and the Pods tab remains empty,
   not unavailable.
 
 **Patterns to follow:**
@@ -166,7 +163,7 @@ because a watched target has no matching Pods.
 
 **Test scenarios:**
 - Happy path: empty Pod details plus no matching Pods tracked item -> display
-  state is `Watch`, primary reason is "no matching pods", and Pods tab empty
+  state is `OK`, row reason is "no matching pods", and Pods tab empty
   message is "No watched pods found".
 - Regression: unavailable Pod data still shows a Pod unavailable message rather
   than the empty watched Pods message.
@@ -177,7 +174,7 @@ because a watched target has no matching Pods.
 - [x] **Unit 3: Update runtime invariant documentation**
 
 **Goal:** Record the new severity rule so future changes do not reclassify no
-matching Pods as a hard failure.
+matching Pods as an attention state.
 
 **Requirements:** R6
 
@@ -188,7 +185,7 @@ matching Pods as a hard failure.
 
 **Approach:**
 - Add a concise invariant near the Pod data rules: no matching Pods is a visible
-  watch condition, not a Bad Pod failure.
+  normal OK condition, not a Watch or Bad Pod failure.
 - Keep wording aligned with existing rules about unavailable data and current
   failed or crash-looping Pods.
 
@@ -205,7 +202,7 @@ matching Pods as a hard failure.
 
 - **Interaction graph:** `KubectlClusterReader` shapes tracked-item state;
   `HealthEvaluator` consumes that state when choosing menu status and reason.
-- **Error propagation:** No matching Pods remains visible as a watch reason;
+- **Error propagation:** No matching Pods remains visible as a normal row reason;
   real Pod read failures still surface through unavailable section messages.
 - **State lifecycle risks:** Empty watched scope must not be confused with
   stale data or unavailable data.
@@ -219,7 +216,7 @@ matching Pods as a hard failure.
 
 | Risk | Mitigation |
 |------|------------|
-| Empty watched scope becomes too quiet | Use `Watch`, not `OK`, and preserve the visible reason text. |
+| Empty watched scope becomes too quiet | Preserve the visible row reason while keeping the status `OK`. |
 | Real bad Pod states are weakened by accident | Keep failed and restarting regression tests passing. |
 | Empty and unavailable Pod states become blurred | Keep model coverage for both empty watched Pods and unavailable Pod data. |
 

--- a/docs/plans/2026-04-23-001-feat-overview-status-hover-detail-plan.md
+++ b/docs/plans/2026-04-23-001-feat-overview-status-hover-detail-plan.md
@@ -1,0 +1,384 @@
+---
+title: "feat: Add Overview status hover detail"
+type: feat
+status: active
+date: 2026-04-23
+origin: docs/brainstorms/2026-04-22-kubebar-overview-design-requirements.md
+---
+
+# feat: Add Overview status hover detail
+
+## Overview
+
+Add detailed hover and accessibility text to the Overview top cluster/status
+description. The visible top-row text stays short and scan-friendly, while the
+hover/help text explains the most specific known reason behind the current
+status: tracked object issue, node or pod condition detail, warning event
+detail, section-unavailable reason, metrics-unavailable detail, or stale refresh
+reason.
+
+This is an incremental plan for the newly added hover-detail requirements in
+the Overview requirements document. The broader Overview cards redesign is
+already covered by `docs/plans/2026-04-22-001-feat-overview-cluster-cards-plan.md`.
+
+## Problem Frame
+
+The current Overview top-row status already shows a compact status phrase and
+uses hover/help, but the hover text repeats the same short phrase. That leaves
+the operator without the concrete error context they expected from hovering:
+which object is affected, which node or pod condition caused the state, which
+warning was most relevant, or why data is stale or unavailable.
+
+The fix should keep the menu glanceable while making hover and accessibility
+text useful enough to answer "why is this status showing?" without opening a
+deeper tab first.
+
+## Requirements Trace
+
+- R15. Keep the visible top-row health description readable and one-line.
+- R15a. Hover over the top-row cluster status must include the most specific
+  known reason for the current status, not only repeat the visible text.
+- R15b. Hover detail should include concrete context when available: affected
+  tracked object, node readiness reason/message, pod condition or container
+  reason/message, warning event detail, section-unavailable reason, or stale
+  refresh reason.
+- R15c. Hover detail must stay safe: no raw command output, tokens, file paths,
+  or kubectl transcripts.
+- R15d. The same detailed status information must be available through
+  accessibility text.
+- R23. Visible top-row status remains concise and exposes full detail through
+  tooltip/accessibility text.
+
+## Scope Boundaries
+
+- No visible long-form status text in the top row.
+- No new troubleshooting actions or links.
+- No changes to health severity categories: `OK`, `Watch`, `Bad`, and `Stale`
+  remain unchanged.
+- No raw kubectl output, JSON, file paths, tokens, or command transcripts in
+  hover or accessibility text.
+- No changes to Nodes, Pods, CPU, Memory, or Recent Warnings layout.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `KubebarCore/Models/MenuDisplayModel.swift` defines `OverviewDisplay` with
+  `statusText` and `statusAccessibilityLabel`; it does not currently carry a
+  separate detailed status/help value.
+- `KubebarCore/Services/HealthEvaluator.swift` computes the current
+  `primaryStatusReason`, overview display fields, stale banner, section
+  notices, node row help text, pod row help text, and warning row help text.
+- `Kubebar/Views/StatusSummaryView.swift` renders the top row and currently
+  applies `.help` using the short `statusText`.
+- `WarningEventDisplay.helpText`, `NodeItemDisplay.helpText`, and
+  `PodItemDisplay.helpText` already show the expected pattern: short visible
+  row text plus more complete hover/accessibility text.
+- `docs/architecture/runtime-invariants.md` already requires tooltips and
+  accessibility labels to avoid command transcripts and JSON.
+- `KubebarTests/Models/MenuDisplayModelTests.swift` covers status priority,
+  stale reasons, section failures, warning rows, node/pod issue detail, and
+  metrics-unavailable behavior.
+- `KubebarTests/QA/MenuStateFixtureCatalogTests.swift` verifies fixture
+  metadata and safe display strings for representative menu states.
+
+### Institutional Learnings
+
+- Keep Overview scan-first; detailed information belongs in hover/help,
+  accessibility, dedicated tabs, or detail views rather than expanding the
+  first row.
+- Preserve `MenuDisplayModel` as the UI rendering boundary and keep
+  `HealthEvaluator` responsible for deciding status meaning.
+- Stale, unavailable, and warning details must be operator-facing and safe, not
+  raw command output.
+
+### External References
+
+- External research is not needed. This is a native SwiftUI display-model
+  enhancement with strong local patterns in existing hover/help and
+  accessibility text.
+
+## Key Technical Decisions
+
+- **Add a dedicated detailed status field to `OverviewDisplay`:** The short
+  `statusText` remains the visible one-line value. A separate display-model
+  field carries hover/help detail so the view does not infer diagnostic meaning.
+- **Compute status detail in `HealthEvaluator`:** The evaluator already owns
+  severity, status priority, stale handling, section availability, and warning
+  summarization. Keeping detail assembly there preserves the existing boundary.
+- **Follow existing priority order:** The detailed status should explain the
+  same condition that drove the visible top-row status: stale first, then bad
+  tracked object, node deficit, pod deficit, warning/tracked warning, section
+  unavailability, metrics unavailability, and finally all-clear state.
+- **Prefer existing safe display facts:** Reuse already-sanitized reasons and
+  existing row help text patterns where possible instead of introducing raw
+  command output or Kubernetes transcripts.
+- **Make accessibility at least as informative as hover:** The accessibility
+  label should include the detailed status context, not only the short visible
+  text.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Update existing completed Overview plan or create a new one?** Create a new
+  incremental plan. The existing Overview plan is already complete and should
+  stay as the record for the broader redesign.
+- **Does this require external research?** No. The change follows local
+  SwiftUI, display-model, and safe-help-text patterns.
+
+### Deferred to Implementation
+
+- **Exact field/helper names:** Keep names consistent with the surrounding
+  implementation once the display shape is updated.
+- **Exact wording for all-clear hover text:** It may safely mirror the visible
+  OK text when no deeper issue exists; the requirement matters most when the
+  status reflects attention, stale, or unavailable data.
+
+## Implementation Units
+
+- [x] **Unit 1: Extend Overview status detail in the display model**
+
+**Goal:** Add a display-model value for detailed Overview status help text and
+populate it with the most specific safe reason available for the current status.
+
+**Requirements:** R15a, R15b, R15c, R15d, R23
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `KubebarCore/Models/MenuDisplayModel.swift`
+- Modify: `KubebarCore/Services/HealthEvaluator.swift`
+- Test: `KubebarTests/Models/MenuDisplayModelTests.swift`
+
+**Approach:**
+- Extend the Overview display contract with a dedicated status detail/help
+  value while preserving existing initializer compatibility where needed.
+- Build the detail from display-safe facts already available to
+  `HealthEvaluator`.
+- For tracked object attention, include the tracked object title and row/detail
+  reason; include affected pod count, example pod names, or latest warning only
+  when that display detail already exists.
+- For node attention, prefer a specific not-ready node and its issue text when
+  node details exist; otherwise fall back to the node deficit summary.
+- For pod attention, prefer a specific affected pod and its issue text when pod
+  details exist; otherwise fall back to the pod deficit summary.
+- For warning-only states, include the top relevant warning row help text,
+  preserving reason, object, age, repeat count, and latest message.
+- For stale states, include the stale reason and last-known timing context when
+  available.
+- For unavailable sections and metrics-unavailable states, include the
+  sanitized unavailable reason that is already shown in section/card display.
+- Fall back to the short visible status text when no more specific detail is
+  available.
+
+**Execution note:** Start with focused display-model tests for the new status
+detail before wiring the view.
+
+**Patterns to follow:**
+- `primaryStatusReason` in `KubebarCore/Services/HealthEvaluator.swift`
+- `nodeHelpText` and `podHelpText` in `KubebarCore/Services/HealthEvaluator.swift`
+- `WarningEventDisplay.helpText` in `KubebarCore/Models/MenuDisplayModel.swift`
+- Existing safe section reason handling in `HealthEvaluator`
+
+**Test scenarios:**
+- Happy path: bad tracked workload with affected pod detail -> status detail
+  names the tracked object and includes the concrete reason behind the Bad
+  state.
+- Happy path: not-ready node with reason and message -> visible status remains
+  short while status detail includes the node name and condition detail.
+- Happy path: not-ready pod with container or condition reason -> status detail
+  includes pod scope and the specific pod issue text.
+- Happy path: warning-only state -> status detail includes the top warning
+  reason, object scope, age/repeat metadata, and latest useful message.
+- Edge case: metrics unavailable while cluster is otherwise OK -> status detail
+  explains metrics unavailability without changing the OK state.
+- Edge case: stale refresh with previous data -> status detail includes the
+  stale/failure reason and does not imply the retained data is current.
+- Error path: unavailable section reason contains unsafe raw-looking content ->
+  status detail uses the safe reason path and does not expose raw command
+  output.
+- Regression: healthy all-clear state still has a non-empty status detail and
+  does not introduce long visible Overview text.
+
+**Verification:**
+- `OverviewDisplay` carries both short visible status and detailed status help.
+- The detail matches the same priority decision as the visible status.
+- Tests cover tracked, node, pod, warning, stale, and unavailable cases.
+
+- [x] **Unit 2: Wire the top-row hover and accessibility text**
+
+**Goal:** Make the Overview top-row cluster status use the detailed status value
+for hover/help and accessibility while keeping visible text compact.
+
+**Requirements:** R15, R15a, R15c, R15d, R23
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `Kubebar/Views/StatusSummaryView.swift`
+- Test: `KubebarTests/Models/MenuDisplayModelTests.swift`
+
+**Approach:**
+- Keep the visible top-row status rendering unchanged: state label plus
+  one-line `statusText`.
+- Change the status row help text to use the detailed status value from
+  `OverviewDisplay`.
+- Update the Overview status accessibility label so it includes the detailed
+  status context.
+- Preserve context-name hover behavior; context hover can remain focused on
+  the full context name, while the status row hover explains status cause.
+- Do not make `StatusSummaryView` inspect snapshot facts or choose fallback
+  messages.
+
+**Patterns to follow:**
+- Existing `.help(Text(...))` usage in `StatusSummaryView`
+- Full-text hover patterns in `WarningEventRowView`, `NodeDetailsView`, and
+  `PodsTabView`
+- Existing accessibility labels in `WarningEventDisplay`, `NodeItemDisplay`,
+  and `PodItemDisplay`
+
+**Test scenarios:**
+- Integration: display model for a warning state provides short visible text and
+  more detailed accessibility text.
+- Integration: display model for stale state provides detailed accessibility
+  text that includes stale reason.
+- Regression: top-row visible status text remains the existing short value and
+  does not duplicate full detail.
+
+**Verification:**
+- Hover over the status row exposes detailed status context.
+- Accessibility text includes the same detailed context.
+- The visible top-row status remains one line.
+
+- [x] **Unit 3: Update QA fixtures and runtime docs for the hover contract**
+
+**Goal:** Record the new hover/accessibility contract in QA expectations and
+runtime invariants so future changes do not regress it.
+
+**Requirements:** R15a, R15b, R15c, R15d
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `KubebarCore/QA/MenuStateFixtureCatalog.swift`
+- Modify: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+- Modify: `docs/architecture/runtime-invariants.md`
+- Modify: `docs/qa/operator-verification.md`
+
+**Approach:**
+- Update fixture expected behavior or limitations where representative states
+  should explicitly mention status hover/accessibility detail.
+- Add fixture-level checks that representative display states carry detailed
+  status context and do not expose sensitive or raw command-like strings.
+- Update runtime invariants to state that the Overview top status row keeps
+  short visible text and uses hover/accessibility for concrete status detail.
+- Update operator verification notes so human QA knows to hover the Overview
+  status row for warning, bad, stale, and unavailable examples.
+
+**Patterns to follow:**
+- Existing fixture metadata tests in `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+- Existing safe-string checks for metadata and failure displays
+- Existing operator verification wording for visible menu inspection
+
+**Test scenarios:**
+- Happy path: watch/bad/stale/metrics-unavailable fixtures contain detailed
+  status help or accessibility text that goes beyond the visible one-liner.
+- Error path: fixture safety checks fail if status detail includes unsafe raw
+  command-like content.
+- Regression: fixture copy still avoids reintroducing the `Watching` section.
+
+**Verification:**
+- QA fixtures describe and test the hover/accessibility behavior.
+- Runtime and operator docs preserve the short-visible/detail-on-hover contract.
+
+- [x] **Unit 4: Final validation**
+
+**Goal:** Confirm the new status hover behavior is complete without changing the
+rest of the Overview design.
+
+**Requirements:** R15, R15a, R15b, R15c, R15d, R23
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Test: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- Test: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+- Modify: `docs/qa/operator-verification.md`
+
+**Approach:**
+- Confirm display-model tests cover every status category with meaningful detail
+  where data exists.
+- Confirm view usage reads the display-model detail rather than inferring from
+  raw state.
+- Confirm no changes accidentally alter Overview cards, Recent Warnings caps,
+  health categories, or warning ordering.
+- Record any human-only verification needed for hover behavior in QA docs.
+
+**Patterns to follow:**
+- Existing final verification expectations in `AGENTS.md`
+- Existing model-first test coverage for Overview display behavior
+
+**Test scenarios:**
+- Integration: Bad tracked object -> visible status stays short, hover detail
+  gives concrete object/reason context.
+- Integration: Stale refresh -> visible status stays short, hover detail gives
+  stale reason.
+- Integration: Metrics unavailable -> OK state remains possible, hover/detail
+  explains unavailable metrics.
+- Regression: Overview still renders the same four cards and capped Recent
+  Warnings.
+
+**Verification:**
+- Focused display-model and QA fixture tests pass.
+- Full local quality gate passes before implementation is considered complete.
+- Manual QA notes clearly identify hover checks that automated tests cannot
+  visually prove.
+
+## System-Wide Impact
+
+- **Interaction graph:** `HealthEvaluator` computes short status and detailed
+  status display fields; `MenuDisplayModel` carries them; `StatusSummaryView`
+  renders the short text and exposes the detailed text through help and
+  accessibility.
+- **Error propagation:** Status detail must use safe reasons and existing
+  display facts. Raw command output remains behind reader/evaluator boundaries.
+- **State lifecycle risks:** Stale displays may retain previous data only with
+  stale marking; hover detail should reinforce, not weaken, that distinction.
+- **API surface parity:** This is an app-internal display model change. It does
+  not change kubectl reads, saved config, menu bar icon categories, or tab
+  availability.
+- **Integration coverage:** Model tests prove detail selection; QA fixture tests
+  protect representative menu states; human QA confirms actual macOS hover
+  behavior.
+- **Unchanged invariants:** UI still renders `MenuDisplayModel`; `HealthEvaluator`
+  remains the source of severity; Overview remains scan-first.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Hover detail repeats the short text and does not solve the operator need | Add tests where the detailed value must include object/reason context beyond the visible one-liner |
+| Detail exposes unsafe command output or paths | Reuse sanitized section/failure reasons and add fixture safety checks |
+| Views start deciding health detail | Keep detail selection in `HealthEvaluator` and have `StatusSummaryView` only render display-model fields |
+| Visible top row becomes too verbose | Preserve `statusText` as the only visible status phrase; keep full detail in hover/accessibility |
+| Accessibility falls behind hover behavior | Make accessibility label include the same detailed status context and cover it in model tests |
+
+## Documentation / Operational Notes
+
+- Update `docs/architecture/runtime-invariants.md` with the new top-row
+  hover/accessibility invariant.
+- Update `docs/qa/operator-verification.md` so manual QA hovers the top status
+  row in Bad, Watch, Stale, and unavailable-data states.
+- No operator setup change is required.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-22-kubebar-overview-design-requirements.md](../brainstorms/2026-04-22-kubebar-overview-design-requirements.md)
+- Related completed plan: [docs/plans/2026-04-22-001-feat-overview-cluster-cards-plan.md](2026-04-22-001-feat-overview-cluster-cards-plan.md)
+- Display model: `KubebarCore/Models/MenuDisplayModel.swift`
+- Status mapping: `KubebarCore/Services/HealthEvaluator.swift`
+- Top row view: `Kubebar/Views/StatusSummaryView.swift`
+- Overview view: `Kubebar/Views/OverviewTabView.swift`
+- Display-model tests: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- QA fixture tests: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`

--- a/docs/plans/2026-04-23-002-fix-completed-job-pods-readiness-plan.md
+++ b/docs/plans/2026-04-23-002-fix-completed-job-pods-readiness-plan.md
@@ -1,0 +1,376 @@
+---
+title: "fix: Exclude completed Job Pods from active readiness"
+type: fix
+status: active
+date: 2026-04-23
+origin: docs/brainstorms/2026-04-22-kubebar-pod-item-menu-ui-requirements.md
+---
+
+# fix: Exclude completed Job Pods from active readiness
+
+## Overview
+
+Treat successfully completed Job Pods as a normal terminal outcome rather than
+an active readiness problem. Completed Job Pods should not reduce Pod ready/all
+counts, should not appear as active Pod rows by default, and should not push the
+menu state to `Watch` or `Bad` on their own.
+
+This is an incremental plan for the completed Job Pod rules added to the Pod UI
+requirements. The broader grouped Pods tab work is already covered by
+`docs/plans/2026-04-22-004-feat-pod-item-menu-ui-plan.md`.
+
+## Problem Frame
+
+Kubebar currently derives Pod readiness from active readiness signals such as
+phase, readiness conditions, and container ready flags. That works for running
+workloads, but completed Job Pods are different: they are expected to stop being
+Ready after successful completion. Counting them as unready active Pods creates
+false `Watch` states and misleading ready/all totals.
+
+The fix should preserve Kubebar's glanceable health model while separating
+active workload readiness from successful completed Job history.
+
+## Requirements Trace
+
+- R14a. A successfully completed Job Pod is a normal completed outcome, not an
+  unready active Pod.
+- R14b. Completed Job Pods do not reduce active Pod ready/all counts in the
+  Pods tab summary or Overview Pods card.
+- R14c. Completed Job Pods do not move the menu state to `Watch` or `Bad` by
+  themselves.
+- R14d. If the watched scope contains only completed Job Pods and no active
+  Pods, Kubebar remains `OK` and shows `No active pods; completed jobs are OK`.
+- R14e. Failed Job Pods remain `Bad`; only successful completion gets the
+  completed treatment.
+- R14f. The default Pods tab does not list completed Job Pods as active Pod
+  rows. A future completed view would need separate neutral presentation.
+- R13. Failed, actively restarting, or crash-looping Pods still use `Bad`.
+- R25-R27. Unavailable, empty, and stale Pod states stay distinct.
+
+## Scope Boundaries
+
+- No completed Job history view.
+- No new health category beyond `OK`, `Watch`, `Bad`, and `Stale`.
+- No change to warning event collection or warning rows.
+- No change to Kubernetes reads, selectors, setup, or saved watchlist data.
+- No deep troubleshooting actions, logs, links, or shell commands.
+- No change to failed, pending, unknown, crash-looping, or active unready Pod
+  behavior except where a Pod is successfully completed.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `KubebarCore/Services/KubectlClusterReader.swift` decodes Pod phase,
+  readiness conditions, container ready flags, and container terminated reasons.
+- `makePodSummary(from:)` currently builds `PodSummary` from all decoded Pods.
+- `trackedStatus(for:pods:warningEvents:workloadSelectors:)` currently evaluates
+  matching Pods without a separate completed/active split.
+- `makePodDetailsSection(...)` currently emits watched Pod details for every
+  matching Pod.
+- `KubebarCore/Services/HealthEvaluator.swift` maps `PodDetail` into active
+  `Ready`, `Watch`, and `Bad` rows and builds the Pods tab summary.
+- Existing tests in `KubebarTests/Services/KubectlClusterReaderTests.swift`
+  cover failed, restarting, pending, unknown, unready, no matching, and matched
+  workload Pod behavior.
+- Existing tests in `KubebarTests/Models/MenuDisplayModelTests.swift` cover
+  Overview Pod ready/all semantics, Pods tab empty/unavailable behavior, and
+  Pod row state mapping.
+
+### External References
+
+External research is not needed. The behavior is defined by the local product
+requirements and existing Kubernetes fields are already decoded in the reader.
+
+## Key Technical Decisions
+
+- **Introduce an active-vs-completed split at the reader boundary:** The reader
+  already owns raw Pod facts and watch-target matching, so it is the right
+  place to decide which matched Pods are active for summaries and rows.
+- **Use completed Pod facts for empty-state meaning:** If a watched scope has
+  completed Pods but no active Pods, the display needs enough information to
+  show the completed-friendly empty message instead of generic no-Pod copy.
+- **Keep completed Pods out of active rows by default:** Listing them as Ready
+  or Watch would mislead; listing them as a new neutral row state is out of
+  scope.
+- **Preserve failed Job behavior:** `Failed` phase and non-Completed terminated
+  reasons continue to count as attention/failure.
+- **Do not suppress warning events globally:** A completed Pod alone is normal,
+  but existing warning event behavior can still surface real warning events.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Update the completed Pod behavior in the old Pod UI plan or create a new
+  plan?** Create a new incremental plan. The original grouped Pods UI plan is
+  completed and should remain as historical context.
+- **Should completed Pods count as ready?** No. They are not active Ready Pods;
+  they are excluded from active readiness instead.
+- **Should completed Pods be shown as a third row state now?** No. The default
+  Pods tab should stay focused on active Pods.
+
+### Deferred to Implementation
+
+- **Exact data shape for completed-only watched scopes:** Choose the smallest
+  display-model or snapshot addition that lets `HealthEvaluator` distinguish
+  completed-only scope from truly empty scope.
+- **Exact completion helper names:** Keep names close to existing
+  `PodRecord`/`PodDetail` conventions.
+
+## Implementation Units
+
+- [x] **Unit 1: Detect successfully completed Pod records**
+
+**Goal:** Give the reader a reliable way to identify successfully completed Job
+Pods separately from active and failed Pods.
+
+**Requirements:** R14a, R14e
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `KubebarCore/Services/KubectlClusterReader.swift`
+- Test: `KubebarTests/Services/KubectlClusterReaderTests.swift`
+
+**Approach:**
+- Add a local Pod-record classification for successful completion.
+- Treat Kubernetes `Succeeded` phase as completed.
+- Treat successful `Completed` container termination as completed when the Pod
+  has no failed, waiting, or non-Completed terminated container state. Do not
+  require Ready conditions or container ready flags to remain true after
+  successful completion.
+- Preserve `Failed` phase and non-Completed terminated reasons as failure.
+- Keep the helper local to the reader unless implementation shows a broader
+  display-model value is needed.
+
+**Patterns to follow:**
+- Existing `PodRecord.isFailed`, `isPending`, `isUnknown`, `isNotReady`, and
+  `currentTerminatedState` helpers in `KubectlClusterReader.swift`.
+- Existing reader tests for failed, restarting, pending, unknown, and workload
+  matching in `KubebarTests/Services/KubectlClusterReaderTests.swift`.
+
+**Test scenarios:**
+- Happy path: Pod with `phase: Succeeded` is classified as completed.
+- Happy path: Pod whose containers are terminated with `reason: Completed` is
+  classified as completed.
+- Regression: Pod with `phase: Failed` and terminated `reason: Error` remains
+  failure.
+- Regression: Pending, Unknown, CrashLoopBackOff, and unready Running Pods are
+  not classified as completed.
+
+**Verification:**
+- Completed Pod detection is explicit and does not weaken failed or active
+  attention states.
+
+- [x] **Unit 2: Exclude completed Pods from active summaries and rows**
+
+**Goal:** Make cluster and watched-scope Pod readiness count only active Pods by
+default.
+
+**Requirements:** R14b, R14c, R14f, R25-R27
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `KubebarCore/Services/KubectlClusterReader.swift`
+- Test: `KubebarTests/Services/KubectlClusterReaderTests.swift`
+
+**Approach:**
+- Build `PodSummary` from active Pods, excluding successfully completed Pods
+  from both numerator and denominator.
+- Build watched Pod details from active matching Pods, excluding successfully
+  completed Pods from default Pods tab rows.
+- Use active matching Pods when deciding tracked item failure or watch state.
+- Preserve a completed-only signal for watched scopes so display mapping can
+  show the completed-specific empty message.
+- Leave invalid Pod JSON and workload selector failure behavior unchanged.
+
+**Patterns to follow:**
+- `makePodSummary(from:)` in `KubectlClusterReader.swift`
+- `makePodDetailsSection(...)` in `KubectlClusterReader.swift`
+- `trackedStatus(for:pods:warningEvents:workloadSelectors:)` in
+  `KubectlClusterReader.swift`
+- Existing no-matching and workload-only tests in
+  `KubebarTests/Services/KubectlClusterReaderTests.swift`
+
+**Test scenarios:**
+- Happy path: one Running ready Pod plus one Succeeded Job Pod -> summary is
+  `1/1`, not `1/2` or `2/2`.
+- Happy path: watched namespace with one active Pod and one completed Job Pod
+  produces one default Pod detail row.
+- Happy path: watched workload with only completed Job Pods produces no active
+  Pod detail rows and does not create a `Watch` tracked item by itself.
+- Regression: failed Job Pod still contributes to Bad tracked item behavior.
+- Regression: pending, unknown, and unready active Pods still contribute to
+  Watch behavior.
+- Regression: invalid Pod data still becomes unavailable, not empty.
+
+**Verification:**
+- Completed Job Pods no longer distort active ready/all counts or active rows.
+
+- [x] **Unit 3: Display completed-only watched scopes clearly**
+
+**Goal:** Show a completed-friendly OK empty message when the watched scope has
+completed Jobs but no active Pods.
+
+**Requirements:** R14c, R14d, R14f, R26, R27
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `KubebarCore/Models/ClusterSnapshot.swift`
+- Modify: `KubebarCore/Models/MenuDisplayModel.swift`
+- Modify: `KubebarCore/Services/HealthEvaluator.swift`
+- Test: `KubebarTests/Models/MenuDisplayModelTests.swift`
+
+**Approach:**
+- Carry the minimal completed-only watched-scope fact needed by
+  `HealthEvaluator`.
+- Keep `HealthEvaluator` responsible for the display text and state mapping.
+- Use `No active pods; completed jobs are OK` for completed-only watched scope.
+- Keep the existing `No watched pods found` message for truly empty watched
+  scope with no matching active or completed Pods.
+- Ensure completed-only state remains `OK` unless another signal such as a
+  warning event, failed Pod, stale data, or unavailable section changes the
+  status.
+
+**Patterns to follow:**
+- Existing `podTabEmptyMessage(from:podDetails:)` in `HealthEvaluator.swift`
+- Existing `PodTabDisplay` empty and unavailable display contract in
+  `MenuDisplayModel.swift`
+- Existing stale and unavailable tests in
+  `KubebarTests/Models/MenuDisplayModelTests.swift`
+
+**Test scenarios:**
+- Happy path: completed-only watched scope -> menu state is `OK`, Pod tab has no
+  active rows, empty message is `No active pods; completed jobs are OK`.
+- Happy path: truly empty watched scope -> existing no-watched-pods copy remains
+  distinct.
+- Regression: stale completed-only display still shows stale marking.
+- Regression: warning events can still produce Watch when warning data exists.
+- Regression: unavailable Pod data still shows unavailable copy rather than the
+  completed-only empty message.
+
+**Verification:**
+- The user can tell completed-only scope from no matches and from failed data.
+
+- [x] **Unit 4: Update QA fixtures and runtime documentation**
+
+**Goal:** Preserve the completed Job Pod contract in deterministic QA and docs.
+
+**Requirements:** R14a-R14f
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Modify: `KubebarCore/QA/MenuStateFixtureCatalog.swift`
+- Modify: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+- Modify: `docs/architecture/runtime-invariants.md`
+- Modify: `docs/qa/operator-verification.md`
+- Modify: `scripts/generate-qa-evidence.sh`
+- Modify: `scripts/swift-quality-gate.sh`
+
+**Approach:**
+- Add completed Job Pod coverage to an existing fixture if it can be done
+  without obscuring the fixture's primary purpose; otherwise add focused model
+  tests and document the manual check.
+- Update runtime invariants to say active Pod readiness excludes successfully
+  completed Job Pods.
+- Update operator verification so humans know completed Job Pods should not
+  create a readiness warning.
+- Keep QA copy short and avoid adding a historical Jobs workflow.
+
+**Patterns to follow:**
+- Existing fixture metadata checks in
+  `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+- Existing Pod runtime invariants in `docs/architecture/runtime-invariants.md`
+- Existing operator verification sections in `docs/qa/operator-verification.md`
+
+**Test scenarios:**
+- Happy path: QA or model coverage proves completed Job Pods do not create
+  Watch/Bad status.
+- Regression: safe metadata checks still reject raw kubectl output, JSON,
+  kubeconfig paths, and tokens.
+- Regression: existing healthy, watch, bad, stale, and metrics-unavailable
+  fixture expectations remain valid.
+
+**Verification:**
+- QA and docs describe completed Job Pod behavior consistently.
+
+- [x] **Unit 5: Final validation**
+
+**Goal:** Confirm completed Job Pod handling is complete without weakening real
+Pod failure detection.
+
+**Requirements:** R13, R14a-R14f, R25-R27
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Test: `KubebarTests/Services/KubectlClusterReaderTests.swift`
+- Test: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- Test: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+
+**Approach:**
+- Run focused reader and display-model tests for completed, failed, and active
+  unready Pod cases.
+- Run the full local Swift quality gate before marking the implementation done.
+- Confirm no raw Pod facts leak into SwiftUI as health decisions.
+
+**Test scenarios:**
+- Completed Job Pods excluded from active ready/all.
+- Completed-only watched scope stays `OK`.
+- Failed Job Pods still become Bad.
+- Pending, Unknown, partially ready, and CrashLoopBackOff Pods still become
+  Watch or Bad according to existing rules.
+- Metrics-unavailable and stale states stay distinct.
+
+**Verification:**
+- Focused tests and `./scripts/swift-quality-gate.sh local` pass.
+
+## System-Wide Impact
+
+- **Interaction graph:** `KubectlClusterReader` separates completed Pods from
+  active Pod facts; `HealthEvaluator` maps the resulting snapshot into
+  user-facing `MenuDisplayModel`; SwiftUI still only renders the display model.
+- **Error propagation:** Completed Pod handling must not hide Pod read failures
+  or failed Job Pods. Unavailable sections still use safe messages.
+- **State lifecycle risks:** Stale completed-only displays may preserve old
+  facts only through the existing stale path.
+- **API surface parity:** No external API, setup, saved config, Kubernetes
+  read set, or menu health vocabulary changes.
+- **Integration coverage:** Reader tests protect classification; display tests
+  protect status and copy; QA/docs protect operator-facing expectations.
+- **Unchanged invariants:** Kubernetes Secrets are not queried; stale data does
+  not look current; UI does not decide cluster health directly.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Completed Pods accidentally hide failed Jobs | Keep Failed phase and non-Completed termination regression tests |
+| Active readiness totals become confusing when all watched Pods completed | Use explicit completed-only empty copy |
+| Completed Pods vanish without explanation | Preserve completed-only scope signal and documented operator behavior |
+| Warning events from completed Jobs are unexpectedly hidden | Do not suppress warning event handling globally |
+| Display model grows more than needed | Carry only the minimal completed-scope fact needed for copy and state |
+
+## Documentation / Operational Notes
+
+- Update runtime invariants with the active-readiness rule.
+- Update operator verification with a completed Job Pod check.
+- No migration or operator setup change is required.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-22-kubebar-pod-item-menu-ui-requirements.md](../brainstorms/2026-04-22-kubebar-pod-item-menu-ui-requirements.md)
+- Related completed plan: [docs/plans/2026-04-22-004-feat-pod-item-menu-ui-plan.md](2026-04-22-004-feat-pod-item-menu-ui-plan.md)
+- Reader: `KubebarCore/Services/KubectlClusterReader.swift`
+- Snapshot model: `KubebarCore/Models/ClusterSnapshot.swift`
+- Display model: `KubebarCore/Models/MenuDisplayModel.swift`
+- Display mapping: `KubebarCore/Services/HealthEvaluator.swift`
+- Reader tests: `KubebarTests/Services/KubectlClusterReaderTests.swift`
+- Display tests: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- QA tests: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+- Runtime rules: `docs/architecture/runtime-invariants.md`
+- Operator QA: `docs/qa/operator-verification.md`

--- a/docs/qa/operator-verification.md
+++ b/docs/qa/operator-verification.md
@@ -7,6 +7,7 @@ This guide covers operator-facing checks for the menu states required by Phase 0
 ## QA State Commands
 
 - `./scripts/compile-and-run.sh --qa-state healthy`
+- `./scripts/compile-and-run.sh --qa-state completed-jobs`
 - `./scripts/compile-and-run.sh --qa-state watch`
 - `./scripts/compile-and-run.sh --qa-state bad`
 - `./scripts/compile-and-run.sh --qa-state stale-refresh-failure`
@@ -22,6 +23,7 @@ This guide covers operator-facing checks for the menu states required by Phase 0
 Screenshots belong under `docs/assets/qa/` with these names:
 
 - `phase-07-healthy.png`
+- `phase-07-completed-jobs.png`
 - `phase-07-watch.png`
 - `phase-07-bad.png`
 - `phase-07-stale-refresh-failure.png`
@@ -52,6 +54,7 @@ for that state.
 | State | Expected visible behavior | Evidence path |
 |-------|---------------------------|---------------|
 | Healthy | Menu shows OK with top status row, four Overview cards, neutral Recent Warnings, and Pods tab rows grouped by namespace with ready counts. | `docs/assets/qa/phase-07-healthy.png` |
+| completed-jobs | Menu shows OK when the watched scope has only completed Job Pods; Pods tab has no active Pod rows and shows `No active pods; completed jobs are OK`. | `docs/assets/qa/phase-07-completed-jobs.png` |
 | Watch | Menu shows Watch with a pinned BackOff warning row; Pods tab shows the watched Pod first with yellow dot, `0/1`, and gray issue text. | `docs/assets/qa/phase-07-watch.png` |
 | Bad | Menu shows Bad and prioritizes the broken tracked target; Nodes tab shows a Not Ready node row, and Pods tab shows failed Pods first with red dots and issue text. | `docs/assets/qa/phase-07-bad.png` |
 | Stale refresh failure | Menu shows Stale while preserving last known top row and cards with stale marking. | `docs/assets/qa/phase-07-stale-refresh-failure.png` |
@@ -105,7 +108,10 @@ status dot, Pod name, ready/all count, and a one-line gray issue description
 when the Pod needs attention. Attention rows must appear before ready rows in a
 namespace. If there are more Pod rows than fit, only the Pod item list should
 scroll vertically while the Pod readiness summary stays visible. In the
-metrics-unavailable state, Pod rows should remain visible.
+metrics-unavailable state, Pod rows should remain visible. In the
+completed-jobs state, completed Job Pods should not appear as unready active
+rows or reduce ready/all counts; the Pods tab should show
+`No active pods; completed jobs are OK`.
 
 ## When To Mark pending-human-verification
 

--- a/docs/qa/operator-verification.md
+++ b/docs/qa/operator-verification.md
@@ -42,6 +42,11 @@ For all configured menu states, confirm the footer remains visible at the
 bottom of the menu and contains only refresh, settings, and quit actions. The
 refresh cadence picker belongs in Settings.
 
+For Watch, Bad, Stale, `kubectl failure`, `metrics-unavailable`, and
+`warning-heavy`, hover the Overview top status row. The visible status text
+should stay short, and the hover text should explain the concrete safe reason
+for that state.
+
 ## State Checklist
 
 | State | Expected visible behavior | Evidence path |
@@ -77,6 +82,13 @@ For the footer, confirm refresh, settings, and quit remain reachable after
 switching between Overview, Nodes, Pods, and Events. The tab bar should have
 equal left and right spacing. After a fresh refresh, `Last checked 0s ago`
 should advance as time passes without pressing refresh again.
+
+## Overview Status Hover Check
+
+For the Overview top status row, confirm hover/help text is more specific than
+the visible one-line status when the state needs attention. It should name the
+affected object or explain the stale/unavailable reason, and it must not expose
+raw command output, kubeconfig paths, full JSON, or tokens.
 
 ## Nodes Tab Check
 

--- a/scripts/generate-qa-evidence.sh
+++ b/scripts/generate-qa-evidence.sh
@@ -17,6 +17,7 @@ cat > "$OUTPUT_FILE" <<'EOF'
 | State | Status | Reproduction steps | Expected behavior | Observed behavior | Evidence path | Limitations | Follow-up risk |
 |-------|--------|--------------------|-------------------|-------------------|---------------|-------------|----------------|
 | Healthy | pending-human-verification | `./scripts/compile-and-run.sh --qa-state healthy` | Menu shows OK with top status row, four Overview cards, neutral Recent Warnings, and Pods tab rows grouped by namespace with ready counts. | pending-human-verification | `docs/assets/qa/phase-07-healthy.png` | Screenshot or visible menu check may require human action. | Do not mark complete without visible evidence. |
+| completed-jobs | pending-human-verification | `./scripts/compile-and-run.sh --qa-state completed-jobs` | Menu shows OK when the watched scope has only completed Job Pods; Pods tab has no active Pod rows and shows `No active pods; completed jobs are OK`. | pending-human-verification | `docs/assets/qa/phase-07-completed-jobs.png` | Screenshot or visible menu check may require human action. | Do not mark complete without visible evidence. |
 | Watch | pending-human-verification | `./scripts/compile-and-run.sh --qa-state watch` | Menu shows Watch with a pinned BackOff warning row; Pods tab shows the watched Pod first with yellow dot, `0/1`, and gray issue text. | pending-human-verification | `docs/assets/qa/phase-07-watch.png` | Screenshot or visible menu check may require human action. | Do not mark complete without visible evidence. |
 | Bad | pending-human-verification | `./scripts/compile-and-run.sh --qa-state bad` | Menu shows Bad and prioritizes the broken tracked target; Nodes tab shows a Not Ready node row, and Pods tab shows failed Pods first with red dots and issue text. | pending-human-verification | `docs/assets/qa/phase-07-bad.png` | Screenshot or visible menu check may require human action. | Do not mark complete without visible evidence. |
 | Stale refresh failure | pending-human-verification | `./scripts/compile-and-run.sh --qa-state stale-refresh-failure` | Menu shows Stale while preserving last known top row and cards with stale marking. | pending-human-verification | `docs/assets/qa/phase-07-stale-refresh-failure.png` | Screenshot or visible menu check may require human action. | Do not mark complete without visible evidence. |
@@ -32,6 +33,7 @@ test -s "$OUTPUT_FILE"
 
 for label in \
   "Healthy" \
+  "completed-jobs" \
   "Watch" \
   "Bad" \
   "Stale refresh failure" \

--- a/scripts/swift-quality-gate.sh
+++ b/scripts/swift-quality-gate.sh
@@ -73,6 +73,7 @@ run_qa_artifact_check() {
   local generated_file
   local labels=(
     "Healthy"
+    "completed-jobs"
     "Watch"
     "Bad"
     "Stale refresh failure"


### PR DESCRIPTION
## Summary
- Exclude successfully completed Job Pods from active pod readiness and active pod rows
- Keep failed Job Pods on the failure path
- Add a completed-jobs QA state plus runtime and operator guidance for the completed-only case
- Add tests for reader behavior, display copy, and QA fixture coverage

## Testing
- `swift test --filter KubectlClusterReaderTests`
- `swift test --filter MenuDisplayModelTests`
- `swift test --filter MenuStateFixtureCatalogTests`
- `./scripts/swift-quality-gate.sh local`