### PR TITLE
Fix k9s handoff launch and status UI

### DIFF
--- a/Kubebar.xcodeproj/project.pbxproj
+++ b/Kubebar.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 63;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -44,6 +44,7 @@
 		606AFC7528260D78D8BC9E45 /* RefreshGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC142C4F1E07378E74546FE /* RefreshGateTests.swift */; };
 		6AD24ACE1B08D85139E55137 /* WatchlistPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F44DC0EB6DFB754A4E074B /* WatchlistPickerView.swift */; };
 		6AF6A15E2D4F765E4C98EE30 /* StatusSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039D4A0BD680E236E953D7EF /* StatusSummaryView.swift */; };
+		708412980F38132D54845E97 /* K9sHandoffCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89C4A509C804C4DE5A72BCD3 /* K9sHandoffCoordinator.swift */; };
 		78DE1F0D561B11983D48D60F /* MenuLayoutSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689EC8218395797C0788B282 /* MenuLayoutSizing.swift */; };
 		7E10219D9134064745C7587E /* MenuBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6AD42A08C3FCF7AFC66B5 /* MenuBarViewModel.swift */; };
 		807978CC3ED867BFDD568099 /* ConfigurationRequiredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A54CD93E75766F134F4B27 /* ConfigurationRequiredView.swift */; };
@@ -54,15 +55,15 @@
 		9C927DBFB7ECCCB5139CEF39 /* SettingsRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044436EFC75907A7253A3A7A /* SettingsRootView.swift */; };
 		9D2AA2BB55D09D9AFDDE7202 /* NodesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4602F3AD3687ABB356E1C266 /* NodesTabView.swift */; };
 		9D925B117B0D234CA736517E /* KubectlClusterReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2864022B6B2FF3AADF1E4F /* KubectlClusterReaderTests.swift */; };
-		A95C911BD85C45D4A69B92BE /* FreshnessDisplaySchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F62A4507F64D0BA2210C31 /* FreshnessDisplaySchedule.swift */; };
 		A6FCE353AEC1C8483F645A4C /* RefreshCadence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFEFC04D522F4DA85DC6FA1 /* RefreshCadence.swift */; };
 		AB13FDF1DD2848688F89CE90 /* MenuStateFixtureCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1D3C5165ECB1392D2664FC /* MenuStateFixtureCatalogTests.swift */; };
 		AC13EC97905550E7D830828B /* MenuTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8BD7D4374CA280EB08BF3E /* MenuTab.swift */; };
+		B39AFD013269B9D4B273BD65 /* FreshnessDisplaySchedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F145C7042CEB53D7185BD7FA /* FreshnessDisplaySchedule.swift */; };
+		B4E172ECAE5DEBA5BB621EB9 /* K9sHandoffLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99FCB8D13880C4DF3090C38 /* K9sHandoffLauncher.swift */; };
 		C37388D088AFEA095E3E172E /* RefreshGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F687524DAA74E9F5F64CFC /* RefreshGate.swift */; };
 		C7D835EE9941E87F99EAF0DE /* WatchlistSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A05316EDD516D6E9253DB4 /* WatchlistSelectionState.swift */; };
 		CB35CF597BAFC816918A11BA /* KubectlClusterReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E8C7051DD3BC07BF86A950 /* KubectlClusterReader.swift */; };
 		D343AF9AAD2DB31A718A3396 /* PodsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE870F98B15D0AD4D10E4031 /* PodsTabView.swift */; };
-		D17E3036C8364D84B33A912C /* FreshnessDisplayScheduleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F0A2B4F9A64D5A8C36E701 /* FreshnessDisplayScheduleTests.swift */; };
 		DC3D760FA2EF2E5789C6CD21 /* ClusterSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF8969BAFC7CADA85C406E9 /* ClusterSnapshot.swift */; };
 		E557AF4691C5FFE49437ADB4 /* EventsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A022D6D54A801257E7493047 /* EventsTabView.swift */; };
 		E5ACFCA3A8AF5731A614DD75 /* ContextCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B80AFB0373C83CDF78D0BE /* ContextCatalog.swift */; };
@@ -71,7 +72,10 @@
 		EA3A58433537560B8EFFE763 /* WatchTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA42B12E1A80F663E483332 /* WatchTargetTests.swift */; };
 		ED00D64BF197F5083B128EF7 /* MenuBarStatusPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4EFC03EAA7FF0C71200678B /* MenuBarStatusPresentation.swift */; };
 		F11947BC8E49AFFF882FE036 /* RefreshCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1ABF4BE1D5A8A8B7E474CBD /* RefreshCoordinator.swift */; };
+		F2C47E9B336DAEBB62C4A38B /* K9sHandoffCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36898C56A6EB1B155A97A6E /* K9sHandoffCoordinatorTests.swift */; };
 		F3BA3AEB1BF36707FCBA26E7 /* KubebarCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5DC3A00788901BF5DDB724A8 /* KubebarCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F67279655B65A5C795235011 /* K9sHandoffLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F1BAE30BE489A363995688 /* K9sHandoffLauncherTests.swift */; };
+		F8166FF0EF8CCCAF14F15DDF /* FreshnessDisplayScheduleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC71932B945E1D6592AA77E /* FreshnessDisplayScheduleTests.swift */; };
 		F9B5425A8538F60891B080EA /* QALaunchMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ED769495D3CCF49456FB7B /* QALaunchMode.swift */; };
 /* End PBXBuildFile section */
 
@@ -149,6 +153,7 @@
 		8240373DA431592CA2BE0AAD /* WatchlistSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchlistSectionView.swift; sourceTree = "<group>"; };
 		85A54CD93E75766F134F4B27 /* ConfigurationRequiredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationRequiredView.swift; sourceTree = "<group>"; };
 		8727736B73E1A28F6DC70C66 /* ContextCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextCatalogTests.swift; sourceTree = "<group>"; };
+		89C4A509C804C4DE5A72BCD3 /* K9sHandoffCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K9sHandoffCoordinator.swift; sourceTree = "<group>"; };
 		9764447501D53DE91281068A /* HealthEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthEvaluator.swift; sourceTree = "<group>"; };
 		A022D6D54A801257E7493047 /* EventsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsTabView.swift; sourceTree = "<group>"; };
 		A1F687524DAA74E9F5F64CFC /* RefreshGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshGate.swift; sourceTree = "<group>"; };
@@ -161,25 +166,28 @@
 		B29566B59D491F95C0EE5504 /* CommandRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandRunnerTests.swift; sourceTree = "<group>"; };
 		B5B3876DBAB67B25904E89EA /* TrackedItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedItemDetailView.swift; sourceTree = "<group>"; };
 		B5F44DC0EB6DFB754A4E074B /* WatchlistPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchlistPickerView.swift; sourceTree = "<group>"; };
-		B8F62A4507F64D0BA2210C31 /* FreshnessDisplaySchedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreshnessDisplaySchedule.swift; sourceTree = "<group>"; };
 		BE870F98B15D0AD4D10E4031 /* PodsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodsTabView.swift; sourceTree = "<group>"; };
+		BEC71932B945E1D6592AA77E /* FreshnessDisplayScheduleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreshnessDisplayScheduleTests.swift; sourceTree = "<group>"; };
 		C0DD632B3A3FF43568D48AF9 /* SetupFlowStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupFlowStateTests.swift; sourceTree = "<group>"; };
-		C5F0A2B4F9A64D5A8C36E701 /* FreshnessDisplayScheduleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreshnessDisplayScheduleTests.swift; sourceTree = "<group>"; };
 		C15B64B428E2F7F739C4E81A /* MenuLayoutSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuLayoutSizingTests.swift; sourceTree = "<group>"; };
 		C15FA43125DF9BF219851EB9 /* CompactCountersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompactCountersView.swift; sourceTree = "<group>"; };
 		C221382EB43B27DF73F677E5 /* SetupFlowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupFlowState.swift; sourceTree = "<group>"; };
 		C83920A23FBBEB8633C45D15 /* MenuDisplayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuDisplayModel.swift; sourceTree = "<group>"; };
+		C9F1BAE30BE489A363995688 /* K9sHandoffLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K9sHandoffLauncherTests.swift; sourceTree = "<group>"; };
 		CE162CB8A5320D87A9EBF55A /* StaleBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaleBannerView.swift; sourceTree = "<group>"; };
 		DB1D3C5165ECB1392D2664FC /* MenuStateFixtureCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuStateFixtureCatalogTests.swift; sourceTree = "<group>"; };
 		DB85B2A6F35FE8060AA9C798 /* ClusterHealthStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClusterHealthStateTests.swift; sourceTree = "<group>"; };
 		DE730D4112D2CD5963295F5C /* Kubebar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Kubebar.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E309AEA967A6E63FE865DCFA /* MenuRuntimeStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRuntimeStateTests.swift; sourceTree = "<group>"; };
+		E36898C56A6EB1B155A97A6E /* K9sHandoffCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K9sHandoffCoordinatorTests.swift; sourceTree = "<group>"; };
 		E3CFEB46C82EDA2D094BDDF0 /* AppConfigStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigStore.swift; sourceTree = "<group>"; };
 		E4EFC03EAA7FF0C71200678B /* MenuBarStatusPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentation.swift; sourceTree = "<group>"; };
 		E8A05316EDD516D6E9253DB4 /* WatchlistSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchlistSelectionState.swift; sourceTree = "<group>"; };
 		ED8BD7D4374CA280EB08BF3E /* MenuTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTab.swift; sourceTree = "<group>"; };
 		F0A043426B709BACA5F1E0AD /* NodeDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeDetailsView.swift; sourceTree = "<group>"; };
+		F145C7042CEB53D7185BD7FA /* FreshnessDisplaySchedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreshnessDisplaySchedule.swift; sourceTree = "<group>"; };
 		F32B1B6F7E78CC246131309D /* WatchlistSelectionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchlistSelectionStateTests.swift; sourceTree = "<group>"; };
+		F99FCB8D13880C4DF3090C38 /* K9sHandoffLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K9sHandoffLauncher.swift; sourceTree = "<group>"; };
 		F9A5B3E0870DDD42620B5920 /* RefreshCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshCoordinatorTests.swift; sourceTree = "<group>"; };
 		FD651CCDAAD62B4E7C090D6F /* WatchTargetCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTargetCatalog.swift; sourceTree = "<group>"; };
 		FD883B4C9F8DBC5EF2A2A75A /* WorkloadKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkloadKind.swift; sourceTree = "<group>"; };
@@ -277,7 +285,9 @@
 				684455D1430321334848EB7F /* AppConfigStoreTests.swift */,
 				B29566B59D491F95C0EE5504 /* CommandRunnerTests.swift */,
 				8727736B73E1A28F6DC70C66 /* ContextCatalogTests.swift */,
-				C5F0A2B4F9A64D5A8C36E701 /* FreshnessDisplayScheduleTests.swift */,
+				BEC71932B945E1D6592AA77E /* FreshnessDisplayScheduleTests.swift */,
+				E36898C56A6EB1B155A97A6E /* K9sHandoffCoordinatorTests.swift */,
+				C9F1BAE30BE489A363995688 /* K9sHandoffLauncherTests.swift */,
 				3E2864022B6B2FF3AADF1E4F /* KubectlClusterReaderTests.swift */,
 				C15B64B428E2F7F739C4E81A /* MenuLayoutSizingTests.swift */,
 				F9A5B3E0870DDD42620B5920 /* RefreshCoordinatorTests.swift */,
@@ -311,8 +321,10 @@
 				E3CFEB46C82EDA2D094BDDF0 /* AppConfigStore.swift */,
 				A59D91E3E139CA91BC232D40 /* CommandRunner.swift */,
 				16B80AFB0373C83CDF78D0BE /* ContextCatalog.swift */,
-				B8F62A4507F64D0BA2210C31 /* FreshnessDisplaySchedule.swift */,
+				F145C7042CEB53D7185BD7FA /* FreshnessDisplaySchedule.swift */,
 				9764447501D53DE91281068A /* HealthEvaluator.swift */,
+				89C4A509C804C4DE5A72BCD3 /* K9sHandoffCoordinator.swift */,
+				F99FCB8D13880C4DF3090C38 /* K9sHandoffLauncher.swift */,
 				09E8C7051DD3BC07BF86A950 /* KubectlClusterReader.swift */,
 				689EC8218395797C0788B282 /* MenuLayoutSizing.swift */,
 				B1ABF4BE1D5A8A8B7E474CBD /* RefreshCoordinator.swift */,
@@ -440,7 +452,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 2640;
+				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					6E81D6B0A5F45689E0C56333 = {
 						DevelopmentTeam = "";
@@ -463,6 +475,7 @@
 			);
 			mainGroup = 1E7C0A7778CEC6F2A9F3DC6F;
 			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -493,7 +506,9 @@
 				495D556A6DF84C8C22BB9D63 /* ClusterHealthStateTests.swift in Sources */,
 				2673AA6352855DBB0B87599A /* CommandRunnerTests.swift in Sources */,
 				1956982E5C1832CD17224A14 /* ContextCatalogTests.swift in Sources */,
-				D17E3036C8364D84B33A912C /* FreshnessDisplayScheduleTests.swift in Sources */,
+				F8166FF0EF8CCCAF14F15DDF /* FreshnessDisplayScheduleTests.swift in Sources */,
+				F2C47E9B336DAEBB62C4A38B /* K9sHandoffCoordinatorTests.swift in Sources */,
+				F67279655B65A5C795235011 /* K9sHandoffLauncherTests.swift in Sources */,
 				9D925B117B0D234CA736517E /* KubectlClusterReaderTests.swift in Sources */,
 				52BA949618FBE1B3F59CFFA0 /* MenuBarStatusPresentationTests.swift in Sources */,
 				0D127D20E9DEDC847D33AE77 /* MenuDisplayModelTests.swift in Sources */,
@@ -519,8 +534,10 @@
 				DC3D760FA2EF2E5789C6CD21 /* ClusterSnapshot.swift in Sources */,
 				3C89297B5C863C683E8D33CA /* CommandRunner.swift in Sources */,
 				E5ACFCA3A8AF5731A614DD75 /* ContextCatalog.swift in Sources */,
-				A95C911BD85C45D4A69B92BE /* FreshnessDisplaySchedule.swift in Sources */,
+				B39AFD013269B9D4B273BD65 /* FreshnessDisplaySchedule.swift in Sources */,
 				19EAD915DF6C79C690F35AA1 /* HealthEvaluator.swift in Sources */,
+				708412980F38132D54845E97 /* K9sHandoffCoordinator.swift in Sources */,
+				B4E172ECAE5DEBA5BB621EB9 /* K9sHandoffLauncher.swift in Sources */,
 				CB35CF597BAFC816918A11BA /* KubectlClusterReader.swift in Sources */,
 				ED00D64BF197F5083B128EF7 /* MenuBarStatusPresentation.swift in Sources */,
 				90A3769DF7A535DE88BBA88B /* MenuDisplayModel.swift in Sources */,
@@ -617,12 +634,10 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -636,7 +651,6 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 6.0;
@@ -677,12 +691,10 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -703,7 +715,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 6.0;
@@ -716,19 +727,16 @@
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nextty.kubebar.core;
 				PRODUCT_NAME = KubebarCore;
 				SDKROOT = macosx;
@@ -742,7 +750,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Kubebar;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -762,7 +769,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Kubebar;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -783,19 +789,16 @@
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nextty.kubebar.core;
 				PRODUCT_NAME = KubebarCore;
 				SDKROOT = macosx;
@@ -809,7 +812,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -826,7 +828,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Kubebar.xcodeproj/xcshareddata/xcschemes/Kubebar.xcscheme
+++ b/Kubebar.xcodeproj/xcshareddata/xcschemes/Kubebar.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2640"
-   version = "1.3">
+   LastUpgradeVersion = "1430"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -40,7 +41,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -63,6 +65,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Kubebar/KubebarApp.swift
+++ b/Kubebar/KubebarApp.swift
@@ -70,6 +70,8 @@ struct KubebarApp: App {
             isRefreshing: viewModel.isRefreshing,
             onRefresh: viewModel.refreshNow,
             onPrepareSettings: viewModel.prepareSettings,
+            k9sHandoffState: viewModel.k9sHandoffState,
+            onOpenK9sHandoff: viewModel.openK9sHandoff,
             onQuit: { NSApplication.shared.terminate(nil) }
         )
     }
@@ -90,6 +92,8 @@ private struct QAFixtureMenuRootView: View {
             isRefreshing: false,
             onRefresh: {},
             onPrepareSettings: {},
+            k9sHandoffState: .idle,
+            onOpenK9sHandoff: {},
             onQuit: { NSApplication.shared.terminate(nil) }
         )
     }

--- a/Kubebar/MenuBarViewModel.swift
+++ b/Kubebar/MenuBarViewModel.swift
@@ -16,6 +16,7 @@ final class MenuBarViewModel: ObservableObject {
     }
     @Published private(set) var isShowingSetup: Bool
     @Published private(set) var isRefreshing: Bool
+    @Published private(set) var k9sHandoffState: K9sHandoffLaunchState
 
     private let configStore: AppConfigStore
     private let refreshCoordinator: RefreshCoordinator
@@ -30,18 +31,21 @@ final class MenuBarViewModel: ObservableObject {
     private var watchTargetLoadTask: Task<Void, Never>?
     private var refreshGate: RefreshGate
     private var staleReason: String?
+    private let k9sHandoffCoordinator: K9sHandoffCoordinator
 
     init(
         configStore: AppConfigStore = AppConfigStore(directory: MenuBarViewModel.defaultConfigDirectory),
         refreshCoordinator: RefreshCoordinator = RefreshCoordinator(),
         contextCatalog: ContextCatalog = ContextCatalog(),
         watchTargetCatalog: any WatchTargetCataloging = WatchTargetCatalog(),
+        k9sHandoffCoordinator: K9sHandoffCoordinator = K9sHandoffCoordinator(),
         now: Date = Date()
     ) {
         self.configStore = configStore
         self.refreshCoordinator = refreshCoordinator
         self.contextCatalog = contextCatalog
         self.watchTargetCatalog = watchTargetCatalog
+        self.k9sHandoffCoordinator = k9sHandoffCoordinator
 
         do {
             self.config = try configStore.load()
@@ -59,6 +63,12 @@ final class MenuBarViewModel: ObservableObject {
         self.refreshGate = RefreshGate()
         self.staleReason = nil
         self.display = Self.initialDisplay(for: config, now: now)
+        self.k9sHandoffState = .idle
+
+        self.k9sHandoffCoordinator.onStateChange = { [weak self] state in
+            self?.k9sHandoffState = state
+        }
+        self.k9sHandoffCoordinator.resetIfTargetUnavailable(display.overview.k9sHandoff)
 
         if runtimeState.isShowingSetup {
             loadContextsIfNeeded()
@@ -124,6 +134,7 @@ final class MenuBarViewModel: ObservableObject {
     }
 
     func openSetup() {
+        k9sHandoffCoordinator.clear()
         runtimeState.openSetup()
         publishRuntimeState()
         loadContextsIfNeeded()
@@ -134,6 +145,7 @@ final class MenuBarViewModel: ObservableObject {
     }
 
     func prepareSettings() {
+        k9sHandoffCoordinator.clear()
         runtimeState.prepareSettings(config: config)
         publishRuntimeState()
         loadContextsForSettings()
@@ -145,6 +157,7 @@ final class MenuBarViewModel: ObservableObject {
 
     @discardableResult
     func completeSetup() -> Bool {
+        k9sHandoffCoordinator.clear()
         guard let completedConfig = runtimeState.completedConfig() else {
             return false
         }
@@ -168,6 +181,7 @@ final class MenuBarViewModel: ObservableObject {
     }
 
     func selectSetupContext(_ context: String?) {
+        k9sHandoffCoordinator.clear()
         watchTargetLoadTask?.cancel()
         watchTargetLoadTask = nil
 
@@ -178,6 +192,7 @@ final class MenuBarViewModel: ObservableObject {
     }
 
     func retryWatchTargetLoad() {
+        k9sHandoffCoordinator.clear()
         guard let selectedContext = runtimeState.targetContextToLoad else {
             runtimeState.setupState.targetLoadingState = .idle
             publishRuntimeState()
@@ -300,6 +315,7 @@ final class MenuBarViewModel: ObservableObject {
         freshnessTimerTask?.cancel()
         freshnessTimerTask = nil
         staleReason = nil
+        k9sHandoffCoordinator.clear()
 
         if clearSnapshot {
             snapshot = nil
@@ -310,6 +326,8 @@ final class MenuBarViewModel: ObservableObject {
         snapshot = result.snapshot
         display = result.display
         staleReason = result.display.staleBanner?.reason
+        k9sHandoffCoordinator.resetIfTargetUnavailable(display.overview.k9sHandoff)
+        k9sHandoffState = k9sHandoffCoordinator.state
         scheduleFreshnessTimer()
     }
 
@@ -337,6 +355,12 @@ final class MenuBarViewModel: ObservableObject {
         }
 
         staleReason = display.staleBanner?.reason
+        k9sHandoffCoordinator.resetIfTargetUnavailable(display.overview.k9sHandoff)
+        k9sHandoffState = k9sHandoffCoordinator.state
+    }
+
+    func openK9sHandoff() {
+        k9sHandoffCoordinator.open(for: display.overview.k9sHandoff)
     }
 
     private func scheduleFreshnessTimer(now: Date = Date()) {

--- a/Kubebar/Views/MenuBarRootView.swift
+++ b/Kubebar/Views/MenuBarRootView.swift
@@ -8,6 +8,8 @@ struct MenuBarRootView: View {
     let isRefreshing: Bool
     let onRefresh: () -> Void
     let onPrepareSettings: () -> Void
+    let k9sHandoffState: K9sHandoffLaunchState
+    let onOpenK9sHandoff: () -> Void
     let onQuit: () -> Void
     @Environment(\.openSettings) private var openSettings
     @State private var selectedTab: MenuTab = .overview
@@ -120,7 +122,11 @@ struct MenuBarRootView: View {
     private var selectedTabContent: some View {
         switch selectedTab {
         case .overview:
-            OverviewTabView(display: display)
+            OverviewTabView(
+                display: display,
+                k9sHandoffState: k9sHandoffState,
+                onOpenK9sHandoff: onOpenK9sHandoff
+            )
         case .nodes:
             NodesTabView(display: display)
         case .pods:

--- a/Kubebar/Views/OverviewTabView.swift
+++ b/Kubebar/Views/OverviewTabView.swift
@@ -3,6 +3,8 @@ import KubebarCore
 
 struct OverviewTabView: View {
     let display: MenuDisplayModel
+    let k9sHandoffState: K9sHandoffLaunchState
+    let onOpenK9sHandoff: () -> Void
 
     private let columns = [
         GridItem(.flexible(), spacing: 8),
@@ -11,7 +13,11 @@ struct OverviewTabView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            StatusSummaryView(display: display)
+            StatusSummaryView(
+                display: display,
+                k9sHandoffState: k9sHandoffState,
+                onOpenK9sHandoff: onOpenK9sHandoff
+            )
             StaleBannerView(banner: display.staleBanner)
 
             LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {

--- a/Kubebar/Views/StatusSummaryView.swift
+++ b/Kubebar/Views/StatusSummaryView.swift
@@ -3,36 +3,106 @@ import KubebarCore
 
 struct StatusSummaryView: View {
     let display: MenuDisplayModel
+    let k9sHandoffState: K9sHandoffLaunchState
+    let onOpenK9sHandoff: () -> Void
 
     private var presentation: MenuBarStatusPresentation {
         MenuBarStatusPresentation(state: display.state)
     }
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Text(display.contextName)
-                .font(.headline)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .help(Text(display.contextName))
-                .accessibilityLabel(display.contextName)
-
-            Spacer(minLength: 8)
-
-            HStack(spacing: 6) {
-                Image(systemName: presentation.symbolName)
-                Text(display.state.label)
-                    .fontWeight(.semibold)
-                Text(display.overview.statusText)
-                    .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(display.contextName)
+                    .font(.headline)
                     .lineLimit(1)
                     .truncationMode(.middle)
+                    .help(Text(display.contextName))
+                    .accessibilityLabel(display.contextName)
+
+                Spacer(minLength: 8)
+
+                HStack(spacing: 6) {
+                    Image(systemName: presentation.symbolName)
+                    Text(display.state.label)
+                        .fontWeight(.semibold)
+                    Text(display.overview.statusText)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                .font(.subheadline)
+                .help(Text(display.overview.statusHelpText))
             }
-            .font(.subheadline)
-            .help(Text(display.overview.statusHelpText))
+
+            if let handoff = display.overview.k9sHandoff {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(display.overview.statusHelpText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                        .help(Text(display.overview.statusHelpText))
+
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Button(action: onOpenK9sHandoff) {
+                            Label(handoff.buttonLabel(for: k9sHandoffState), systemImage: "arrow.up.right.square")
+                                .labelStyle(.titleAndIcon)
+                        }
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .keyboardShortcut("k", modifiers: .command)
+                        .help(Text(handoff.helpText))
+                        .accessibilityLabel(handoff.accessibilityLabel)
+                        .disabled(k9sHandoffState.isOpeningForSameTarget(handoff))
+
+                        if let statusMessage = k9sHandoffState.feedbackMessage(for: handoff) {
+                            Text(statusMessage)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .help(Text(statusMessage))
+                        }
+                    }
+                }
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel("Open watched target in k9s")
+            }
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(display.overview.statusAccessibilityLabel)
         .focusable()
+    }
+}
+
+private extension K9sHandoffLaunchState {
+    func isOpeningForSameTarget(_ handoff: OverviewK9sHandoff) -> Bool {
+        switch self {
+        case let .opening(target):
+            target == handoff
+        default:
+            false
+        }
+    }
+
+    func feedbackMessage(for handoff: OverviewK9sHandoff) -> String? {
+        switch self {
+        case .idle:
+            nil
+        case .opening(let target):
+            target == handoff ? "Opening k9s..." : nil
+        case .failed(let target, let message):
+            target == handoff ? message : nil
+        }
+    }
+}
+
+private extension OverviewK9sHandoff {
+    func buttonLabel(for state: K9sHandoffLaunchState) -> String {
+        if state.isOpeningForSameTarget(self) {
+            return "Opening in k9s..."
+        }
+
+        return actionLabel
     }
 }

--- a/Kubebar/Views/StatusSummaryView.swift
+++ b/Kubebar/Views/StatusSummaryView.swift
@@ -36,12 +36,9 @@ struct StatusSummaryView: View {
             }
 
             if let handoff = display.overview.k9sHandoff {
+                let message = k9sHandoffState.feedbackMessage(for: handoff) ?? display.overview.statusHelpText
                 VStack(alignment: .leading, spacing: 6) {
-                    if let statusMessage = k9sHandoffState.feedbackMessage(for: handoff) {
-                        statusMessageRow(message: statusMessage, for: handoff)
-                    } else {
-                        statusHelpRow(for: handoff)
-                    }
+                    handoffStatusRow(text: message, for: handoff)
                 }
                 .accessibilityElement(children: .contain)
                 .accessibilityLabel("Open watched target in k9s")
@@ -52,28 +49,14 @@ struct StatusSummaryView: View {
         .focusable()
     }
 
-    private func statusMessageRow(message: String, for handoff: OverviewK9sHandoff) -> some View {
+    private func handoffStatusRow(text: String, for handoff: OverviewK9sHandoff) -> some View {
         HStack(alignment: .center, spacing: 8) {
-            Text(message)
+            Text(text)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
                 .truncationMode(.middle)
-                .help(Text(message))
-
-            Spacer(minLength: 0)
-            openK9sButton(for: handoff)
-        }
-    }
-
-    private func statusHelpRow(for handoff: OverviewK9sHandoff) -> some View {
-        HStack(alignment: .center, spacing: 8) {
-            Text(display.overview.statusHelpText)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(2)
-                .truncationMode(.middle)
-                .help(Text(display.overview.statusHelpText))
+                .help(Text(text))
 
             Spacer(minLength: 0)
             openK9sButton(for: handoff)

--- a/Kubebar/Views/StatusSummaryView.swift
+++ b/Kubebar/Views/StatusSummaryView.swift
@@ -44,25 +44,18 @@ struct StatusSummaryView: View {
                         .truncationMode(.middle)
                         .help(Text(display.overview.statusHelpText))
 
-                    HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Button(action: onOpenK9sHandoff) {
-                            Label(handoff.buttonLabel(for: k9sHandoffState), systemImage: "arrow.up.right.square")
-                                .labelStyle(.titleAndIcon)
-                        }
-                        .buttonStyle(.borderless)
-                        .controlSize(.small)
-                        .keyboardShortcut("k", modifiers: .command)
-                        .help(Text(handoff.helpText))
-                        .accessibilityLabel(handoff.accessibilityLabel)
-                        .disabled(k9sHandoffState.isOpeningForSameTarget(handoff))
-
-                        if let statusMessage = k9sHandoffState.feedbackMessage(for: handoff) {
+                    if let statusMessage = k9sHandoffState.feedbackMessage(for: handoff) {
+                        HStack(alignment: .center, spacing: 8) {
                             Text(statusMessage)
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
                                 .help(Text(statusMessage))
+
+                            openK9sButton(for: handoff)
                         }
+                    } else {
+                        openK9sButton(for: handoff)
                     }
                 }
                 .accessibilityElement(children: .contain)
@@ -72,6 +65,20 @@ struct StatusSummaryView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(display.overview.statusAccessibilityLabel)
         .focusable()
+    }
+
+    private func openK9sButton(for handoff: OverviewK9sHandoff) -> some View {
+        Button(action: onOpenK9sHandoff) {
+            Image(systemName: "arrow.up.right.square")
+                .font(.caption)
+        }
+        .buttonStyle(.borderless)
+        .controlSize(.small)
+        .keyboardShortcut("k", modifiers: .command)
+        .help(Text(handoff.helpText))
+        .accessibilityLabel(handoff.accessibilityLabel)
+        .accessibilityHint(Text(handoff.buttonLabel(for: k9sHandoffState)))
+        .disabled(k9sHandoffState.isOpeningForSameTarget(handoff))
     }
 }
 
@@ -95,6 +102,7 @@ private extension K9sHandoffLaunchState {
             target == handoff ? message : nil
         }
     }
+
 }
 
 private extension OverviewK9sHandoff {

--- a/Kubebar/Views/StatusSummaryView.swift
+++ b/Kubebar/Views/StatusSummaryView.swift
@@ -37,25 +37,10 @@ struct StatusSummaryView: View {
 
             if let handoff = display.overview.k9sHandoff {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(display.overview.statusHelpText)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                        .truncationMode(.middle)
-                        .help(Text(display.overview.statusHelpText))
-
                     if let statusMessage = k9sHandoffState.feedbackMessage(for: handoff) {
-                        HStack(alignment: .center, spacing: 8) {
-                            Text(statusMessage)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                                .help(Text(statusMessage))
-
-                            openK9sButton(for: handoff)
-                        }
+                        statusMessageRow(message: statusMessage, for: handoff)
                     } else {
-                        openK9sButton(for: handoff)
+                        statusHelpRow(for: handoff)
                     }
                 }
                 .accessibilityElement(children: .contain)
@@ -67,9 +52,37 @@ struct StatusSummaryView: View {
         .focusable()
     }
 
+    private func statusMessageRow(message: String, for handoff: OverviewK9sHandoff) -> some View {
+        HStack(alignment: .center, spacing: 8) {
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .truncationMode(.middle)
+                .help(Text(message))
+
+            Spacer(minLength: 0)
+            openK9sButton(for: handoff)
+        }
+    }
+
+    private func statusHelpRow(for handoff: OverviewK9sHandoff) -> some View {
+        HStack(alignment: .center, spacing: 8) {
+            Text(display.overview.statusHelpText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .truncationMode(.middle)
+                .help(Text(display.overview.statusHelpText))
+
+            Spacer(minLength: 0)
+            openK9sButton(for: handoff)
+        }
+    }
+
     private func openK9sButton(for handoff: OverviewK9sHandoff) -> some View {
         Button(action: onOpenK9sHandoff) {
-            Image(systemName: "arrow.up.right.square")
+            Image(systemName: "arrow.right")
                 .font(.caption)
         }
         .buttonStyle(.borderless)
@@ -80,29 +93,6 @@ struct StatusSummaryView: View {
         .accessibilityHint(Text(handoff.buttonLabel(for: k9sHandoffState)))
         .disabled(k9sHandoffState.isOpeningForSameTarget(handoff))
     }
-}
-
-private extension K9sHandoffLaunchState {
-    func isOpeningForSameTarget(_ handoff: OverviewK9sHandoff) -> Bool {
-        switch self {
-        case let .opening(target):
-            target == handoff
-        default:
-            false
-        }
-    }
-
-    func feedbackMessage(for handoff: OverviewK9sHandoff) -> String? {
-        switch self {
-        case .idle:
-            nil
-        case .opening(let target):
-            target == handoff ? "Opening k9s..." : nil
-        case .failed(let target, let message):
-            target == handoff ? message : nil
-        }
-    }
-
 }
 
 private extension OverviewK9sHandoff {

--- a/KubebarCore/Models/MenuDisplayModel.swift
+++ b/KubebarCore/Models/MenuDisplayModel.swift
@@ -176,6 +176,35 @@ public struct OverviewNoticeDisplay: Equatable, Sendable, Identifiable {
     }
 }
 
+public struct K9sHandoffTarget: Equatable, Sendable {
+    public let contextName: String
+    public let namespace: String
+
+    public init(contextName: String, namespace: String) {
+        self.contextName = contextName
+        self.namespace = namespace
+    }
+}
+
+public struct OverviewK9sHandoff: Equatable, Sendable {
+    public let target: K9sHandoffTarget
+    public let actionLabel: String
+    public let helpText: String
+    public let accessibilityLabel: String
+
+    public init(
+        target: K9sHandoffTarget,
+        actionLabel: String,
+        helpText: String,
+        accessibilityLabel: String
+    ) {
+        self.target = target
+        self.actionLabel = actionLabel
+        self.helpText = helpText
+        self.accessibilityLabel = accessibilityLabel
+    }
+}
+
 public enum NodeItemReadiness: Equatable, Sendable {
     case ready
     case notReady
@@ -371,6 +400,7 @@ public struct OverviewDisplay: Equatable, Sendable {
     public let statusText: String
     public let statusHelpText: String
     public let statusAccessibilityLabel: String
+    public let k9sHandoff: OverviewK9sHandoff?
     public let cards: [OverviewCardDisplay]
     public let recentWarnings: [WarningEventDisplay]
     public let recentWarningsOverflowCount: Int
@@ -381,6 +411,7 @@ public struct OverviewDisplay: Equatable, Sendable {
         statusText: String,
         statusHelpText: String? = nil,
         statusAccessibilityLabel: String,
+        k9sHandoff: OverviewK9sHandoff? = nil,
         cards: [OverviewCardDisplay],
         recentWarnings: [WarningEventDisplay],
         recentWarningsOverflowCount: Int,
@@ -390,6 +421,7 @@ public struct OverviewDisplay: Equatable, Sendable {
         self.statusText = statusText
         self.statusHelpText = statusHelpText ?? statusText
         self.statusAccessibilityLabel = statusAccessibilityLabel
+        self.k9sHandoff = k9sHandoff
         self.cards = cards
         self.recentWarnings = recentWarnings
         self.recentWarningsOverflowCount = recentWarningsOverflowCount

--- a/KubebarCore/QA/MenuStateFixtureCatalog.swift
+++ b/KubebarCore/QA/MenuStateFixtureCatalog.swift
@@ -75,6 +75,7 @@ public enum MenuStateFixtureCatalog {
                 id: state,
                 display: evaluator.evaluate(snapshot: watchSnapshot(), now: now),
                 expectedBehavior: "Overview shows Watch with a pinned BackOff warning row."
+                    + " The top detail includes a direct `Open in k9s` action for qa-api."
                     + " Hovering the top status explains the restarting qa-api Pod."
                     + " Pods tab shows the watched Pod first with yellow dot, 0/1, and gray issue text.",
                 limitations: "Requires visible menu inspection to confirm reason-first warning copy, pinned marker, and card readability."
@@ -84,6 +85,7 @@ public enum MenuStateFixtureCatalog {
                 id: state,
                 display: evaluator.evaluate(snapshot: badSnapshot(), now: now),
                 expectedBehavior: "Overview shows Bad and prioritizes the broken tracked target in the top row."
+                    + " The top detail includes a direct `Open in k9s` action for qa-payments."
                     + " Hovering the top status names the affected qa-payments Pods."
                     + " Pods tab shows failed Pods first with red dots and issue text.",
                 limitations: "Requires visible menu inspection to confirm top-row priority and card state."

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -128,7 +128,8 @@ public struct HealthEvaluator: Sendable {
                 visibleItems: Array(visibleItems),
                 sectionNotices: sectionNotices,
                 warningRows: overviewWarnings,
-                totalWarningRows: overviewWarningRows.count
+                totalWarningRows: overviewWarningRows.count,
+                k9sHandoff: k9sHandoffTarget(from: snapshot, state: resolvedState)
             ),
             nodeTab: makeNodeTab(from: snapshot, sectionNotices: sectionNotices),
             podTab: makePodTab(from: snapshot, visibleItems: Array(visibleItems), sectionNotices: sectionNotices),
@@ -208,7 +209,8 @@ public struct HealthEvaluator: Sendable {
         visibleItems: [WatchItemDisplay],
         sectionNotices: [SectionAvailabilityDisplay],
         warningRows: [WarningEventDisplay],
-        totalWarningRows: Int
+        totalWarningRows: Int,
+        k9sHandoff: OverviewK9sHandoff?
     ) -> OverviewDisplay {
         let statusHelpText = primaryStatusHelpText(
             for: state,
@@ -230,6 +232,7 @@ public struct HealthEvaluator: Sendable {
                 statusHelpText: statusHelpText,
                 contextName: snapshot.contextName
             ),
+            k9sHandoff: k9sHandoff,
             cards: [
                 nodeOverviewCard(from: snapshot, state: state),
                 podOverviewCard(from: snapshot, state: state),
@@ -269,6 +272,49 @@ public struct HealthEvaluator: Sendable {
             recentWarningsOverflowCount: 0,
             recentWarningsEmptyMessage: "Warning event count unavailable"
         )
+    }
+
+    private func k9sHandoffTarget(from snapshot: ClusterSnapshot, state: ClusterHealthState) -> OverviewK9sHandoff? {
+        guard state == .watch || state == .bad else {
+            return nil
+        }
+
+        let sortedTrackedItems = sortByAttention(snapshot.trackedItems)
+        guard let item = sortedTrackedItems.first(where: { $0.state == .bad || $0.state == .watch }),
+              let target = handoffTarget(for: item.target, contextName: snapshot.contextName)
+        else {
+            return nil
+        }
+
+        return OverviewK9sHandoff(
+            target: target,
+            actionLabel: "Open in k9s",
+            helpText: "Open watched target in k9s",
+            accessibilityLabel: "Open watched target in k9s"
+        )
+    }
+
+    private func handoffTarget(for target: WatchTarget, contextName: String) -> K9sHandoffTarget? {
+        guard let normalizedContextName = normalizedText(contextName), !normalizedContextName.isEmpty,
+              normalizedContextName != "Not configured"
+        else {
+            return nil
+        }
+
+        switch target {
+        case let .namespace(namespace):
+            guard let normalizedNamespace = normalizedText(namespace), !normalizedNamespace.isEmpty else {
+                return nil
+            }
+
+            return K9sHandoffTarget(contextName: normalizedContextName, namespace: normalizedNamespace)
+        case let .workload(namespace: namespace, _, _):
+            guard let normalizedNamespace = normalizedText(namespace), !normalizedNamespace.isEmpty else {
+                return nil
+            }
+
+            return K9sHandoffTarget(contextName: normalizedContextName, namespace: normalizedNamespace)
+        }
     }
 
     private func nodeOverviewCard(from snapshot: ClusterSnapshot, state: ClusterHealthState) -> OverviewCardDisplay {

--- a/KubebarCore/Services/K9sHandoffCoordinator.swift
+++ b/KubebarCore/Services/K9sHandoffCoordinator.swift
@@ -36,6 +36,28 @@ public enum K9sHandoffLaunchState: Equatable, Sendable {
     }
 }
 
+public extension K9sHandoffLaunchState {
+    func isOpeningForSameTarget(_ handoff: OverviewK9sHandoff) -> Bool {
+        switch self {
+        case let .opening(target):
+            target == handoff
+        default:
+            false
+        }
+    }
+
+    func feedbackMessage(for handoff: OverviewK9sHandoff) -> String? {
+        switch self {
+        case .idle:
+            nil
+        case .opening(let target):
+            target == handoff ? "Opening k9s..." : nil
+        case .failed(let target, let message):
+            target == handoff ? message : nil
+        }
+    }
+}
+
 @MainActor
 public final class K9sHandoffCoordinator {
     public private(set) var state: K9sHandoffLaunchState = .idle

--- a/KubebarCore/Services/K9sHandoffCoordinator.swift
+++ b/KubebarCore/Services/K9sHandoffCoordinator.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+public enum K9sHandoffLaunchState: Equatable, Sendable {
+    case idle
+    case opening(target: OverviewK9sHandoff)
+    case failed(target: OverviewK9sHandoff, message: String)
+
+    public var target: OverviewK9sHandoff? {
+        switch self {
+        case .idle:
+            nil
+        case let .opening(target: target):
+            target
+        case let .failed(target: target, message: _):
+            target
+        }
+    }
+
+    public var message: String? {
+        switch self {
+        case .idle:
+            nil
+        case .opening:
+            "Opening k9s..."
+        case let .failed(_, message):
+            message
+        }
+    }
+
+    public var isOpening: Bool {
+        if case .opening = self {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+@MainActor
+public final class K9sHandoffCoordinator {
+    public private(set) var state: K9sHandoffLaunchState = .idle
+    public var onStateChange: ((K9sHandoffLaunchState) -> Void)?
+
+    private let launcher: K9sHandoffLaunching
+    private var launchTask: Task<Void, Never>?
+
+    public init(launcher: K9sHandoffLaunching = K9sHandoffLauncher()) {
+        self.launcher = launcher
+    }
+
+    public func open(for handoff: OverviewK9sHandoff?) {
+        guard let handoff else {
+            clear()
+            return
+        }
+
+        if case .opening = state {
+            return
+        }
+
+        transition(to: .opening(target: handoff))
+
+        let launchTarget = handoff.target
+        launchTask = Task(priority: .userInitiated) { [weak self, launcher = launcher] in
+            do {
+                try await Task.detached(priority: .userInitiated) {
+                    try launcher.launch(contextName: launchTarget.contextName, namespace: launchTarget.namespace)
+                }.value
+
+                self?.completeLaunch()
+            } catch {
+                self?.failLaunch(for: handoff)
+            }
+        }
+    }
+
+    public func clear() {
+        launchTask?.cancel()
+        launchTask = nil
+        transition(to: .idle)
+    }
+
+    public func resetIfTargetUnavailable(_ handoff: OverviewK9sHandoff?) {
+        guard let handoff else {
+            clear()
+            return
+        }
+
+        guard state.target == handoff else {
+            clear()
+            return
+        }
+    }
+
+    private func completeLaunch() {
+        launchTask = nil
+        transition(to: .idle)
+    }
+
+    private func failLaunch(for handoff: OverviewK9sHandoff) {
+        launchTask = nil
+        transition(
+            to: .failed(
+                target: handoff,
+                message: "Could not open k9s for \(handoff.target.contextName)/\(handoff.target.namespace)"
+            )
+        )
+    }
+
+    private func transition(to next: K9sHandoffLaunchState) {
+        if state == next {
+            return
+        }
+
+        state = next
+        onStateChange?(state)
+    }
+}

--- a/KubebarCore/Services/K9sHandoffLauncher.swift
+++ b/KubebarCore/Services/K9sHandoffLauncher.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public enum K9sHandoffLauncherError: Error, Equatable, Sendable {
+    case failed
+}
+
+public protocol K9sHandoffLaunching: Sendable {
+    func launch(contextName: String, namespace: String) throws
+}
+
+public final class K9sHandoffLauncher: K9sHandoffLaunching {
+    private let runner: CommandRunning
+
+    public init(runner: CommandRunning = ProcessCommandRunner()) {
+        self.runner = runner
+    }
+
+    public func launch(contextName: String, namespace: String) throws {
+        let path = ProcessCommandRunner.launchEnvironment(base: ProcessInfo.processInfo.environment)["PATH"]
+            ?? "/usr/bin:/bin:/usr/sbin:/sbin"
+
+        let request = CommandRequest(
+            executable: "osascript",
+            arguments: [
+                "-e",
+                launchScript(),
+                contextName,
+                namespace,
+                path
+            ],
+            timeoutSeconds: 12
+        )
+
+        do {
+            let result = try runner.run(request)
+            guard result.exitCode == 0 else {
+                throw K9sHandoffLauncherError.failed
+            }
+        } catch {
+            throw K9sHandoffLauncherError.failed
+        }
+    }
+
+    private func launchScript() -> String {
+        """
+        on run argv
+            set contextName to item 1 of argv
+            set namespaceName to item 2 of argv
+            set pathEnvironment to item 3 of argv
+
+            tell application "Terminal"
+                activate
+                do script "export PATH=" & quoted form of pathEnvironment & "; exec k9s --context " & quoted form of contextName & " -n " & quoted form of namespaceName
+            end tell
+        end run
+        """
+    }
+}

--- a/KubebarCore/Services/K9sHandoffLauncher.swift
+++ b/KubebarCore/Services/K9sHandoffLauncher.swift
@@ -49,8 +49,12 @@ public final class K9sHandoffLauncher: K9sHandoffLaunching {
             set pathEnvironment to item 3 of argv
 
             tell application "Terminal"
-                activate
-                do script "export PATH=" & quoted form of pathEnvironment & "; exec k9s --context " & quoted form of contextName & " -n " & quoted form of namespaceName
+                set k9sCommand to "export PATH=" & quoted form of pathEnvironment & "; exec k9s --context " & quoted form of contextName & " -n " & quoted form of namespaceName
+                if (count of windows) is greater than 0 then
+                    do script k9sCommand in front window
+                else
+                    do script k9sCommand
+                end if
             end tell
         end run
         """

--- a/KubebarCore/Services/K9sHandoffLauncher.swift
+++ b/KubebarCore/Services/K9sHandoffLauncher.swift
@@ -31,12 +31,7 @@ public final class K9sHandoffLauncher: K9sHandoffLaunching {
             timeoutSeconds: 12
         )
 
-        do {
-            let result = try runner.run(request)
-            guard result.exitCode == 0 else {
-                throw K9sHandoffLauncherError.failed
-            }
-        } catch {
+        guard let result = try? runner.run(request), result.exitCode == 0 else {
             throw K9sHandoffLauncherError.failed
         }
     }

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -99,6 +99,104 @@ struct MenuDisplayModelTests {
         #expect(display.primaryStatusReason == "1 pod pending")
     }
 
+    @Test("watch and bad tracked targets expose k9s handoff target")
+    func watchAndBadTrackedTargetsExposeK9sHandoff() {
+        let watchSnapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodeSummary: NodeSummary(ready: 3, total: 3),
+            podSummary: PodSummary(running: 12, total: 12),
+            warningEventCount: 0,
+            trackedItems: [
+                TrackedItemStatus(
+                    target: .namespace("api"),
+                    state: .watch,
+                    reason: "1 pod restarting"
+                )
+            ],
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+        let badSnapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodeSummary: NodeSummary(ready: 3, total: 3),
+            podSummary: PodSummary(running: 5, total: 6),
+            warningEventCount: 0,
+            trackedItems: [
+                TrackedItemStatus(
+                    target: .workload(namespace: "api", name: "checkout"),
+                    state: .bad,
+                    reason: "1 pod unavailable"
+                )
+            ],
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let watchDisplay = HealthEvaluator().evaluate(snapshot: watchSnapshot, now: Date(timeIntervalSince1970: 120))
+        let badDisplay = HealthEvaluator().evaluate(snapshot: badSnapshot, now: Date(timeIntervalSince1970: 120))
+
+        #expect(watchDisplay.overview.k9sHandoff?.target.contextName == "prod")
+        #expect(watchDisplay.overview.k9sHandoff?.target.namespace == "api")
+        #expect(badDisplay.overview.k9sHandoff?.target.namespace == "api")
+        #expect(watchDisplay.state == .watch)
+        #expect(badDisplay.state == .bad)
+    }
+
+    @Test("healthy, stale, and warning-only states do not expose k9s handoff")
+    func nonAbnormalTrackedStatesDoNotExposeK9sHandoff() {
+        let healthySnapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodeSummary: NodeSummary(ready: 3, total: 3),
+            podSummary: PodSummary(running: 12, total: 12),
+            warningEventCount: 0,
+            trackedItems: [
+                TrackedItemStatus(
+                    target: .namespace("api"),
+                    state: .ok,
+                    reason: "6/6 watched pods running"
+                )
+            ],
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+        let warningOnlySnapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 12, total: 12)),
+            warningEventsSection: .available([warningEvent(reason: "BackOff", observedAt: Date(timeIntervalSince1970: 100), count: 1)]),
+            workloadsSection: .available([]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+        let staleSnapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodeSummary: NodeSummary(ready: 3, total: 3),
+            podSummary: PodSummary(running: 12, total: 12),
+            warningEventCount: 0,
+            trackedItems: [
+                TrackedItemStatus(
+                    target: .namespace("api"),
+                    state: .bad,
+                    reason: "1 pod unavailable"
+                )
+            ],
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let healthyDisplay = HealthEvaluator().evaluate(snapshot: healthySnapshot, now: Date(timeIntervalSince1970: 120))
+        let warningDisplay = HealthEvaluator().evaluate(
+            snapshot: warningOnlySnapshot,
+            now: Date(timeIntervalSince1970: 120)
+        )
+        let staleDisplay = HealthEvaluator().evaluate(
+            snapshot: nil,
+            previousSnapshot: staleSnapshot,
+            failure: nil,
+            now: Date(timeIntervalSince1970: 130),
+            staleAfterSeconds: 10,
+        )
+
+        #expect(healthyDisplay.overview.k9sHandoff == nil)
+        #expect(warningDisplay.overview.k9sHandoff == nil)
+        #expect(staleDisplay.overview.k9sHandoff == nil)
+    }
+
     @Test("tracked item status help includes expanded detail")
     func trackedItemStatusHelpIncludesExpandedDetail() {
         let latestWarning = warningEvent(

--- a/KubebarTests/Services/K9sHandoffCoordinatorTests.swift
+++ b/KubebarTests/Services/K9sHandoffCoordinatorTests.swift
@@ -21,7 +21,7 @@ struct K9sHandoffCoordinatorTests {
 
         launcher.release()
 
-        try? await Task.sleep(for: .milliseconds(150))
+        #expect(await waitForState(coordinator, expected: .idle, timeout: .seconds(1)))
         #expect(coordinator.state == .idle)
         #expect(launcher.callCount == 1)
     }
@@ -42,7 +42,7 @@ struct K9sHandoffCoordinatorTests {
 
         #expect(coordinator.state == .opening(target: target))
         launcher.release()
-        try? await Task.sleep(for: .milliseconds(150))
+        #expect(await waitForState(coordinator, expected: .idle, timeout: .seconds(1)))
         #expect(launcher.callCount == 1)
     }
 
@@ -60,8 +60,7 @@ struct K9sHandoffCoordinatorTests {
         coordinator.open(for: target)
         #expect(coordinator.state == .opening(target: target))
         launcher.release()
-        try? await Task.sleep(for: .milliseconds(150))
-
+        #expect(await waitForState(coordinator, expected: .failed(target: target, message: "Could not open k9s for prod/api"), timeout: .seconds(1)))
         #expect(coordinator.state == .failed(target: target, message: "Could not open k9s for prod/api"))
     }
 
@@ -170,4 +169,20 @@ private final class ControlledLauncher: K9sHandoffLaunching, @unchecked Sendable
     func release() {
         releaseGate.signal()
     }
+}
+
+@MainActor
+private func waitForState(
+    _ coordinator: K9sHandoffCoordinator,
+    expected: K9sHandoffLaunchState,
+    timeout: Duration
+) async -> Bool {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+
+    while coordinator.state != expected && clock.now < deadline {
+        try? await Task.sleep(for: .milliseconds(20))
+    }
+
+    return coordinator.state == expected
 }

--- a/KubebarTests/Services/K9sHandoffCoordinatorTests.swift
+++ b/KubebarTests/Services/K9sHandoffCoordinatorTests.swift
@@ -80,6 +80,59 @@ struct K9sHandoffCoordinatorTests {
         coordinator.resetIfTargetUnavailable(nil)
         #expect(coordinator.state == .idle)
     }
+
+    @Test("handoff state exposes feedback message for matching target only")
+    func feedbackMessageTargetsOnlyTheMatchingLaunchTarget() {
+        let matchingTarget = OverviewK9sHandoff(
+            target: K9sHandoffTarget(contextName: "prod", namespace: "api"),
+            actionLabel: "Open in k9s",
+            helpText: "Open watched target in k9s",
+            accessibilityLabel: "Open watched target in k9s"
+        )
+        let otherTarget = OverviewK9sHandoff(
+            target: K9sHandoffTarget(contextName: "stage", namespace: "api"),
+            actionLabel: "Open in k9s",
+            helpText: "Open watched target in k9s",
+            accessibilityLabel: "Open watched target in k9s"
+        )
+
+        #expect(K9sHandoffLaunchState.idle.feedbackMessage(for: matchingTarget) == nil)
+        #expect(K9sHandoffLaunchState.opening(target: matchingTarget).feedbackMessage(for: matchingTarget) == "Opening k9s...")
+        #expect(K9sHandoffLaunchState.opening(target: matchingTarget).feedbackMessage(for: otherTarget) == nil)
+        #expect(
+            K9sHandoffLaunchState.failed(
+                target: matchingTarget,
+                message: "Could not open k9s for prod/api"
+            ).feedbackMessage(for: matchingTarget) == "Could not open k9s for prod/api"
+        )
+        #expect(
+            K9sHandoffLaunchState.failed(
+                target: matchingTarget,
+                message: "Could not open k9s for prod/api"
+            ).feedbackMessage(for: otherTarget) == nil
+        )
+    }
+
+    @Test("opening feedback flag is target-specific")
+    func openingStateIsOpeningOnlyForTheMatchingTarget() {
+        let matchingTarget = OverviewK9sHandoff(
+            target: K9sHandoffTarget(contextName: "prod", namespace: "api"),
+            actionLabel: "Open in k9s",
+            helpText: "Open watched target in k9s",
+            accessibilityLabel: "Open watched target in k9s"
+        )
+        let otherTarget = OverviewK9sHandoff(
+            target: K9sHandoffTarget(contextName: "stage", namespace: "api"),
+            actionLabel: "Open in k9s",
+            helpText: "Open watched target in k9s",
+            accessibilityLabel: "Open watched target in k9s"
+        )
+        let openingState = K9sHandoffLaunchState.opening(target: matchingTarget)
+
+        #expect(openingState.isOpeningForSameTarget(matchingTarget))
+        #expect(!openingState.isOpeningForSameTarget(otherTarget))
+        #expect(!K9sHandoffLaunchState.idle.isOpeningForSameTarget(matchingTarget))
+    }
 }
 
 private final class ControlledLauncher: K9sHandoffLaunching, @unchecked Sendable {

--- a/KubebarTests/Services/K9sHandoffCoordinatorTests.swift
+++ b/KubebarTests/Services/K9sHandoffCoordinatorTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Testing
+@testable import KubebarCore
+
+@MainActor
+@Suite("k9s handoff coordinator")
+struct K9sHandoffCoordinatorTests {
+    @Test("opening target shows opening state then returns to idle")
+    func openingTargetReturnsToIdle() async {
+        let launcher = ControlledLauncher(delayNanoseconds: 100_000_000)
+        let coordinator = K9sHandoffCoordinator(launcher: launcher)
+        let target = OverviewK9sHandoff(
+            target: K9sHandoffTarget(contextName: "prod", namespace: "api"),
+            actionLabel: "Open in k9s",
+            helpText: "Open watched target in k9s",
+            accessibilityLabel: "Open watched target in k9s"
+        )
+
+        coordinator.open(for: target)
+        #expect(coordinator.state == .opening(target: target))
+
+        launcher.release()
+
+        try? await Task.sleep(for: .milliseconds(150))
+        #expect(coordinator.state == .idle)
+        #expect(launcher.callCount == 1)
+    }
+
+    @Test("repeated activation while opening does not retry launch")
+    func repeatedActivationIsIgnoredWhileOpening() async {
+        let launcher = ControlledLauncher(delayNanoseconds: 100_000_000)
+        let coordinator = K9sHandoffCoordinator(launcher: launcher)
+        let target = OverviewK9sHandoff(
+            target: K9sHandoffTarget(contextName: "prod", namespace: "api"),
+            actionLabel: "Open in k9s",
+            helpText: "Open watched target in k9s",
+            accessibilityLabel: "Open watched target in k9s"
+        )
+
+        coordinator.open(for: target)
+        coordinator.open(for: target)
+
+        #expect(coordinator.state == .opening(target: target))
+        launcher.release()
+        try? await Task.sleep(for: .milliseconds(150))
+        #expect(launcher.callCount == 1)
+    }
+
+    @Test("failure publishes safe message and stays target-specific")
+    func launchFailureIsScopedToTarget() async {
+        let launcher = ControlledLauncher(result: .failure(K9sHandoffLauncherError.failed), delayNanoseconds: 100_000_000)
+        let coordinator = K9sHandoffCoordinator(launcher: launcher)
+        let target = OverviewK9sHandoff(
+            target: K9sHandoffTarget(contextName: "prod", namespace: "api"),
+            actionLabel: "Open in k9s",
+            helpText: "Open watched target in k9s",
+            accessibilityLabel: "Open watched target in k9s"
+        )
+
+        coordinator.open(for: target)
+        #expect(coordinator.state == .opening(target: target))
+        launcher.release()
+        try? await Task.sleep(for: .milliseconds(150))
+
+        #expect(coordinator.state == .failed(target: target, message: "Could not open k9s for prod/api"))
+    }
+
+    @Test("state clears when target disappears")
+    func stateClearsWhenTargetDisappears() {
+        let launcher = ControlledLauncher()
+        let coordinator = K9sHandoffCoordinator(launcher: launcher)
+        let target = OverviewK9sHandoff(
+            target: K9sHandoffTarget(contextName: "prod", namespace: "api"),
+            actionLabel: "Open in k9s",
+            helpText: "Open watched target in k9s",
+            accessibilityLabel: "Open watched target in k9s"
+        )
+
+        coordinator.open(for: target)
+        coordinator.resetIfTargetUnavailable(nil)
+        #expect(coordinator.state == .idle)
+    }
+}
+
+private final class ControlledLauncher: K9sHandoffLaunching, @unchecked Sendable {
+    private let result: Result<Void, Error>
+    private let delayNanoseconds: UInt64
+    private let releaseGate = DispatchSemaphore(value: 0)
+    private(set) var callCount = 0
+
+    init(
+        result: Result<Void, Error> = .success(()),
+        delayNanoseconds: UInt64 = 0
+    ) {
+        self.result = result
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    func launch(contextName: String, namespace: String) throws {
+        _ = contextName
+        _ = namespace
+        callCount += 1
+
+        if delayNanoseconds > 0 {
+            releaseGate.wait()
+            Thread.sleep(forTimeInterval: TimeInterval(delayNanoseconds) / 1_000_000_000)
+        }
+
+        switch result {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func release() {
+        releaseGate.signal()
+    }
+}

--- a/KubebarTests/Services/K9sHandoffLauncherTests.swift
+++ b/KubebarTests/Services/K9sHandoffLauncherTests.swift
@@ -20,6 +20,20 @@ struct K9sHandoffLauncherTests {
         #expect(request.arguments[4].contains("/usr/bin"))
     }
 
+    @Test("launch avoids opening a separate blank terminal window")
+    func launchUsesExistingTerminalWindowIfAvailable() throws {
+        let runner = FakeCommandRunner()
+        let launcher = K9sHandoffLauncher(runner: runner)
+
+        try launcher.launch(contextName: "prod", namespace: "api")
+
+        let request = try #require(runner.request)
+        let script = request.arguments[1]
+        #expect(!script.contains("activate"))
+        #expect(script.contains("if (count of windows) is greater than 0"))
+        #expect(script.contains("do script k9sCommand in front window"))
+    }
+
     @Test("launch supports special characters in context and namespace")
     func launchSupportsSpecialCharacters() throws {
         let runner = FakeCommandRunner()

--- a/KubebarTests/Services/K9sHandoffLauncherTests.swift
+++ b/KubebarTests/Services/K9sHandoffLauncherTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import KubebarCore
+
+@Suite("k9s handoff launcher")
+struct K9sHandoffLauncherTests {
+    @Test("launch target is passed as command arguments")
+    func launchTargetIsPassedAsCommandArguments() throws {
+        let runner = FakeCommandRunner()
+        let launcher = K9sHandoffLauncher(runner: runner)
+
+        try launcher.launch(contextName: "prod", namespace: "api")
+
+        let request = try #require(runner.request)
+        #expect(request.executable == "osascript")
+        #expect(request.arguments.count == 5)
+        #expect(request.arguments[0] == "-e")
+        #expect(request.arguments[2] == "prod")
+        #expect(request.arguments[3] == "api")
+        #expect(request.arguments[4].contains("/usr/bin"))
+    }
+
+    @Test("launch supports special characters in context and namespace")
+    func launchSupportsSpecialCharacters() throws {
+        let runner = FakeCommandRunner()
+        let launcher = K9sHandoffLauncher(runner: runner)
+        let contextName = "prod staging"
+        let namespace = "qa/api; rm -rf /"
+
+        try launcher.launch(contextName: contextName, namespace: namespace)
+
+        let request = try #require(runner.request)
+        #expect(request.arguments[2] == contextName)
+        #expect(request.arguments[3] == namespace)
+    }
+
+    @Test("launcher maps exit failure to handoff failure")
+    func launcherMapsFailureToFailureError() throws {
+        let runner = FakeCommandRunner(result: CommandResult(stdout: "", stderr: "", exitCode: 1))
+        let launcher = K9sHandoffLauncher(runner: runner)
+
+        #expect(throws: K9sHandoffLauncherError.failed) {
+            try launcher.launch(contextName: "prod", namespace: "api")
+        }
+    }
+}
+
+private final class FakeCommandRunner: CommandRunning, @unchecked Sendable {
+    private(set) var request: CommandRequest?
+    private let result: CommandResult
+
+    init(result: CommandResult = CommandResult(stdout: "ok", stderr: "", exitCode: 0)) {
+        self.result = result
+    }
+
+    func run(_ request: CommandRequest) throws -> CommandResult {
+        self.request = request
+        return result
+    }
+}

--- a/docs/brainstorms/2026-04-23-kubebar-k9s-handoff-requirements.md
+++ b/docs/brainstorms/2026-04-23-kubebar-k9s-handoff-requirements.md
@@ -1,0 +1,136 @@
+---
+date: 2026-04-23
+topic: kubebar-k9s-handoff
+---
+
+# Kubebar k9s Handoff Requirements
+
+## Problem Frame
+
+Kubebar helps a daily Kubernetes operator notice when a watched target needs
+attention. Today, the next step is manual: open `k9s`, choose the right context,
+and navigate back to the relevant namespace before investigating.
+
+This feature should reduce that handoff friction without changing Kubebar's
+role. Kubebar remains the glanceable status tool. `k9s` remains the deeper
+debugging tool.
+
+## Requirements
+
+**Handoff Entry**
+- R1. Kubebar must provide an `Open in k9s` action for watched targets
+  whose current state is `Watch` or `Bad`.
+- R2. The action must appear in the Overview top status short detail when that
+  status is driven by an abnormal watched target. It must be a deliberate
+  button-style action, not an automatic launch or a primary row click.
+- R3. Kubebar must not show this action for healthy watched targets, setup states,
+  empty watchlist states, or any stale display state where the issue may no
+  longer be current.
+- R4. The first version of this handoff must focus on watched targets, not
+  Recent Warnings, node rows, or a global context launcher.
+- R5. Kubebar must only show the action when the app-owned context and watched
+  target's namespace are both known. If either value is unavailable, the detail
+  view must explain that `k9s` cannot be opened for that target.
+
+**Handoff Behavior**
+- R6. Activating `Open in k9s` must open the user's local `k9s` in the same
+  app-owned Kubernetes context that Kubebar is displaying.
+- R7. The handoff must land in the watched target's namespace. Namespace-level
+  targeting is the required baseline; exact workload or pod positioning is not
+  required for this version unless planning proves it can be done safely without
+  adding deeper troubleshooting behavior to Kubebar.
+- R8. While the handoff is opening, Kubebar must provide brief feedback so the
+  user does not mistake a delayed launch for a dead action.
+- R9. If `k9s` cannot be opened, Kubebar must show a clear failure message that
+  identifies the intended context and namespace.
+- R10. The handoff must not silently fall back to the terminal's current
+  Kubernetes context.
+
+**Product Boundaries**
+- R11. Kubebar must not embed a terminal, stream logs, show raw command output,
+  or add a troubleshooting console as part of this feature.
+- R12. Kubernetes watch streams remain out of scope for this feature; fixed
+  polling should continue to prove the daily status loop first.
+- R13. Multi-cluster switching remains out of scope. The handoff uses the
+  context Kubebar already owns and displays.
+- R14. The menu must remain glanceable after this action is added; the handoff
+  must not crowd out the primary watched target state or reason.
+- R15. The action must remain reachable through keyboard navigation and must
+  have accessibility text that names the external action and target namespace.
+
+## Success Criteria
+
+- From an abnormal watched target, the user can open `k9s` for the same
+  context and namespace with one deliberate action.
+- Healthy, stale, setup, and empty-watchlist states do not offer a misleading
+  handoff.
+- Watched targets without a known context or namespace do not offer a broken
+  handoff.
+- Missing or unavailable `k9s` produces an understandable message rather than a
+  silent failure.
+- A slow launch shows feedback before success or failure.
+- Keyboard and screen-reader users can reach and understand the handoff action.
+- Kubebar still reads as a lightweight status instrument, not a replacement for
+  `k9s`.
+
+## Scope Boundaries
+
+- No embedded terminal.
+- No logs view.
+- No command transcript display.
+- No full troubleshooting surface inside the menu.
+- No Recent Warnings handoff in this version.
+- No node-level handoff in this version.
+- No multi-cluster switching UI.
+- No Kubernetes watch-stream behavior.
+
+## Key Decisions
+
+- **Start with watched target handoff:** This matches Kubebar's watchlist-first
+  product value and avoids turning every warning or node row into a launcher.
+- **Open directly, without a confirmation step:** The feature's value is
+  reducing friction from signal to investigation. Failure states can explain
+  what went wrong when local `k9s` is unavailable.
+- **Use namespace-level targeting as the baseline:** It is enough to place the
+  operator in the right context and namespace without requiring Kubebar to own
+  deeper `k9s` navigation semantics. Exact workload targeting can be considered
+  during planning only if it stays within the same shallow handoff boundary.
+- **Keep stale data from launching investigations:** Stale state must not look
+  current, and a handoff from stale data could point the operator at an outdated
+  problem.
+- **Place the action in Overview top status detail:** The entry stays close to
+  the abnormal signal that made the operator open Kubebar, while keeping the
+  visible top row focused on state and reason.
+
+## Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+| --- | --- | --- | --- |
+| Keep as backlog only | Lowest scope risk | Does not reduce daily handoff friction | Rejected |
+| Recent Warnings handoff | Useful for event-driven investigation | Less aligned with watchlist-first value | Deferred |
+| Global context launcher | Simple and low risk | Does not help locate the watched issue | Rejected for first version |
+| Copy command instead of opening `k9s` | Transparent and safe | Adds manual friction | Rejected |
+| Open plus copy options | Flexible fallback | Adds extra UI weight | Deferred |
+
+## Dependencies / Assumptions
+
+- The user has local Kubernetes access already configured for `kubectl`.
+- `k9s` is an optional local tool; Kubebar must handle it being absent.
+- The display model can identify the abnormal watched target, app-owned
+  context, and namespace needed for the handoff.
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R6-R10][Technical] What is the simplest macOS-safe way to open the
+  user's local `k9s` with an explicit context and namespace?
+- [Affects R9][Technical] How should Kubebar detect and message unavailable
+  `k9s` without exposing command transcripts?
+- [Affects R8][Technical] What short in-progress state is enough for a slow
+  external launch?
+- [Affects R15][Technical] What exact keyboard focus order and accessibility
+  label should the Overview top status detail use?
+
+## Next Steps
+
+-> `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-04-23-004-feat-k9s-handoff-plan.md
+++ b/docs/plans/2026-04-23-004-feat-k9s-handoff-plan.md
@@ -1,0 +1,527 @@
+---
+title: "feat: Add k9s handoff"
+type: feat
+status: active
+date: 2026-04-23
+origin: docs/brainstorms/2026-04-23-kubebar-k9s-handoff-requirements.md
+---
+
+# feat: Add k9s handoff
+
+## Overview
+
+Add a narrow `Open in k9s` handoff from Kubebar's Overview top status detail
+when the current status is driven by an abnormal watched target. The handoff
+opens the user's local `k9s` for the same app-owned context and namespace, gives
+brief launch feedback, and fails with safe user-facing copy when `k9s` cannot
+be opened.
+
+Kubebar remains the glanceable status tool. The new action moves the operator
+from signal to investigation without embedding a terminal, logs, watch streams,
+or a troubleshooting console in the menu.
+
+## Problem Frame
+
+Issue #9 asks whether deeper-debugging handoff is useful without pulling
+Kubebar beyond its first-version product boundary. The origin document resolves
+that as a watched-target handoff: when Kubebar says an important watched target
+is `Watch` or `Bad`, the operator should be able to jump to `k9s` for the same
+context and namespace with one deliberate action (see origin:
+`docs/brainstorms/2026-04-23-kubebar-k9s-handoff-requirements.md`).
+
+The current Overview no longer shows a `Watching` section. Tracked-object
+attention appears through the top status row and pinned warnings, so this plan
+places the handoff in a short Overview status detail rather than reintroducing a
+watchlist block.
+
+## Requirements Trace
+
+- R1. Provide `Open in k9s` for watched targets whose current state is `Watch`
+  or `Bad`.
+- R2. Put the action in the Overview top status short detail as a deliberate
+  button-style action, not an automatic launch or primary row click.
+- R3. Do not show the action for healthy, setup, empty-watchlist, or stale
+  display states.
+- R4. Keep the first version focused on watched targets, not Recent Warnings,
+  node rows, or a global context launcher.
+- R5. Only show the action when the app-owned context and target namespace are
+  known; otherwise explain why it cannot be opened.
+- R6. Open the user's local `k9s` using the app-owned Kubernetes context.
+- R7. Land in the watched target namespace. Exact workload or pod positioning
+  is optional only if it stays within a shallow handoff boundary.
+- R8. Show brief feedback while `k9s` is opening.
+- R9. Show a clear safe failure message when `k9s` cannot be opened.
+- R10. Never fall back to the terminal's current Kubernetes context.
+- R11-R13. Do not add terminal embedding, logs, raw command output, watch
+  streams, or multi-cluster switching.
+- R14-R15. Keep the menu glanceable and keep the action keyboard and
+  accessibility reachable.
+
+## Scope Boundaries
+
+- No embedded terminal.
+- No logs view.
+- No command transcript display in Kubebar.
+- No full troubleshooting surface inside the menu.
+- No Recent Warnings handoff in this version.
+- No node-level handoff in this version.
+- No global context launcher.
+- No multi-cluster switching UI.
+- No Kubernetes watch-stream behavior.
+
+### Deferred to Separate Tasks
+
+- Exact workload or pod positioning inside `k9s`: may be considered later if
+  daily use shows namespace-level handoff is still too broad.
+- Copy-command fallback: remains deferred unless direct launching proves too
+  brittle across local Mac setups.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `docs/architecture/runtime-invariants.md` requires the menu to stay
+  watchlist-first, keep deep troubleshooting out of version 1, avoid raw command
+  transcripts, and never make stale data look current.
+- `docs/architecture/system-overview.md` defines the current flow:
+  `RefreshCoordinator` reads data, `HealthEvaluator` creates
+  `MenuDisplayModel`, and the menu renders only that display model.
+- `KubebarCore/Models/WatchTarget.swift` already represents namespace and
+  workload watched targets. Both carry namespace information that can become a
+  handoff target.
+- `KubebarCore/Models/MenuDisplayModel.swift` contains `OverviewDisplay`,
+  `WatchItemDisplay`, and safe help/accessibility fields. It does not yet carry
+  a k9s handoff target.
+- `KubebarCore/Services/HealthEvaluator.swift` already decides the top status
+  reason and prioritizes abnormal watched targets before lower-priority signals.
+- `Kubebar/Views/StatusSummaryView.swift` renders the Overview top status row
+  and already owns hover/accessibility for the status summary.
+- `Kubebar/MenuBarViewModel.swift` owns UI-bound side effects such as refresh,
+  setup, and view state updates. It is the right place to coordinate launch
+  feedback.
+- `KubebarCore/Services/CommandRunner.swift` provides an injectable process
+  boundary and safe PATH handling for local command execution.
+- `Kubebar/Views/MenuFooterView.swift` shows the existing icon-button style,
+  tooltip, accessibility label, disabled state, and keyboard shortcut patterns.
+- `docs/qa/operator-verification.md` is the operator-facing QA checklist for
+  visual, keyboard, hover, stale, and warning states.
+
+### Institutional Learnings
+
+- No `docs/solutions/` learnings exist in this repository.
+- Prior Overview plans removed the visible `Watching` section. Handoff must not
+  reverse that product decision.
+- Existing product docs consistently treat `k9s` as the deeper tool and
+  Kubebar as the glanceable signal.
+
+### External References
+
+- k9s command docs confirm the CLI can launch in a namespace with `-n`, launch
+  a resource view with `-c`, and use a non-default context with `--context`:
+  https://k9scli.io/topics/commands/
+- Apple `NSWorkspace` documentation confirms macOS apps can launch other apps
+  and that `OpenConfiguration` supports launch arguments, but k9s is a terminal
+  CLI rather than a normal document-opening app:
+  https://developer.apple.com/documentation/AppKit/NSWorkspace
+
+## Key Technical Decisions
+
+- **Carry handoff eligibility in `MenuDisplayModel`:** The view should not infer
+  cluster meaning. `HealthEvaluator` already knows why the top status is
+  showing, so it should decide when a handoff target exists.
+- **Treat namespace-level targeting as the guaranteed behavior:** k9s documents
+  context and namespace flags. Workload-level positioning is useful but should
+  only be added if implementation proves a stable shallow command shape.
+- **Use an injectable launcher boundary:** External launching is a side effect
+  like kubectl reads. It should be testable through a protocol and fake runner,
+  not embedded directly in SwiftUI views.
+- **Prefer argument arrays over shell interpolation:** Context and namespace are
+  cluster-owned strings. Launch code must keep them as structured arguments as
+  far as the macOS handoff mechanism allows, and any unavoidable shell layer
+  needs focused escaping tests.
+- **Keep launch feedback UI-local:** Opening, success, and failure feedback
+  belong to `MenuBarViewModel` and the Overview detail. They should not alter
+  cluster health state.
+- **Do not log or display command transcripts:** User-facing failure copy should
+  name the intended context and namespace, not stderr, raw command lines, JSON,
+  or kubeconfig paths.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where does the action live now that Overview has no watched list?** In a
+  short detail for the Overview top status when that status is driven by an
+  abnormal watched target.
+- **Does a namespace watch target qualify?** Yes. The current product supports
+  namespace and workload watch targets. Both have a namespace and can satisfy
+  the same handoff contract.
+- **Should the plan require exact workload/pod positioning?** No. k9s documents
+  stable context and namespace launch flags. Workload or pod positioning is
+  deferred unless it can be added without turning Kubebar into a deeper
+  navigation surface.
+- **Does this need external research?** Yes, lightly. The plan touches an
+  external CLI and macOS launch behavior. k9s docs confirm context/namespace
+  support; Apple docs clarify the available app-launch surface.
+
+### Deferred to Implementation
+
+- **Exact terminal launch mechanism:** Implement the smallest macOS approach
+  that visibly opens k9s and can be tested behind an injected launcher. If the
+  chosen mechanism requires a shell bridge, add escaping tests for context and
+  namespace values.
+- **Exact in-progress wording:** Keep it short, such as `Opening k9s...`, and
+  ensure it does not shift the top-row layout.
+- **Exact detail affordance shape:** Use the existing SwiftUI constraints to
+  choose the least crowded top-status detail pattern while preserving keyboard
+  access.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for
+> review, not implementation specification. The implementing agent should treat
+> it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+    Snapshot["ClusterSnapshot with watched targets"] --> Evaluator["HealthEvaluator"]
+    Evaluator --> Display["MenuDisplayModel / OverviewDisplay"]
+    Display --> Status["Overview top status detail"]
+    Status --> Button["Open in k9s button"]
+    Button --> ViewModel["MenuBarViewModel"]
+    ViewModel --> Launcher["K9s handoff launcher"]
+    Launcher --> External["Terminal/k9s"]
+    Launcher --> Feedback["Opening or failure feedback"]
+    Feedback --> Status
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add handoff target to the display model**
+
+**Goal:** Represent whether the current Overview top status can offer a k9s
+handoff, including the safe target labels needed by the UI.
+
+**Requirements:** R1-R5, R10, R14-R15
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `KubebarCore/Models/MenuDisplayModel.swift`
+- Modify: `KubebarCore/Services/HealthEvaluator.swift`
+- Test: `KubebarTests/Models/MenuDisplayModelTests.swift`
+
+**Approach:**
+- Add a small display value for k9s handoff eligibility, carrying app-owned
+  context, namespace, target title, action label, help text, and accessibility
+  label.
+- Attach the value to `OverviewDisplay` or another top-status display shape, not
+  to raw UI state.
+- Populate it in `HealthEvaluator` only when the top status is driven by a
+  non-stale watched target in `Watch` or `Bad`.
+- Treat namespace and workload watch targets as eligible when their namespace is
+  known.
+- Omit the value for healthy, setup, empty-watchlist, stale, node-driven,
+  warning-only, metrics-unavailable-only, and section-unavailable-only states.
+- Do not include command strings, executable paths, or raw launch data in the
+  display value.
+
+**Execution note:** Add display-model tests before wiring the UI so eligibility
+rules are fixed at the product boundary.
+
+**Patterns to follow:**
+- `primaryStatusReason` and `statusHelpText` construction in
+  `KubebarCore/Services/HealthEvaluator.swift`
+- `WarningEventDisplay.helpText` and accessibility-label patterns in
+  `KubebarCore/Models/MenuDisplayModel.swift`
+- Stale and unavailable handling in `MenuDisplayModelTests`
+
+**Test scenarios:**
+- Happy path: bad workload target in namespace `api` and context `prod` ->
+  Overview exposes an `Open in k9s` handoff target for `prod/api`.
+- Happy path: watch namespace target `api` -> Overview exposes the same
+  namespace-level handoff target.
+- Edge case: healthy watched target -> no handoff target.
+- Edge case: stale display with previous bad watched target -> no handoff
+  target.
+- Edge case: warning-only state with no abnormal watched target -> no handoff
+  target.
+- Edge case: node-driven `Bad` state with watched targets otherwise OK -> no
+  handoff target.
+- Error path: unavailable workload section or setup-required display -> no
+  broken handoff target.
+- Regression: visible top status text and accessibility status detail remain
+  unchanged except for the additional optional handoff value.
+
+**Verification:**
+- `MenuDisplayModel` contains enough safe data for the UI to render a handoff
+  without interpreting raw cluster facts.
+- Tests prove stale and non-watched attention never exposes the action.
+
+- [ ] **Unit 2: Add a testable k9s launch boundary**
+
+**Goal:** Create the service boundary that opens k9s for a context and namespace
+without leaking command construction into SwiftUI.
+
+**Requirements:** R6-R10, R11-R13
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `KubebarCore/Services/K9sHandoffLauncher.swift`
+- Test: `KubebarTests/Services/K9sHandoffLauncherTests.swift`
+- Modify: `KubebarCore/Services/CommandRunner.swift`
+
+**Approach:**
+- Define a small `K9sHandoffLaunching` protocol that accepts a validated handoff
+  target and returns success or a safe failure category.
+- Use the existing `CommandRunning` pattern so tests can assert launch requests
+  without opening Terminal or k9s.
+- Build k9s arguments from structured values: required context and namespace,
+  with optional resource view only if implementation validates a stable shallow
+  k9s command.
+- Search common executable locations through the existing PATH augmentation
+  pattern rather than assuming the user's login shell is available.
+- If the chosen macOS launch path requires Terminal or AppleScript, keep that
+  bridge contained in this service and add escaping tests for special characters
+  in context and namespace.
+- Map launch failures to safe messages such as `k9s could not be opened for
+  prod / api`; do not surface stderr, shell text, or command transcripts.
+
+**Execution note:** Characterize the launch-request builder with tests before
+connecting it to the view model.
+
+**Patterns to follow:**
+- `CommandRunning`, `CommandRequest`, and `ProcessCommandRunner` in
+  `KubebarCore/Services/CommandRunner.swift`
+- Failure categorization in `KubebarCore/Services/KubectlClusterReader.swift`
+- Existing fake command runners in `KubebarTests/Services/*Tests.swift`
+
+**Test scenarios:**
+- Happy path: target context `prod`, namespace `api` -> launcher builds a
+  request that includes explicit k9s context and namespace arguments.
+- Happy path: executable discovered through augmented PATH -> launcher reports
+  success from a zero-exit fake runner.
+- Edge case: context and namespace with spaces, quotes, or shell metacharacters
+  -> values remain safe and are not interpolated unsafely.
+- Error path: k9s executable missing or launch fails -> safe failure category,
+  no raw stderr in the user-facing message.
+- Error path: terminal bridge returns non-zero -> safe failure category with the
+  intended context and namespace.
+- Regression: launch request never omits the explicit context flag and never
+  relies on terminal current context.
+
+**Verification:**
+- Launching is behind an injectable boundary.
+- Tests prove explicit context/namespace targeting and safe failure mapping.
+
+- [ ] **Unit 3: Coordinate handoff state in the view model**
+
+**Goal:** Wire the launcher into the menu state so the UI can show opening and
+failure feedback without changing cluster health.
+
+**Requirements:** R2, R6-R10, R14-R15
+
+**Dependencies:** Units 1-2
+
+**Files:**
+- Create: `KubebarCore/Services/K9sHandoffCoordinator.swift`
+- Modify: `Kubebar/MenuBarViewModel.swift`
+- Test: `KubebarTests/Services/K9sHandoffCoordinatorTests.swift`
+
+**Approach:**
+- Add a small core coordinator for launch state so the state machine can be
+  tested without importing the macOS app target.
+- Inject the `K9sHandoffLaunching` boundary into the coordinator and then into
+  `MenuBarViewModel`.
+- Represent idle, opening target, and failed target states with safe display
+  text for the Overview detail.
+- Add a view-model action that passes the current Overview handoff target to the
+  coordinator.
+- Clear obsolete launch feedback when refresh changes the displayed target,
+  setup opens, or the display becomes stale.
+- Keep launch state separate from `ClusterHealthState`; a failed external
+  launch must not make the cluster `Watch`, `Bad`, or `Stale`.
+- Ensure repeated taps while opening are disabled or ignored.
+
+**Patterns to follow:**
+- `isRefreshing` and `refreshGate` state handling in `MenuBarViewModel.swift`
+- `applyRefreshResult` and stale/freshness display updates in
+  `MenuBarViewModel.swift`
+- Existing setup save failure state in `MenuRuntimeState`
+- Existing core service tests with fake dependencies in `KubebarTests/Services`
+
+**Test scenarios:**
+- Happy path: opening an eligible handoff target sets opening feedback, invokes
+  launcher once, then returns to idle on success.
+- Edge case: repeated activation while opening -> launcher is not invoked
+  twice.
+- Edge case: refresh removes or changes the handoff target -> previous failure
+  feedback clears.
+- Error path: launcher fails -> view model exposes safe failure text with
+  intended context and namespace.
+- Regression: cluster display state does not change when external launch fails.
+
+**Verification:**
+- View model exposes enough state for short UI feedback.
+- Launch success and failure do not mutate cluster health or saved config.
+
+- [ ] **Unit 4: Add the Overview top status detail action**
+
+**Goal:** Render the handoff action in a compact Overview top status detail
+without crowding the normal one-line status row.
+
+**Requirements:** R1-R5, R8-R9, R14-R15
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Modify: `Kubebar/Views/MenuBarRootView.swift`
+- Modify: `Kubebar/Views/OverviewTabView.swift`
+- Modify: `Kubebar/Views/StatusSummaryView.swift`
+- Test: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+
+**Approach:**
+- Keep the visible top status row one line: context, status icon, status label,
+  and short reason.
+- Add a small detail affordance for eligible abnormal watched-target statuses.
+  The expanded detail should show the safe status detail and an icon+text
+  `Open in k9s` button.
+- Keep the action out of the footer and out of healthy/stale/setup states.
+- Use native SwiftUI controls so keyboard navigation reaches the detail and the
+  button.
+- Use tooltip and accessibility text that names the external action and target
+  namespace.
+- Show brief opening feedback and safe failure feedback near the action without
+  showing command lines or stderr.
+- Preserve the existing Overview focus order, adding the status detail/button
+  immediately after the top status row when present.
+
+**Patterns to follow:**
+- `StatusSummaryView` for top status composition and safe help text.
+- `MenuFooterView` for compact icon button style, disabled state, help text, and
+  accessibility labels.
+- `OverviewTabView` layout spacing and no nested-card constraints.
+- `docs/architecture/runtime-invariants.md` keyboard and stale-data rules.
+
+**Test scenarios:**
+- Happy path: QA `watch` state metadata expects top status detail with
+  `Open in k9s` for the watched namespace.
+- Happy path: QA `bad` state metadata expects the action near the top status,
+  not in the footer or Events.
+- Edge case: healthy fixture metadata does not mention a handoff action.
+- Edge case: stale fixtures do not mention or expose a handoff action.
+- Error path: failure feedback copy is safe and names context/namespace without
+  command output.
+- Accessibility: focus order reaches top status, status detail, `Open in k9s`,
+  cards, Recent Warnings.
+
+**Verification:**
+- Overview stays scan-first and the top row remains one line.
+- The action is discoverable only when an abnormal watched target drives the
+  status.
+- Keyboard and accessibility paths are documented in QA expectations.
+
+- [ ] **Unit 5: Update QA and architecture docs**
+
+**Goal:** Keep product docs and operator verification aligned with the new
+handoff behavior and its boundaries.
+
+**Requirements:** R3-R5, R8-R15
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `docs/architecture/runtime-invariants.md`
+- Modify: `docs/architecture/system-overview.md`
+- Modify: `docs/qa/operator-verification.md`
+- Modify: `KubebarCore/QA/MenuStateFixtureCatalog.swift`
+- Test: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+
+**Approach:**
+- Add runtime invariants that `Open in k9s` appears only for current abnormal
+  watched-target status details with known context and namespace.
+- State that stale data, warning-only attention, node-only attention, and setup
+  states do not offer the handoff.
+- Update system overview to mention the external handoff boundary while
+  preserving "Where The UI Stops": no embedded terminal or troubleshooting
+  console.
+- Update operator verification so Watch and Bad QA states check the top status
+  detail action, keyboard reachability, and safe failure behavior.
+- Keep human-visible QA evidence explicit; do not mark launch behavior verified
+  from model tests alone.
+
+**Patterns to follow:**
+- Existing runtime invariant bullets for stale, watchlist, keyboard, and failure
+  rules.
+- Existing operator verification sections for hover, keyboard, and menu footer.
+- Existing QA fixture expected-behavior phrasing.
+
+**Test scenarios:**
+- Happy path: QA fixture catalog descriptions for Watch and Bad mention the
+  top-status k9s handoff.
+- Edge case: stale, healthy, first-use, empty-watchlist, and warning-heavy
+  fixture descriptions do not imply the handoff is available.
+- Regression: docs still say deep troubleshooting stays out of version 1.
+- Regression: docs still forbid raw command transcripts in menu views.
+
+**Verification:**
+- Runtime docs describe the new allowed handoff and its exclusions.
+- QA docs provide a human-visible checklist for action placement, stale
+  suppression, keyboard access, and safe failure messaging.
+
+## System-Wide Impact
+
+- **Interaction graph:** `HealthEvaluator` selects the handoff target for
+  `MenuDisplayModel`; `StatusSummaryView` renders the detail; `MenuBarViewModel`
+  invokes the launcher; the launcher opens external k9s and reports safe
+  feedback.
+- **Error propagation:** Launcher failures become UI feedback near the action.
+  They do not alter cluster health, saved config, freshness, or watchlist state.
+- **State lifecycle risks:** Handoff feedback must clear when the displayed
+  status changes, when stale data replaces current data, or when setup opens.
+- **API surface parity:** This is a menu UI action only. It does not change
+  Kubernetes reads, setup persistence, refresh cadence, or Events/Nodes/Pods tab
+  scope.
+- **Integration coverage:** Unit tests prove display eligibility and launch
+  request construction. QA fixtures and operator verification cover the
+  cross-layer visual placement and keyboard path.
+- **Unchanged invariants:** `HealthEvaluator` remains the source of severity;
+  UI renders `MenuDisplayModel`; stale data does not look current; the menu does
+  not expose raw command output; deep troubleshooting remains outside Kubebar.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Local k9s is not installed or not discoverable | Use a safe failure state that names the intended context and namespace and keeps cluster state unchanged |
+| macOS terminal launch behavior differs by user setup | Keep launch behind an injectable service and verify the selected mechanism manually in operator QA |
+| Context or namespace values contain shell-sensitive characters | Prefer structured arguments; if a shell bridge is unavoidable, add escaping tests before wiring UI |
+| Handoff appears for stale or non-watched status | Put eligibility in `HealthEvaluator` and cover stale, warning-only, node-only, and healthy cases in tests |
+| Top status becomes too crowded | Put the action in a short detail affordance, not in the one-line row or footer |
+| Exact workload targeting is tempting scope creep | Keep namespace-level targeting as required behavior and defer deeper positioning unless it remains shallow and stable |
+
+## Documentation / Operational Notes
+
+- Update architecture and runtime invariant docs because this is a new external
+  handoff capability.
+- Update operator verification with a manual launch check for Watch and Bad QA
+  states.
+- Do not document `k9s` as a Kubebar prerequisite. It remains optional; missing
+  `k9s` must be handled as an understandable failure.
+- If final launch behavior uses Terminal, document that the external window is
+  where deeper investigation happens; Kubebar itself still does not show logs,
+  terminal output, or command transcripts.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-23-kubebar-k9s-handoff-requirements.md](../brainstorms/2026-04-23-kubebar-k9s-handoff-requirements.md)
+- **GitHub issue:** [#9 Explore optional deeper-debugging handoff](https://github.com/nexttylabs/kubebar/issues/9)
+- Related architecture: [docs/architecture/system-overview.md](../architecture/system-overview.md)
+- Related invariants: [docs/architecture/runtime-invariants.md](../architecture/runtime-invariants.md)
+- Existing top status view: `Kubebar/Views/StatusSummaryView.swift`
+- Existing display model: `KubebarCore/Models/MenuDisplayModel.swift`
+- Existing health mapping: `KubebarCore/Services/HealthEvaluator.swift`
+- Existing command boundary: `KubebarCore/Services/CommandRunner.swift`
+- k9s command docs: https://k9scli.io/topics/commands/
+- Apple NSWorkspace docs: https://developer.apple.com/documentation/AppKit/NSWorkspace


### PR DESCRIPTION
## Summary
- Add a k9s handoff for watch and bad targets
- Launch `k9s` in the existing terminal window instead of opening a blank one first
- Update the status row so the open button sits beside the message with a right-arrow icon
- Add tests for handoff state, launcher behavior, and display model coverage

## Testing
- Local Swift quality gate passed
- New unit tests cover handoff state transitions, launch scripting, and display mapping