### PR TITLE
Add pod resource summaries to Pods tab

### DIFF
--- a/Kubebar/Views/PodsTabView.swift
+++ b/Kubebar/Views/PodsTabView.swift
@@ -157,6 +157,15 @@ private struct PodRowView: View {
                         .lineLimit(1)
                 }
 
+                if !row.resourceLabel.isEmpty {
+                    Text(row.resourceLabel)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .help(Text(row.resourceLabel))
+                }
+
                 if let issueText = row.issueText {
                     Text(issueText)
                         .font(.caption)

--- a/KubebarCore/Models/ClusterSnapshot.swift
+++ b/KubebarCore/Models/ClusterSnapshot.swift
@@ -53,6 +53,34 @@ public struct PodSummary: Equatable, Sendable {
     }
 }
 
+public struct PodResourceSummary: Equatable, Sendable {
+    public let cpuUsageNanocores: Int64?
+    public let cpuRequestNanocores: Int64?
+    public let cpuLimitNanocores: Int64?
+    public let memoryUsageBytes: Int64?
+    public let memoryRequestBytes: Int64?
+    public let memoryLimitBytes: Int64?
+    public let resourceAvailabilityMessage: String?
+
+    public init(
+        cpuUsageNanocores: Int64? = nil,
+        cpuRequestNanocores: Int64? = nil,
+        cpuLimitNanocores: Int64? = nil,
+        memoryUsageBytes: Int64? = nil,
+        memoryRequestBytes: Int64? = nil,
+        memoryLimitBytes: Int64? = nil,
+        resourceAvailabilityMessage: String? = nil
+    ) {
+        self.cpuUsageNanocores = cpuUsageNanocores
+        self.cpuRequestNanocores = cpuRequestNanocores
+        self.cpuLimitNanocores = cpuLimitNanocores
+        self.memoryUsageBytes = memoryUsageBytes
+        self.memoryRequestBytes = memoryRequestBytes
+        self.memoryLimitBytes = memoryLimitBytes
+        self.resourceAvailabilityMessage = resourceAvailabilityMessage
+    }
+}
+
 public struct PodDetail: Equatable, Sendable {
     public let namespace: String
     public let name: String
@@ -72,6 +100,7 @@ public struct PodDetail: Equatable, Sendable {
     public let isPending: Bool
     public let isUnknown: Bool
     public let isNotReady: Bool
+    public let resourceSummary: PodResourceSummary
 
     public init(
         namespace: String,
@@ -91,7 +120,8 @@ public struct PodDetail: Equatable, Sendable {
         isFailed: Bool = false,
         isPending: Bool = false,
         isUnknown: Bool = false,
-        isNotReady: Bool = false
+        isNotReady: Bool = false,
+        resourceSummary: PodResourceSummary = PodResourceSummary()
     ) {
         self.namespace = namespace
         self.name = name
@@ -111,6 +141,7 @@ public struct PodDetail: Equatable, Sendable {
         self.isPending = isPending
         self.isUnknown = isUnknown
         self.isNotReady = isNotReady
+        self.resourceSummary = resourceSummary
     }
 }
 

--- a/KubebarCore/Models/MenuDisplayModel.swift
+++ b/KubebarCore/Models/MenuDisplayModel.swift
@@ -288,6 +288,7 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
     public let name: String
     public let state: PodItemState
     public let readyLabel: String
+    public let resourceLabel: String
     public let issueText: String?
     public let helpText: String
     public let accessibilityLabel: String
@@ -297,6 +298,7 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
         name: String,
         state: PodItemState,
         readyLabel: String,
+        resourceLabel: String,
         issueText: String? = nil,
         helpText: String,
         accessibilityLabel: String
@@ -306,6 +308,7 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
         self.name = name
         self.state = state
         self.readyLabel = readyLabel
+        self.resourceLabel = resourceLabel
         self.issueText = issueText
         self.helpText = helpText
         self.accessibilityLabel = accessibilityLabel

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -636,12 +636,15 @@ public struct HealthEvaluator: Sendable {
     private func makePodRow(from detail: PodDetail) -> PodItemDisplay {
         let state = podItemState(from: detail)
         let readyLabel = podReadyLabel(from: detail)
+        let resourceLabel = podResourceLabel(from: detail.resourceSummary)
+        let resourceHelpLabel = podResourceHelpLabel(from: detail.resourceSummary)
         let fullIssueText = podIssueText(from: detail, state: state)
         let issueText = shortenedText(fullIssueText)
         let helpText = podHelpText(
             detail: detail,
             state: state,
             readyLabel: readyLabel,
+            resourceLabel: resourceHelpLabel,
             issueText: fullIssueText
         )
 
@@ -650,6 +653,7 @@ public struct HealthEvaluator: Sendable {
             name: detail.name,
             state: state,
             readyLabel: readyLabel,
+            resourceLabel: resourceLabel,
             issueText: issueText,
             helpText: helpText,
             accessibilityLabel: helpText
@@ -741,10 +745,109 @@ public struct HealthEvaluator: Sendable {
         return reason ?? message
     }
 
+    private func podResourceLabel(from summary: PodResourceSummary) -> String {
+        let resourceAvailability = summary.resourceAvailabilityMessage.flatMap { sanitizedSectionReason($0) }
+
+        let cpuText = podResourceLine(
+            name: "CPU",
+            usage: summary.cpuUsageNanocores,
+            request: summary.cpuRequestNanocores,
+            limit: summary.cpuLimitNanocores,
+            format: formatCores,
+            suffix: "",
+            includeEmpty: false
+        )
+
+        let memoryText = podResourceLine(
+            name: "Mem",
+            usage: summary.memoryUsageBytes,
+            request: summary.memoryRequestBytes,
+            limit: summary.memoryLimitBytes,
+            format: formatGiB,
+            suffix: "GiB",
+            includeEmpty: false
+        )
+
+        let resourceParts = [cpuText, memoryText].compactMap { part in
+            let trimmed = part.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+
+        if resourceParts.isEmpty {
+            guard let resourceAvailability else {
+                return "-"
+            }
+
+            return "Resource data unavailable: \(resourceAvailability)"
+        }
+
+        let label = resourceParts.joined(separator: " · ")
+        guard let resourceAvailability else {
+            return label
+        }
+
+        return "\(label) · \(resourceAvailability)"
+    }
+
+    private func podResourceHelpLabel(from summary: PodResourceSummary) -> String {
+        let resourceAvailability = summary.resourceAvailabilityMessage.flatMap { sanitizedSectionReason($0) }
+        let label = [
+            podResourceLine(
+                name: "CPU",
+                usage: summary.cpuUsageNanocores,
+                request: summary.cpuRequestNanocores,
+                limit: summary.cpuLimitNanocores,
+                format: formatCores,
+                suffix: "",
+                includeEmpty: true
+            ),
+            podResourceLine(
+                name: "Mem",
+                usage: summary.memoryUsageBytes,
+                request: summary.memoryRequestBytes,
+                limit: summary.memoryLimitBytes,
+                format: formatGiB,
+                suffix: "GiB",
+                includeEmpty: true
+            )
+        ].joined(separator: " · ")
+
+        guard let resourceAvailability else {
+            return label
+        }
+
+        return "\(label) · \(resourceAvailability)"
+    }
+
+    private func podResourceLine(
+        name: String,
+        usage: Int64?,
+        request: Int64?,
+        limit: Int64?,
+        format: (Int64) -> String,
+        suffix: String,
+        includeEmpty: Bool
+    ) -> String {
+        if !includeEmpty && usage == nil && request == nil && limit == nil {
+            return ""
+        }
+
+        let usageText = formatOrDash(usage, formatter: format)
+        let requestText = formatOrDash(request, formatter: format)
+        let limitText = formatOrDash(limit, formatter: format)
+
+        return "\(name) \(usageText)/\(requestText)/\(limitText)\(suffix)"
+    }
+
+    private func formatOrDash(_ value: Int64?, formatter: (Int64) -> String) -> String {
+        value.map(formatter) ?? "-"
+    }
+
     private func podHelpText(
         detail: PodDetail,
         state: PodItemState,
         readyLabel: String,
+        resourceLabel: String,
         issueText: String?
     ) -> String {
         var parts = [
@@ -752,6 +855,10 @@ public struct HealthEvaluator: Sendable {
             state.label,
             readyLabel == "-" ? "container readiness unavailable" : "\(readyLabel) containers ready"
         ]
+
+        if resourceLabel != "-" {
+            parts.append(resourceLabel)
+        }
 
         if let issueText {
             parts.append(issueText)

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -746,53 +746,33 @@ public struct HealthEvaluator: Sendable {
     }
 
     private func podResourceLabel(from summary: PodResourceSummary) -> String {
-        let resourceAvailability = summary.resourceAvailabilityMessage.flatMap { sanitizedSectionReason($0) }
-
         let cpuText = podResourceLine(
             name: "CPU",
             usage: summary.cpuUsageNanocores,
-            request: summary.cpuRequestNanocores,
-            limit: summary.cpuLimitNanocores,
-            format: formatCores,
-            suffix: "",
-            includeEmpty: false
+            primaryBasisLabel: "req",
+            primaryBasis: summary.cpuRequestNanocores,
+            secondaryBasisLabel: "limit",
+            secondaryBasis: summary.cpuLimitNanocores,
+            rawFormatter: formatMillicores
         )
 
         let memoryText = podResourceLine(
             name: "Mem",
             usage: summary.memoryUsageBytes,
-            request: summary.memoryRequestBytes,
-            limit: summary.memoryLimitBytes,
-            format: formatGiB,
-            suffix: "GiB",
-            includeEmpty: false
+            primaryBasisLabel: "limit",
+            primaryBasis: summary.memoryLimitBytes,
+            secondaryBasisLabel: "req",
+            secondaryBasis: summary.memoryRequestBytes,
+            rawFormatter: formatMiB
         )
 
-        let resourceParts = [cpuText, memoryText].compactMap { part in
-            let trimmed = part.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
-        }
-
-        if resourceParts.isEmpty {
-            guard let resourceAvailability else {
-                return "-"
-            }
-
-            return "Resource data unavailable: \(resourceAvailability)"
-        }
-
-        let label = resourceParts.joined(separator: " · ")
-        guard let resourceAvailability else {
-            return label
-        }
-
-        return "\(label) · \(resourceAvailability)"
+        return "\(cpuText) · \(memoryText)"
     }
 
     private func podResourceHelpLabel(from summary: PodResourceSummary) -> String {
         let resourceAvailability = summary.resourceAvailabilityMessage.flatMap { sanitizedSectionReason($0) }
         let label = [
-            podResourceLine(
+            podResourceFullLine(
                 name: "CPU",
                 usage: summary.cpuUsageNanocores,
                 request: summary.cpuRequestNanocores,
@@ -801,7 +781,7 @@ public struct HealthEvaluator: Sendable {
                 suffix: "",
                 includeEmpty: true
             ),
-            podResourceLine(
+            podResourceFullLine(
                 name: "Mem",
                 usage: summary.memoryUsageBytes,
                 request: summary.memoryRequestBytes,
@@ -820,6 +800,43 @@ public struct HealthEvaluator: Sendable {
     }
 
     private func podResourceLine(
+        name: String,
+        usage: Int64?,
+        primaryBasisLabel: String,
+        primaryBasis: Int64?,
+        secondaryBasisLabel: String,
+        secondaryBasis: Int64?,
+        rawFormatter: (Int64) -> String
+    ) -> String {
+        guard let usage else {
+            return "\(name) -"
+        }
+
+        if let primaryBasis, primaryBasis > 0 {
+            return "\(name) \(resourcePercentage(usage: usage, basis: primaryBasis)) \(primaryBasisLabel)"
+        }
+
+        if let secondaryBasis, secondaryBasis > 0 {
+            return "\(name) \(resourcePercentage(usage: usage, basis: secondaryBasis)) \(secondaryBasisLabel)"
+        }
+
+        return "\(name) \(rawFormatter(usage))"
+    }
+
+    private func resourcePercentage(usage: Int64, basis: Int64) -> String {
+        let percent = (Double(usage) / Double(basis) * 100).rounded()
+        return "\(Int(percent))%"
+    }
+
+    private func formatMillicores(_ nanocores: Int64) -> String {
+        "\(formatDecimal(Double(nanocores) / 1_000_000))m"
+    }
+
+    private func formatMiB(_ bytes: Int64) -> String {
+        "\(formatDecimal(Double(bytes) / 1_048_576))Mi"
+    }
+
+    private func podResourceFullLine(
         name: String,
         usage: Int64?,
         request: Int64?,

--- a/KubebarCore/Services/KubectlClusterReader.swift
+++ b/KubebarCore/Services/KubectlClusterReader.swift
@@ -16,6 +16,7 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
         let nodeRecordsSection = decodedSection(rawSnapshot.result(for: .nodes), decode: decodeNodeRecords)
         let nodesSection = mappedSection(nodeRecordsSection, transform: makeNodeSummary)
         let metricsRecordsSection = decodedSection(rawSnapshot.result(for: .nodeMetrics), decode: decodeNodeMetrics)
+        let podMetricsSection = decodePodMetricsSection(rawSnapshot.result(for: .podMetrics))
         let nodeDetailsSection = makeNodeDetailsSection(
             nodeRecordsSection: nodeRecordsSection,
             metricsRecordsSection: metricsRecordsSection
@@ -31,6 +32,7 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
         let podDetailsSection = makePodDetailsSection(
             podRecordsSection: podRecordsSection,
             workloadSelectorsSection: workloadSelectorsSection,
+            podMetricsSection: podMetricsSection,
             watchTargets: watchTargets
         )
         let hasCompletedWatchedPods = containsCompletedWatchedPods(
@@ -186,6 +188,22 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
         }
     }
 
+    private func decodePodMetrics(_ json: String) throws -> [PodMetricsRecord] {
+        do {
+            return try JSONDecoder().decode(PodMetricsList.self, from: Data(json.utf8)).items
+        } catch {
+            throw KubectlCommandError.failed("invalid pod metrics JSON")
+        }
+    }
+
+    private func decodePodMetricsSection(_ result: Result<String, KubectlCommandError>?) -> SnapshotSection<[PodMetricsRecord]> {
+        guard let result else {
+            return .available([])
+        }
+
+        return decodedSection(result, decode: decodePodMetrics)
+    }
+
     private func makeMetricsSection(
         nodeRecordsSection: SnapshotSection<[NodeRecord]>,
         metricsRecordsSection: SnapshotSection<[NodeMetricsRecord]>
@@ -263,6 +281,7 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
     private func makePodDetailsSection(
         podRecordsSection: SnapshotSection<[PodRecord]>,
         workloadSelectorsSection: SnapshotSection<[WorkloadIdentity: [String: String]]>,
+        podMetricsSection: SnapshotSection<[PodMetricsRecord]>,
         watchTargets: [WatchTarget]
     ) -> SnapshotSection<[PodDetail]> {
         guard let pods = podRecordsSection.value else {
@@ -273,6 +292,14 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
             return .unavailable(reason: workloadSelectorsSection.unavailableReason ?? "invalid workload JSON")
         }
 
+        guard !watchTargets.isEmpty else {
+            return .available([])
+        }
+
+        let resourceSummaryByPod = resourceSummaryByPod(
+            podRecords: pods,
+            podMetricsSection: podMetricsSection
+        )
         var seenPodIDs: Set<String> = []
         var details: [PodDetail] = []
 
@@ -283,11 +310,73 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
                     continue
                 }
 
-                details.append(pod.makeDetail())
+                let resourceSummary = resourceSummaryByPod[id] ?? PodResourceSummary(
+                    resourceAvailabilityMessage: podMetricsSection.unavailableReason
+                )
+                details.append(pod.makeDetail(resourceSummary: resourceSummary))
             }
         }
 
         return .available(details)
+    }
+
+    private func resourceSummaryByPod(
+        podRecords: [PodRecord],
+        podMetricsSection: SnapshotSection<[PodMetricsRecord]>
+    ) -> [String: PodResourceSummary] {
+        guard let podMetrics = podMetricsSection.value else {
+            return Dictionary(
+                uniqueKeysWithValues: podRecords.map { pod in
+                    (
+                        "\(pod.metadata.namespace)/\(pod.metadata.name)",
+                        PodResourceSummary(
+                            cpuRequestNanocores: pod.cpuRequestNanocores,
+                            cpuLimitNanocores: pod.cpuLimitNanocores,
+                            memoryRequestBytes: pod.memoryRequestBytes,
+                            memoryLimitBytes: pod.memoryLimitBytes,
+                            resourceAvailabilityMessage: podMetricsSection.unavailableReason
+                        )
+                    )
+                }
+            )
+        }
+
+        let metricsByPodID = Dictionary(
+            podMetrics.map { metric in
+                (PodRecord.ID(namespace: metric.metadata.namespace, name: metric.metadata.name), metric)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        return Dictionary(uniqueKeysWithValues: podRecords.map { pod in
+            let key = PodRecord.ID(namespace: pod.metadata.namespace, name: pod.metadata.name)
+            let metric = metricsByPodID[key]
+
+            return (
+                "\(pod.metadata.namespace)/\(pod.metadata.name)",
+                PodResourceSummary(
+                    cpuUsageNanocores: sumPodMetricResource(metric, resource: "cpu", scale: .cpuNanocores),
+                    cpuRequestNanocores: pod.cpuRequestNanocores,
+                    cpuLimitNanocores: pod.cpuLimitNanocores,
+                    memoryUsageBytes: sumPodMetricResource(metric, resource: "memory", scale: .memoryBytes),
+                    memoryRequestBytes: pod.memoryRequestBytes,
+                    memoryLimitBytes: pod.memoryLimitBytes
+                )
+            )
+        })
+    }
+
+    private func sumPodMetricResource(
+        _ metric: PodMetricsRecord?,
+        resource: String,
+        scale: ResourceQuantityScale
+    ) -> Int64? {
+        guard let metric else {
+            return nil
+        }
+
+        let values = metric.containers.compactMap { $0.usage[resource] }
+        return sumQuantities(values, scale: scale)
     }
 
     private func containsCompletedWatchedPods(
@@ -335,11 +424,13 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
 
     private func sumQuantities(_ values: [String?], scale: ResourceQuantityScale) -> Int64? {
         var total: Int64 = 0
+        var hadValue = false
 
         for value in values {
             guard let value, let parsed = parseResourceQuantity(value, scale: scale) else {
                 return nil
             }
+            hadValue = true
 
             let nextTotal = total.addingReportingOverflow(parsed)
             if nextTotal.overflow {
@@ -347,6 +438,10 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
             }
 
             total = nextTotal.partialValue
+        }
+
+        guard hadValue else {
+            return nil
         }
 
         return total
@@ -708,6 +803,7 @@ private enum KubectlRead: Hashable, Sendable {
     case nodes
     case pods
     case nodeMetrics
+    case podMetrics
     case warningEvents
     case workload(WorkloadKind)
 
@@ -719,6 +815,8 @@ private enum KubectlRead: Hashable, Sendable {
             return ["get", "pods", "--all-namespaces", "-o", "json"]
         case .nodeMetrics:
             return ["get", "--raw", "/apis/metrics.k8s.io/v1beta1/nodes"]
+        case .podMetrics:
+            return ["get", "--raw", "/apis/metrics.k8s.io/v1beta1/pods"]
         case .warningEvents:
             return ["get", "events", "--all-namespaces", "--field-selector", "type=Warning", "-o", "json"]
         case let .workload(kind):
@@ -728,6 +826,10 @@ private enum KubectlRead: Hashable, Sendable {
 
     static func reads(for watchTargets: [WatchTarget]) -> [KubectlRead] {
         var reads: [KubectlRead] = [.nodes, .pods, .nodeMetrics, .warningEvents]
+        if !watchTargets.isEmpty {
+            reads.append(.podMetrics)
+        }
+
         let targetKinds = Set(watchTargets.compactMap { target -> WorkloadKind? in
             guard case let .workload(_, _, kind) = target, kind.supportsSelectorMetadata else {
                 return nil
@@ -841,6 +943,24 @@ private struct NodeMetricsRecord: Decodable, Equatable, Sendable {
     let usage: [String: String]
 }
 
+private struct PodMetricsList: Decodable {
+    let items: [PodMetricsRecord]
+}
+
+private struct PodMetricsRecord: Decodable, Equatable, Sendable {
+    struct Metadata: Decodable, Equatable, Sendable {
+        let namespace: String
+        let name: String
+    }
+
+    struct Container: Decodable, Equatable, Sendable {
+        let usage: [String: String]
+    }
+
+    let metadata: Metadata
+    let containers: [Container]
+}
+
 private func normalizedNodeText(_ value: String?) -> String? {
     let text = value?.trimmingCharacters(in: .whitespacesAndNewlines)
     guard let text, !text.isEmpty else {
@@ -936,6 +1056,24 @@ private struct PodRecord: Decodable, Equatable, Sendable {
         let ownerReferences: [OwnerReference]?
     }
 
+    struct ID: Hashable, Sendable {
+        let namespace: String
+        let name: String
+    }
+
+    struct Spec: Decodable, Equatable, Sendable {
+        let containers: [ContainerSpec]?
+    }
+
+    struct ContainerSpec: Decodable, Equatable, Sendable {
+        let resources: ContainerResources?
+    }
+
+    struct ContainerResources: Decodable, Equatable, Sendable {
+        let requests: [String: String]?
+        let limits: [String: String]?
+    }
+
     struct Status: Decodable, Equatable, Sendable {
         let phase: String?
         let reason: String?
@@ -946,6 +1084,7 @@ private struct PodRecord: Decodable, Equatable, Sendable {
 
     let metadata: Metadata
     let status: Status
+    let spec: Spec?
 
     var isRunning: Bool {
         status.phase == "Running"
@@ -1059,7 +1198,7 @@ private struct PodRecord: Decodable, Equatable, Sendable {
         }
     }
 
-    func makeDetail() -> PodDetail {
+    func makeDetail(resourceSummary: PodResourceSummary) -> PodDetail {
         let waitingState = currentWaitingState
         let terminatedState = currentTerminatedState
         let condition = notReadyCondition
@@ -1082,8 +1221,97 @@ private struct PodRecord: Decodable, Equatable, Sendable {
             isFailed: isFailed,
             isPending: isPending,
             isUnknown: isUnknown,
-            isNotReady: isNotReady
+            isNotReady: isNotReady,
+            resourceSummary: resourceSummary
         )
+    }
+
+    var cpuRequestNanocores: Int64? {
+        sumPodResources(for: "cpu", from: spec?.containers, selector: \.requests, scale: .cpuNanocores)
+    }
+
+    var cpuLimitNanocores: Int64? {
+        sumPodResources(for: "cpu", from: spec?.containers, selector: \.limits, scale: .cpuNanocores)
+    }
+
+    var memoryRequestBytes: Int64? {
+        sumPodResources(for: "memory", from: spec?.containers, selector: \.requests, scale: .memoryBytes)
+    }
+
+    var memoryLimitBytes: Int64? {
+        sumPodResources(for: "memory", from: spec?.containers, selector: \.limits, scale: .memoryBytes)
+    }
+
+    private func sumPodResources(
+        for resource: String,
+        from containers: [ContainerSpec]?,
+        selector: KeyPath<ContainerResources, [String: String]?>,
+        scale: ResourceQuantityScale
+    ) -> Int64? {
+        guard let containers, !containers.isEmpty else {
+            return nil
+        }
+
+        var total: Int64 = 0
+
+        for container in containers {
+            guard
+                let resourceValue = container.resources?[keyPath: selector]?[resource],
+                let parsed = parsePodResourceQuantity(resourceValue, scale: scale)
+            else {
+                return nil
+            }
+
+            let nextTotal = total.addingReportingOverflow(parsed)
+            if nextTotal.overflow {
+                return nil
+            }
+
+            total = nextTotal.partialValue
+        }
+
+        return total
+    }
+
+    private func parsePodResourceQuantity(_ value: String, scale: ResourceQuantityScale) -> Int64? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        if let number = Double(trimmed), number >= 0, number.isFinite {
+            return scaledPodResourceQuantity(number: number, multiplier: scale.multiplier(for: ""))
+        }
+
+        let splitIndex = trimmed.firstIndex {
+            !($0.isNumber || $0 == "." || $0 == "+" || $0 == "-")
+        } ?? trimmed.endIndex
+        let numberText = String(trimmed[..<splitIndex])
+        let suffix = String(trimmed[splitIndex...])
+
+        guard
+            let number = Double(numberText),
+            number >= 0,
+            number.isFinite,
+            let multiplier = scale.multiplier(for: suffix)
+        else {
+            return nil
+        }
+
+        return scaledPodResourceQuantity(number: number, multiplier: multiplier)
+    }
+
+    private func scaledPodResourceQuantity(number: Double, multiplier: Double?) -> Int64? {
+        guard let multiplier else {
+            return nil
+        }
+
+        let scaled = number * multiplier
+        guard scaled.isFinite, scaled <= Double(Int64.max) else {
+            return nil
+        }
+
+        return Int64(scaled.rounded(.toNearestOrAwayFromZero))
     }
 
     func matches(target: WatchTarget, workloadSelectors: [WorkloadIdentity: [String: String]]) -> Bool {

--- a/KubebarCore/Services/KubectlClusterReader.swift
+++ b/KubebarCore/Services/KubectlClusterReader.swift
@@ -447,47 +447,6 @@ public struct KubectlClusterReader: ClusterReading, Sendable {
         return total
     }
 
-    private func parseResourceQuantity(_ value: String, scale: ResourceQuantityScale) -> Int64? {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            return nil
-        }
-
-        if let number = Double(trimmed), number >= 0, number.isFinite {
-            return scaledQuantity(number: number, multiplier: scale.multiplier(for: ""))
-        }
-
-        let splitIndex = trimmed.firstIndex { character in
-            !(character.isNumber || character == "." || character == "+" || character == "-")
-        } ?? trimmed.endIndex
-        let numberText = String(trimmed[..<splitIndex])
-        let suffix = String(trimmed[splitIndex...])
-
-        guard
-            let number = Double(numberText),
-            number >= 0,
-            number.isFinite,
-            let multiplier = scale.multiplier(for: suffix)
-        else {
-            return nil
-        }
-
-        return scaledQuantity(number: number, multiplier: multiplier)
-    }
-
-    private func scaledQuantity(number: Double, multiplier: Double?) -> Int64? {
-        guard let multiplier else {
-            return nil
-        }
-
-        let scaled = number * multiplier
-        guard scaled.isFinite, scaled <= Double(Int64.max) else {
-            return nil
-        }
-
-        return Int64(scaled.rounded(.toNearestOrAwayFromZero))
-    }
-
     private func decodeWarningEvents(_ json: String) throws -> [WarningEventRecord] {
         do {
             return try JSONDecoder()
@@ -1044,6 +1003,47 @@ private enum ResourceQuantityScale {
     }
 }
 
+private func parseResourceQuantity(_ value: String, scale: ResourceQuantityScale) -> Int64? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+        return nil
+    }
+
+    if let number = Double(trimmed), number >= 0, number.isFinite {
+        return scaledResourceQuantity(number: number, multiplier: scale.multiplier(for: ""))
+    }
+
+    let splitIndex = trimmed.firstIndex { character in
+        !(character.isNumber || character == "." || character == "+" || character == "-")
+    } ?? trimmed.endIndex
+    let numberText = String(trimmed[..<splitIndex])
+    let suffix = String(trimmed[splitIndex...])
+
+    guard
+        let number = Double(numberText),
+        number >= 0,
+        number.isFinite,
+        let multiplier = scale.multiplier(for: suffix)
+    else {
+        return nil
+    }
+
+    return scaledResourceQuantity(number: number, multiplier: multiplier)
+}
+
+private func scaledResourceQuantity(number: Double, multiplier: Double?) -> Int64? {
+    guard let multiplier else {
+        return nil
+    }
+
+    let scaled = number * multiplier
+    guard scaled.isFinite, scaled <= Double(Int64.max) else {
+        return nil
+    }
+
+    return Int64(scaled.rounded(.toNearestOrAwayFromZero))
+}
+
 private struct PodList: Decodable {
     let items: [PodRecord]
 }
@@ -1257,7 +1257,7 @@ private struct PodRecord: Decodable, Equatable, Sendable {
         for container in containers {
             guard
                 let resourceValue = container.resources?[keyPath: selector]?[resource],
-                let parsed = parsePodResourceQuantity(resourceValue, scale: scale)
+                let parsed = parseResourceQuantity(resourceValue, scale: scale)
             else {
                 return nil
             }
@@ -1271,47 +1271,6 @@ private struct PodRecord: Decodable, Equatable, Sendable {
         }
 
         return total
-    }
-
-    private func parsePodResourceQuantity(_ value: String, scale: ResourceQuantityScale) -> Int64? {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            return nil
-        }
-
-        if let number = Double(trimmed), number >= 0, number.isFinite {
-            return scaledPodResourceQuantity(number: number, multiplier: scale.multiplier(for: ""))
-        }
-
-        let splitIndex = trimmed.firstIndex {
-            !($0.isNumber || $0 == "." || $0 == "+" || $0 == "-")
-        } ?? trimmed.endIndex
-        let numberText = String(trimmed[..<splitIndex])
-        let suffix = String(trimmed[splitIndex...])
-
-        guard
-            let number = Double(numberText),
-            number >= 0,
-            number.isFinite,
-            let multiplier = scale.multiplier(for: suffix)
-        else {
-            return nil
-        }
-
-        return scaledPodResourceQuantity(number: number, multiplier: multiplier)
-    }
-
-    private func scaledPodResourceQuantity(number: Double, multiplier: Double?) -> Int64? {
-        guard let multiplier else {
-            return nil
-        }
-
-        let scaled = number * multiplier
-        guard scaled.isFinite, scaled <= Double(Int64.max) else {
-            return nil
-        }
-
-        return Int64(scaled.rounded(.toNearestOrAwayFromZero))
     }
 
     func matches(target: WatchTarget, workloadSelectors: [WorkloadIdentity: [String: String]]) -> Bool {

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -548,7 +548,7 @@ struct MenuDisplayModelTests {
         let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
         let row = try #require(display.podTab.sections.first?.rows.first)
 
-        #expect(row.resourceLabel == "CPU 0.5/1/2 · Mem 1/2/4GiB")
+        #expect(row.resourceLabel == "CPU 50% req · Mem 25% limit")
     }
 
     @Test("pod rows show resource summary when usage is missing")
@@ -583,9 +583,57 @@ struct MenuDisplayModelTests {
         let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
         let row = try #require(display.podTab.sections.first?.rows.first)
 
-        #expect(row.resourceLabel == "CPU -/1/2 · Mem -/2/-GiB")
+        #expect(row.resourceLabel == "CPU - · Mem -")
         #expect(row.helpText.contains("CPU -/1/2 · Mem -/2/-GiB"))
         #expect(row.accessibilityLabel == row.helpText)
+    }
+
+    @Test("pod rows use fallback basis and raw resource labels")
+    func podRowsUseFallbackBasisAndRawResourceLabels() throws {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 2, total: 2)),
+            podDetailsSection: .available([
+                podDetail(
+                    namespace: "api",
+                    name: "fallback-basis",
+                    readyContainerCount: 1,
+                    totalContainerCount: 1,
+                    resourceSummary: PodResourceSummary(
+                        cpuUsageNanocores: 250_000_000,
+                        cpuRequestNanocores: nil,
+                        cpuLimitNanocores: 1_000_000_000,
+                        memoryUsageBytes: 268_435_456,
+                        memoryRequestBytes: 536_870_912,
+                        memoryLimitBytes: nil
+                    )
+                ),
+                podDetail(
+                    namespace: "api",
+                    name: "raw-only",
+                    readyContainerCount: 1,
+                    totalContainerCount: 1,
+                    resourceSummary: PodResourceSummary(
+                        cpuUsageNanocores: 120_000_000,
+                        memoryUsageBytes: 268_435_456
+                    )
+                )
+            ]),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([
+                TrackedItemStatus(target: .namespace("api"), state: .ok, reason: "2/2 pods running")
+            ]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+        let rows = try #require(display.podTab.sections.first?.rows)
+        let fallback = try #require(rows.first { $0.name == "fallback-basis" })
+        let rawOnly = try #require(rows.first { $0.name == "raw-only" })
+
+        #expect(fallback.resourceLabel == "CPU 25% limit · Mem 50% req")
+        #expect(rawOnly.resourceLabel == "CPU 120m · Mem 256Mi")
     }
 
     @Test("pod row help keeps resource markers when all values are unavailable")
@@ -612,7 +660,7 @@ struct MenuDisplayModelTests {
         let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
         let row = try #require(display.podTab.sections.first?.rows.first)
 
-        #expect(row.resourceLabel == "-")
+        #expect(row.resourceLabel == "CPU - · Mem -")
         #expect(row.helpText == "api/checkout-7f9d, Ready, 1/1 containers ready, CPU -/-/- · Mem -/-/-GiB")
         #expect(row.accessibilityLabel == row.helpText)
     }
@@ -653,7 +701,7 @@ struct MenuDisplayModelTests {
 
         #expect(row.state == .bad)
         #expect(row.issueText == "CrashLoopBackOff: back-off restarting container")
-        #expect(row.resourceLabel == "CPU 0.3/0.5/1 · Mem 0.3/0.5/1GiB")
+        #expect(row.resourceLabel == "CPU 50% req · Mem 25% limit")
     }
 
     @Test("pod tab does not mark historical restarts as bad")

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -345,7 +345,7 @@ struct MenuDisplayModelTests {
         let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
 
         #expect(display.primaryStatusReason == "1 pod not ready")
-        #expect(display.overview.statusHelpText == "api/checkout, Watch, 0/1 containers ready, ContainersNotReady: containers with unready status")
+        #expect(display.overview.statusHelpText == "api/checkout, Watch, 0/1 containers ready, CPU -/-/- · Mem -/-/-GiB, ContainersNotReady: containers with unready status")
         #expect(display.overview.statusAccessibilityLabel.contains("ContainersNotReady: containers with unready status"))
     }
 
@@ -514,6 +514,146 @@ struct MenuDisplayModelTests {
         #expect(apiRows[1].readyLabel == "-")
         #expect(apiRows[1].issueText == "Pending")
         #expect(apiRows[2].issueText == nil)
+    }
+
+    @Test("pod rows include resource summary labels")
+    func podRowsIncludeResourceSummaryLabels() throws {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 2, total: 2)),
+            podDetailsSection: .available([
+                podDetail(
+                    namespace: "api",
+                    name: "checkout-7f9d",
+                    readyContainerCount: 1,
+                    totalContainerCount: 1,
+                    resourceSummary: PodResourceSummary(
+                        cpuUsageNanocores: 500_000_000,
+                        cpuRequestNanocores: 1_000_000_000,
+                        cpuLimitNanocores: 2_000_000_000,
+                        memoryUsageBytes: 1_073_741_824,
+                        memoryRequestBytes: 2_147_483_648,
+                        memoryLimitBytes: 4_294_967_296
+                    )
+                )
+            ]),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([
+                TrackedItemStatus(target: .namespace("api"), state: .ok, reason: "1/1 pods running")
+            ]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+        let row = try #require(display.podTab.sections.first?.rows.first)
+
+        #expect(row.resourceLabel == "CPU 0.5/1/2 · Mem 1/2/4GiB")
+    }
+
+    @Test("pod rows show resource summary when usage is missing")
+    func podRowsShowResourceSummaryWhenUsageIsMissing() throws {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 1, total: 1)),
+            podDetailsSection: .available([
+                podDetail(
+                    namespace: "api",
+                    name: "checkout-7f9d",
+                    readyContainerCount: 1,
+                    totalContainerCount: 1,
+                    resourceSummary: PodResourceSummary(
+                        cpuUsageNanocores: nil,
+                        cpuRequestNanocores: 1_000_000_000,
+                        cpuLimitNanocores: 2_000_000_000,
+                        memoryUsageBytes: nil,
+                        memoryRequestBytes: 2_147_483_648,
+                        memoryLimitBytes: nil
+                    )
+                )
+            ]),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([
+                TrackedItemStatus(target: .namespace("api"), state: .ok, reason: "1/1 pods running")
+            ]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+        let row = try #require(display.podTab.sections.first?.rows.first)
+
+        #expect(row.resourceLabel == "CPU -/1/2 · Mem -/2/-GiB")
+        #expect(row.helpText.contains("CPU -/1/2 · Mem -/2/-GiB"))
+        #expect(row.accessibilityLabel == row.helpText)
+    }
+
+    @Test("pod row help keeps resource markers when all values are unavailable")
+    func podRowHelpKeepsResourceMarkersWhenAllValuesAreUnavailable() throws {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 1, total: 1)),
+            podDetailsSection: .available([
+                podDetail(
+                    namespace: "api",
+                    name: "checkout-7f9d",
+                    readyContainerCount: 1,
+                    totalContainerCount: 1
+                )
+            ]),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([
+                TrackedItemStatus(target: .namespace("api"), state: .ok, reason: "1/1 pods running")
+            ]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+        let row = try #require(display.podTab.sections.first?.rows.first)
+
+        #expect(row.resourceLabel == "-")
+        #expect(row.helpText == "api/checkout-7f9d, Ready, 1/1 containers ready, CPU -/-/- · Mem -/-/-GiB")
+        #expect(row.accessibilityLabel == row.helpText)
+    }
+
+    @Test("pod rows can show issue and resource summary together")
+    func podRowsCanShowIssueAndResourceSummaryTogether() throws {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 1, total: 1)),
+            podDetailsSection: .available([
+                podDetail(
+                    namespace: "api",
+                    name: "checkout-7f9d",
+                    readyContainerCount: 1,
+                    totalContainerCount: 1,
+                    waitingReason: "CrashLoopBackOff",
+                    waitingMessage: "back-off restarting container",
+                    resourceSummary: PodResourceSummary(
+                        cpuUsageNanocores: 250_000_000,
+                        cpuRequestNanocores: 500_000_000,
+                        cpuLimitNanocores: 1_000_000_000,
+                        memoryUsageBytes: 268_435_456,
+                        memoryRequestBytes: 536_870_912,
+                        memoryLimitBytes: 1_073_741_824
+                    )
+                )
+            ]),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([
+                TrackedItemStatus(target: .namespace("api"), state: .bad, reason: "1 pod restarting")
+            ]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+        let row = try #require(display.podTab.sections.first?.rows.first)
+
+        #expect(row.state == .bad)
+        #expect(row.issueText == "CrashLoopBackOff: back-off restarting container")
+        #expect(row.resourceLabel == "CPU 0.3/0.5/1 · Mem 0.3/0.5/1GiB")
     }
 
     @Test("pod tab does not mark historical restarts as bad")
@@ -1350,7 +1490,8 @@ private func podDetail(
     isFailed: Bool = false,
     isPending: Bool = false,
     isUnknown: Bool = false,
-    isNotReady: Bool = false
+    isNotReady: Bool = false,
+    resourceSummary: PodResourceSummary = PodResourceSummary()
 ) -> PodDetail {
     PodDetail(
         namespace: namespace,
@@ -1370,6 +1511,7 @@ private func podDetail(
         isFailed: isFailed,
         isPending: isPending,
         isUnknown: isUnknown,
-        isNotReady: isNotReady
+        isNotReady: isNotReady,
+        resourceSummary: resourceSummary
     )
 }

--- a/KubebarTests/Services/KubectlClusterReaderTests.swift
+++ b/KubebarTests/Services/KubectlClusterReaderTests.swift
@@ -10,6 +10,7 @@ struct KubectlClusterReaderTests {
             nodesCommand: CommandResult(output: nodesJSON, error: "", exitCode: 0),
             podsCommand: CommandResult(output: podsJSON, error: "", exitCode: 0),
             nodeMetricsCommand: CommandResult(output: nodeMetricsJSON, error: "", exitCode: 0),
+            podMetricsCommand: CommandResult(output: podMetricsWithResourceDataJSON, error: "", exitCode: 0),
             warningEventsCommand: CommandResult(output: warningEventsJSON, error: "", exitCode: 0),
             deploymentsCommand: CommandResult(output: deploymentMetadataJSON, error: "", exitCode: 0)
         ])
@@ -33,6 +34,133 @@ struct KubectlClusterReaderTests {
         #expect(snapshot.trackedItems.first?.reason == "1 pod not ready")
         #expect(snapshot.trackedItems.first?.affectedPodCount == 1)
         #expect(snapshot.trackedItems.first?.examplePodNames == ["checkout-8a1b"])
+    }
+
+    @Test("decodes pod resource requests, limits and usage")
+    func decodesPodResourceRequestsLimitsAndUsage() throws {
+        let snapshot = try readSnapshot(
+            pods: podsWithResourceSpecsJSON,
+            warningEvents: emptyListJSON,
+            podMetrics: podResourceMetricsJSON,
+            workloadMetadata: deploymentMetadataJSON,
+            watchTargets: [.namespace("api")]
+        )
+        let details = try #require(snapshot.podDetailsSection.value)
+        let detail = try #require(details.first(where: { $0.name == "checkout-7f9d" }))
+
+        #expect(detail.resourceSummary.cpuRequestNanocores == 250_000_000)
+        #expect(detail.resourceSummary.cpuLimitNanocores == 500_000_000)
+        #expect(detail.resourceSummary.memoryRequestBytes == 268_435_456)
+        #expect(detail.resourceSummary.memoryLimitBytes == 536_870_912)
+        #expect(detail.resourceSummary.cpuUsageNanocores == 100_000_000)
+        #expect(detail.resourceSummary.memoryUsageBytes == 134_217_728)
+    }
+
+    @Test("keeps request and limit when pod usage is unavailable")
+    func keepsRequestLimitWhenUsageUnavailable() throws {
+        let snapshot = try readSnapshot(
+            pods: podsWithResourceSpecsJSON,
+            warningEvents: emptyListJSON,
+            podMetrics: podResourceNoUsageJSON,
+            workloadMetadata: deploymentMetadataJSON,
+            watchTargets: [.namespace("api")]
+        )
+        let details = try #require(snapshot.podDetailsSection.value)
+        let detail = try #require(details.first(where: { $0.name == "checkout-7f9d" }))
+
+        #expect(detail.resourceSummary.cpuRequestNanocores == 250_000_000)
+        #expect(detail.resourceSummary.cpuLimitNanocores == 500_000_000)
+        #expect(detail.resourceSummary.memoryRequestBytes == 268_435_456)
+        #expect(detail.resourceSummary.memoryLimitBytes == 536_870_912)
+        #expect(detail.resourceSummary.cpuUsageNanocores == nil)
+        #expect(detail.resourceSummary.memoryUsageBytes == nil)
+    }
+
+    @Test("pod metrics failure preserves pod rows and resource spec")
+    func podMetricsFailurePreservesPodRowsAndResourceSpec() throws {
+        let runner = FakeMultiCommandRunner(results: [
+            nodesCommand: CommandResult(output: nodesJSON, error: "", exitCode: 0),
+            podsCommand: CommandResult(output: podsWithResourceSpecsJSON, error: "", exitCode: 0),
+            nodeMetricsCommand: CommandResult(output: nodeMetricsJSON, error: "", exitCode: 0),
+            podMetricsCommand: CommandResult(output: "", error: "metrics API unavailable", exitCode: 1),
+            warningEventsCommand: CommandResult(output: emptyListJSON, error: "", exitCode: 0)
+        ])
+        let reader = KubectlClusterReader(runner: runner)
+
+        let snapshot = try reader.readSnapshot(
+            contextName: "prod",
+            watchTargets: [.namespace("api")],
+            now: Date(timeIntervalSince1970: 100)
+        )
+        let details = try #require(snapshot.podDetailsSection.value)
+        let detail = try #require(details.first(where: { $0.name == "checkout-7f9d" }))
+
+        #expect(detail.resourceSummary.cpuRequestNanocores == 250_000_000)
+        #expect(detail.resourceSummary.cpuLimitNanocores == 500_000_000)
+        #expect(detail.resourceSummary.memoryRequestBytes == 268_435_456)
+        #expect(detail.resourceSummary.memoryLimitBytes == 536_870_912)
+        #expect(detail.resourceSummary.cpuUsageNanocores == nil)
+        #expect(detail.resourceSummary.memoryUsageBytes == nil)
+        #expect(detail.resourceSummary.resourceAvailabilityMessage == "metrics API unavailable")
+        #expect(snapshot.sectionFailures == [])
+        #expect(snapshot.trackedItems.first?.state == .watch)
+        #expect(snapshot.trackedItems.first?.reason == "1 pod not ready")
+    }
+
+    @Test("does not fail pod snapshot on malformed pod resource values")
+    func doesNotFailSnapshotOnMalformedPodResourceValues() throws {
+        let snapshot = try readSnapshot(
+            pods: podsWithMalformedResourcesJSON,
+            warningEvents: emptyListJSON,
+            podMetrics: malformedPodMetricsJSON,
+            workloadMetadata: deploymentMetadataJSON,
+            watchTargets: [.namespace("api")]
+        )
+        let details = try #require(snapshot.podDetailsSection.value)
+        let detail = try #require(details.first(where: { $0.name == "badpod" }))
+
+        #expect(detail.resourceSummary.cpuRequestNanocores == nil)
+        #expect(detail.resourceSummary.cpuLimitNanocores == nil)
+        #expect(detail.resourceSummary.memoryRequestBytes == nil)
+        #expect(detail.resourceSummary.memoryLimitBytes == nil)
+        #expect(detail.resourceSummary.cpuUsageNanocores == nil)
+        #expect(detail.resourceSummary.memoryUsageBytes == nil)
+    }
+
+    @Test("missing pod resource declarations stay unavailable")
+    func missingPodResourceDeclarationsStayUnavailable() throws {
+        let snapshot = try readSnapshot(
+            pods: podsWithoutResourceDeclarationsJSON,
+            warningEvents: emptyListJSON,
+            podMetrics: emptyPodMetricsJSON,
+            workloadMetadata: deploymentMetadataJSON,
+            watchTargets: [.namespace("api")]
+        )
+        let details = try #require(snapshot.podDetailsSection.value)
+        let detail = try #require(details.first(where: { $0.name == "checkout-no-resources" }))
+
+        #expect(detail.resourceSummary.cpuRequestNanocores == nil)
+        #expect(detail.resourceSummary.cpuLimitNanocores == nil)
+        #expect(detail.resourceSummary.memoryRequestBytes == nil)
+        #expect(detail.resourceSummary.memoryLimitBytes == nil)
+        #expect(detail.resourceSummary.cpuUsageNanocores == nil)
+        #expect(detail.resourceSummary.memoryUsageBytes == nil)
+    }
+
+    @Test("duplicate pod metrics entries do not fail snapshot")
+    func duplicatePodMetricsEntriesDoNotFailSnapshot() throws {
+        let snapshot = try readSnapshot(
+            pods: podsWithResourceSpecsJSON,
+            warningEvents: emptyListJSON,
+            podMetrics: duplicatePodResourceMetricsJSON,
+            workloadMetadata: deploymentMetadataJSON,
+            watchTargets: [.namespace("api")]
+        )
+        let details = try #require(snapshot.podDetailsSection.value)
+        let detail = try #require(details.first(where: { $0.name == "checkout-7f9d" }))
+
+        #expect(detail.resourceSummary.cpuUsageNanocores == 100_000_000)
+        #expect(detail.resourceSummary.memoryUsageBytes == 134_217_728)
     }
 
     @Test("builds per-node detail rows from node and metrics JSON")
@@ -707,12 +835,14 @@ private final class SlowRecordingCommandRunner: CommandRunning, @unchecked Senda
 private func readSnapshot(
     pods: String,
     warningEvents: String,
+    podMetrics: String = emptyPodMetricsJSON,
     workloadMetadata: String = deploymentMetadataJSON,
     watchTargets: [WatchTarget]
 ) throws -> ClusterSnapshot {
     let runner = FakeMultiCommandRunner(results: [
         nodesCommand: CommandResult(output: nodesJSON, error: "", exitCode: 0),
         podsCommand: CommandResult(output: pods, error: "", exitCode: 0),
+        podMetricsCommand: CommandResult(output: podMetrics, error: "", exitCode: 0),
         warningEventsCommand: CommandResult(output: warningEvents, error: "", exitCode: 0),
         deploymentsCommand: CommandResult(output: workloadMetadata, error: "", exitCode: 0)
     ])
@@ -727,6 +857,7 @@ private func readSnapshot(
 private let nodesCommand = ["--context", "prod", "get", "nodes", "-o", "json"]
 private let podsCommand = ["--context", "prod", "get", "pods", "--all-namespaces", "-o", "json"]
 private let nodeMetricsCommand = ["--context", "prod", "get", "--raw", "/apis/metrics.k8s.io/v1beta1/nodes"]
+private let podMetricsCommand = ["--context", "prod", "get", "--raw", "/apis/metrics.k8s.io/v1beta1/pods"]
 private let warningEventsCommand = ["--context", "prod", "get", "events", "--all-namespaces", "--field-selector", "type=Warning", "-o", "json"]
 private let deploymentsCommand = ["--context", "prod", "get", "deployments", "--all-namespaces", "-o", "json"]
 
@@ -848,12 +979,156 @@ private let pressureNodeMetricsJSON = """
 }
 """
 
+private let emptyPodMetricsJSON = """
+{
+  "items": []
+}
+"""
+
 private let podsJSON = """
 {
   "items": [
     {"metadata": {"namespace": "api", "name": "checkout-7f9d", "labels": {"app.kubernetes.io/name": "checkout"}}, "status": {"phase": "Running"}},
     {"metadata": {"namespace": "api", "name": "checkout-8a1b", "labels": {"app.kubernetes.io/name": "checkout"}}, "status": {"phase": "Pending"}},
     {"metadata": {"namespace": "api", "name": "checkout-worker-1", "labels": {"app.kubernetes.io/name": "checkout-worker"}}, "status": {"phase": "Pending"}}
+  ]
+}
+"""
+
+private let podsWithResourceSpecsJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "api", "name": "checkout-7f9d", "labels": {"app.kubernetes.io/name": "checkout"}},
+      "spec": {
+        "containers": [
+          {
+            "resources": {
+              "requests": {"cpu": "250m", "memory": "256Mi"},
+              "limits": {"cpu": "500m", "memory": "512Mi"}
+            }
+          }
+        ]
+      },
+      "status": {"phase": "Running"}
+    },
+    {
+      "metadata": {"namespace": "api", "name": "checkout-8a1b", "labels": {"app.kubernetes.io/name": "checkout"}},
+      "status": {"phase": "Pending"}
+    }
+  ]
+}
+"""
+
+private let podMetricsWithResourceDataJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "api", "name": "checkout-7f9d"},
+      "containers": [
+        {"name": "app", "usage": {"cpu": "100m", "memory": "128Mi"}}
+      ]
+    },
+    {
+      "metadata": {"namespace": "api", "name": "checkout-8a1b"},
+      "containers": []
+    }
+  ]
+}
+"""
+
+private let podResourceMetricsJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "api", "name": "checkout-7f9d"},
+      "containers": [
+        {"name": "app", "usage": {"cpu": "100m", "memory": "128Mi"}}
+      ]
+    }
+  ]
+}
+"""
+
+private let podResourceNoUsageJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "api", "name": "checkout-7f9d"},
+      "containers": [
+        {"name": "app", "usage": {}}
+      ]
+    }
+  ]
+}
+"""
+
+private let malformedPodMetricsJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "api", "name": "badpod"},
+      "containers": [
+        {"name": "app", "usage": {"cpu": "oops", "memory": "??"}}
+      ]
+    }
+  ]
+}
+"""
+
+private let duplicatePodResourceMetricsJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "api", "name": "checkout-7f9d"},
+      "containers": [
+        {"name": "app", "usage": {"cpu": "100m", "memory": "128Mi"}}
+      ]
+    },
+    {
+      "metadata": {"namespace": "api", "name": "checkout-7f9d"},
+      "containers": [
+        {"name": "app", "usage": {"cpu": "200m", "memory": "256Mi"}}
+      ]
+    }
+  ]
+}
+"""
+
+private let podsWithMalformedResourcesJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "api", "name": "badpod", "labels": {"app.kubernetes.io/name": "badpod"}},
+      "spec": {
+        "containers": [
+          {
+            "resources": {
+              "requests": {"cpu": "bad", "memory": "bad-unit"},
+              "limits": {"cpu": "also-bad", "memory": "???"}
+            }
+          }
+        ]
+      },
+      "status": {"phase": "Running"}
+    }
+  ]
+}
+"""
+
+private let podsWithoutResourceDeclarationsJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "api", "name": "checkout-no-resources", "labels": {"app.kubernetes.io/name": "checkout"}},
+      "spec": {
+        "containers": [
+          {"name": "app", "resources": {}},
+          {"name": "sidecar"}
+        ]
+      },
+      "status": {"phase": "Running"}
+    }
   ]
 }
 """

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -52,6 +52,9 @@ These are the rules Kubebar must keep true at runtime.
 - Pods tab rows come from `MenuDisplayModel` Pod display data. They group by
   namespace and show Pod name, status dot, ready/all count, and one short issue
   line when attention is needed.
+- Pod rows also show compact resource labels built from request/limit from Pod spec and
+  optional usage from `metrics.k8s.io/v1beta1/pods`; resource parsing failures do
+  not change pod health state.
 - When watched Pod rows exceed the available menu space, the Pod item list
   scrolls vertically while the Pods tab summary remains visible.
 - Pod row status must not rely on color alone. Help and accessibility text must

--- a/docs/brainstorms/2026-04-24-kubebar-pod-resource-display-requirements.md
+++ b/docs/brainstorms/2026-04-24-kubebar-pod-resource-display-requirements.md
@@ -1,0 +1,222 @@
+---
+date: 2026-04-24
+topic: kubebar-pod-resource-display
+---
+
+# Kubebar Pod Resource Display Requirements
+
+## Problem Frame
+
+Kubebar's Pods tab already helps an operator see which watched Pods are ready
+and which ones need attention. The next useful scan is whether a Pod is under
+resource pressure: current CPU and memory use only become meaningful when they
+can be compared with requests and limits.
+
+Without this, an operator has to open a deeper tool just to answer whether a
+suspicious or unhealthy Pod is also resource-constrained. That slows down a
+quick health check and makes Kubebar less useful at the exact moment when the
+operator is deciding whether to investigate further.
+
+The menu should surface Pod resource information without becoming a full
+performance dashboard. It should help an operator decide whether a Pod is worth
+opening in deeper tools, while preserving Kubebar's compact, watchlist-first
+menu behavior.
+
+This document extends the Pod row behavior described in
+`docs/brainstorms/2026-04-22-kubebar-pod-item-menu-ui-requirements.md`.
+
+## Visual Aid
+
+```text
+Pods
+5/7 ready
+
+api
+o checkout-7f9d                         1/1
+  CPU 82% req · Mem 64% limit
+
+o checkout-8a1b                         0/1
+  CrashLoopBackOff: back-off restarting container
+  CPU - · Mem -
+```
+
+`CPU - · Mem -` means resource usage is unavailable for that row. It is not a
+generic rule for unhealthy Pods; issue rows should still show known resource
+facts when they are available.
+
+Complete help/accessibility text example:
+
+```text
+api/checkout-7f9d, Ready, 1/1 containers ready,
+CPU 120m used / 150m request / 500m limit,
+Memory 256Mi used / 400Mi request / 512Mi limit
+```
+
+## Requirements
+
+**Displayed resource content**
+- R1. Each visible active Pod row should include CPU and memory resource
+  display, using known values or explicit unavailable markers.
+- R2. Resource information must include current usage and the configured
+  request/limit context when available.
+- R3. The row-level display should be a Pod-level summary, not a per-container
+  breakdown.
+- R4. Hover/help and accessibility text must include the complete available
+  resource values for CPU and memory: usage, request, and limit.
+- R5. Missing values in hover/help and accessibility text must use explicit
+  unavailable markers such as `usage -`, `request -`, or `limit -` rather than
+  being silently omitted.
+
+**Row display**
+- R6. The visible row should show compact CPU and memory labels together when
+  a visible active Pod row is shown.
+- R7. The normal compact format is `CPU <value> <basis> · Mem <value> <basis>`,
+  such as `CPU 82% req · Mem 64% limit`.
+- R8. CPU should compare usage to request when request is available, and to
+  limit only when request is unavailable.
+- R9. Memory should compare usage to limit when limit is available, and to
+  request only when limit is unavailable.
+- R10. If usage exists but no comparison basis exists, the compact label should
+  show raw usage, such as `CPU 120m` or `Mem 256Mi`, instead of inventing a
+  percentage.
+- R11. If usage is unavailable, the compact label should show an unavailable
+  value, such as `CPU -` or `Mem -`.
+- R12. Raw usage numbers should remain available through hover/help text rather
+  than competing with the Pod name, readiness count, and issue text.
+- R13. Resource text must not push the Pod name, ready count, or issue reason out
+  of view.
+- R14. If a Pod has an issue line, the issue line remains above resource text
+  and remains more important than resource text.
+- R15. When space is tight, resource text may truncate before the issue line
+  does, while the full resource values remain available through help and
+  accessibility text.
+- R16. Complete resource values must be available through keyboard focus and
+  accessibility, not only through pointer hover.
+
+**Missing and partial data**
+- R17. Missing current usage must show an unavailable value such as `-`; it must
+  not be shown as `0`.
+- R18. Missing requests or limits must be represented as unavailable or absent
+  comparison context; Kubebar must not invent a percentage.
+- R19. Partial resource data should still show the parts that are known, as long
+  as unavailable parts are clearly marked.
+- R20. Metrics API or resource-data failures must not make unavailable resource
+  data look healthy, current, or normal.
+- R21. Resource-only failures must not hide otherwise valid Pod rows.
+- R22. If all current Pod usage is unavailable, visible rows should show
+  unavailable usage labels such as `CPU - · Mem -`, and complete help text
+  should include a safe unavailable reason.
+- R23. If request/limit context is unavailable but current usage is available,
+  visible rows should show raw usage without a percentage.
+- R24. Stale snapshots must continue to be marked as stale; resource numbers
+  from stale data must not look current.
+
+**Health behavior**
+- R25. Pod resource pressure must not change the menu bar state, Overview state,
+  Pod row state, or OK/Watch/Bad categorization in the first version.
+- R26. Resource display should support human judgment, not act as a resource
+  alerting system.
+- R27. Existing Pod readiness, failed state, restarting state, completed Job
+  handling, and unavailable-data behavior remain authoritative for health
+  status.
+- R28. Any future change that lets resource pressure affect Watch or Bad must
+  be handled as a separate product decision with explicit thresholds and
+  false-positive expectations.
+
+**Scope and density**
+- R29. The Pods tab must remain a compact menu bar view, not a resource
+  dashboard.
+- R30. Resource labels should be short enough for repeated scanning across many
+  Pod rows.
+- R31. The existing namespace grouping and attention-first ordering should
+  remain intact.
+- R32. Completed Job Pods should keep the existing default behavior: they are
+  not listed as active Pod rows by default, so they do not need resource display
+  in this version.
+
+## Success Criteria
+
+- A user can scan the Pods tab and see whether visible Pods are under CPU or
+  memory pressure.
+- A user can inspect complete available usage, request, and limit values without
+  leaving the menu.
+- Resource information does not obscure readiness, namespace grouping, or
+  issue reasons.
+- Missing metrics or missing requests/limits are clearly unavailable rather
+  than rendered as zero or normal.
+- Resource pressure does not create new Watch or Bad states in the first
+  version.
+- The menu still feels like a quick health tool rather than a Kubernetes
+  dashboard.
+
+## Scope Boundaries
+
+- This change does not add resource-based alerting.
+- This change does not change menu bar health categories.
+- This change does not change existing Pod readiness or completed Job rules.
+- This change does not add per-container resource rows in the first version.
+- This change does not add charts, history, trends, or sparklines.
+- This change does not add Prometheus, Grafana, or any external monitoring
+  dependency.
+- This change does not add Pod logs, events drilldown, shell commands, or
+  deeper troubleshooting controls.
+
+## Key Decisions
+
+- **Show both usage and request/limit context:** Usage alone is hard to judge,
+  while requests and limits alone do not show current pressure.
+- **Show compact pressure in-row and complete values through help and focus:**
+  The visible list stays scannable, while full values remain available when
+  needed.
+- **Use request for CPU before limit:** CPU request is the better first scan for
+  whether the Pod is using more CPU than it asked the scheduler to reserve.
+- **Use limit for memory before request:** Memory limit is the better first scan
+  for whether the Pod is approaching a hard cap.
+- **Do not let resource pressure affect health state yet:** The first version
+  should avoid noisy status changes until the display proves useful.
+- **Start with Pod-level summaries:** This matches Kubebar's glanceable scope
+  and avoids turning the Pods tab into a container-level debugging view.
+- **Keep unavailable data explicit:** Resource data can be partial or missing,
+  and missing data must never look like a healthy zero.
+
+## Alternatives Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| Show only current usage | Simple and familiar | Hard to know whether usage is high or normal |
+| Show only request/limit pressure | Fast to scan | Hides the underlying values unless complete help text is added |
+| Show pressure in-row and complete values through help/focus | Best balance of scanning and detail | Requires careful copy and layout density |
+| Let high pressure make Pods Watch | Makes pressure more visible | Adds alert-like behavior and threshold noise |
+| Add per-container details immediately | More complete for debugging | Too dense for the first menu version |
+
+Recommended option: show compact resource pressure in each visible active Pod
+row, with full usage/request/limit values available through help, keyboard
+focus, and accessibility text. Keep resource pressure informational in the first
+version.
+
+## Dependencies / Assumptions
+
+- The existing Pods tab remains the primary home for Pod resource information.
+- The existing Nodes tab resource display remains separate and continues to
+  describe node-level CPU and memory.
+- Current Pod usage should come from Kubernetes Pod metrics data, and
+  request/limit context should come from Pod resource configuration.
+- Planning should verify whether existing Kubernetes reads already include the
+  needed request/limit context and add only the narrow local read needed for
+  current Pod usage if it is absent.
+- Planning should preserve the security boundary documented in
+  `docs/PERMISSIONS.md`: Kubebar does not query Secrets and does not send
+  cluster data to external services.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R2, R4][Technical] Confirm how to aggregate multi-container Pod
+  usage, requests, and limits into a Pod-level summary.
+- [Affects R25-R28][Technical] Add regression coverage proving resource data
+  display does not change health state.
+
+## Next Steps
+
+-> `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-04-24-007-feat-pod-resource-display-plan.md
+++ b/docs/plans/2026-04-24-007-feat-pod-resource-display-plan.md
@@ -1,0 +1,272 @@
+---
+title: feat: Pod resource summary in Pods tab
+status: complete
+type: feat
+date: 2026-04-24
+origin: docs/brainstorms/2026-04-24-kubebar-pod-resource-display-requirements.md
+---
+
+# feat: Pod resource summary in Pods tab
+
+## Overview
+
+Add a compact Pod-level CPU and Memory signal to each visible Pod row in the Pods tab using local-safe numeric context and explicit availability markers. The detailed usage/request/limit values must still be accessible through help, focus, and accessibility text, while preserving existing row status and keeping current health category rules unchanged.
+
+## Problem Frame
+
+Operators need a fast signal for whether a visible Pod is under CPU or memory pressure before opening deeper tools. The Pod list already provides status, readiness, and scope; this feature extends row text without turning Kubebar into a dashboard. The existing constraint remains: no deep troubleshooting actions in this version.
+
+## Requirements Trace
+
+- R1-R12, R17-R24, R25-R27, R29-R31
+- R28, R32
+- R30
+- Existing Pod row behavior from `docs/brainstorms/2026-04-22-kubebar-pod-item-menu-ui-requirements.md`
+
+## Scope Boundaries
+
+- No new resource alerting, no status model change (`OK/Watch/Bad/Stale` unchanged).
+- No per-container row expansion in first version.
+- No charts, trends, or external monitoring dependency.
+- No Pod logs/events/drilldown actions in Pods tab.
+- No change to completed Job inclusion rules beyond keeping current behavior.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `KubebarCore/Models/MenuDisplayModel.swift`: row payload for Pods, Pod tab data shapes, and section availability patterns.
+- `KubebarCore/Models/ClusterSnapshot.swift`: `PodDetail`, `PodSummary`, and section wiring.
+- `KubebarCore/Services/KubectlClusterReader.swift`: concurrent `kubectl` reads, pod decoding, and watched-target filtering.
+- `KubebarCore/Services/HealthEvaluator.swift`: row mapping, tab summaries, section notices, and status composition.
+- `Kubebar/Views/PodsTabView.swift`: row-level rendering, help/accessibility hooks, and keyboard focus.
+- `KubebarTests/Models/MenuDisplayModelTests.swift`: current expected row ordering and Pod detail mapping behavior.
+- `KubebarTests/Services/KubectlClusterReaderTests.swift`: pod filtering, workload selector, and missing-data fallback coverage.
+- `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`: fixture-level stability checks for Pods tab copy.
+- `docs/architecture/runtime-invariants.md`: stale/unavailable and status invariants.
+
+### Institutional Learnings
+
+- No `docs/solutions/` entries in this repo for this pattern.
+- Existing resource handling is done in health-only aggregates (nodes/overview); no Pod-level usage/request/limit path exists yet.
+
+### External References
+
+- Not used. Kubernetes API shapes are already handled in-repo for pods/nodes and metrics.
+
+## Key Technical Decisions
+
+- **Keep `HealthEvaluator` as health truth and UI status source** (`status` never driven by resource pressure in this version).
+- **Compute Pod resource summary at source into `PodDetail`-level fields** so rows can render compact and full values consistently.
+- **Add an optional pod metrics read** and map `k8s metrics.k8s.io/pods` only to Pod usage; request/limit remain from Pod spec.
+- **Use per-column fallback logic**: CPU compares usage to request first, then limit, then falls back to raw; Memory compares to limit first, then request, then raw.
+- **Preserve non-regression behavior by making unavailable values explicit `-`**, never implied zeros.
+- **Only unavailable resource contexts are suppressed in compact rows**; issue text and Pod state remain full priority.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Partial data handling:** show available usage/request/limit parts and mark unavailable components clearly.
+- **Aggregation level:** Pod resource summary is across all containers in the Pod.
+- **Health coupling:** resource pressure rows do not alter cluster, watchlist, or Overview state in this version.
+
+### Deferred to Implementation
+
+- **Malformed unit handling policy:** decide whether one invalid container request/limit unit should drop only that resource dimension or all containers for that Pod.
+- **Compact unit format:** confirm whether CPU raw fallback should prefer m-core style or decimal with suffix for consistency.
+
+## Implementation Units
+
+- [x] **Unit 1: Extend Pod data contracts for resource context**
+
+**Goal:** Store Pod usage, request, and limit context in snapshot/display model without changing health state logic.
+
+**Requirements:** R1, R2, R17, R19, R20, R24
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `KubebarCore/Models/ClusterSnapshot.swift`
+- Modify: `KubebarCore/Models/MenuDisplayModel.swift`
+- Test: `KubebarTests/Services/KubectlClusterReaderTests.swift`
+
+**Approach:**
+- Add a dedicated Pod-level resource struct (usage, request, limit fields per CPU/memory, with safe optionals).
+- Add that field to `PodDetail`, with default-safe init to avoid breaking fixtures and decoding call sites.
+- Extend `PodItemDisplay` with compact and full resource text fields used by row rendering.
+- Keep `HealthEvaluator` untouched in this unit; only data shape grows.
+
+**Patterns to follow:**
+- Existing `NodeDetail`/`NodeItemDisplay` patterns for value/summary/help/accessibility pairing.
+- Existing equality semantics in model structs.
+
+**Test scenarios:**
+- Happy path: `PodDetail` can include all four resource values and remain `Equatable`.
+- Edge case: snapshot with no resource payload still builds `PodDetail`/`PodItemDisplay` defaults safely.
+- Error path: partial model fixture creation compiles without defaulting to fake zeros.
+
+**Verification:**
+- New model fields exist with safe optional values and no compile breakage in existing snapshots.
+
+- [x] **Unit 2: Read pod metrics and compute Pod-level resource summaries**
+
+**Goal:** Populate request/limit from Pod spec and usage from pod metrics for watched Pods only.
+
+**Requirements:** R2, R7, R8, R9, R10, R17-R24, R25, R30
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `KubebarCore/Services/KubectlClusterReader.swift`
+- Test: `KubebarTests/Services/KubectlClusterReaderTests.swift`
+
+**Approach:**
+- Add a pod-metrics read command (existing list endpoint) to the concurrent read set.
+- Extend `PodRecord` decoding to include container resources and aggregate pod request/limit safely per container.
+- Extend pod metrics decoding for pod-level entries and container usage, then aggregate to Pod totals.
+- Update `makePodDetailsSection` to inject resource summary into each matched `PodDetail`.
+- Keep pod-metrics failures as row-level unavailability (`-`) and avoid turning section availability into global `Watch`/`Bad`.
+
+**Patterns to follow:**
+- Existing `parseResourceQuantity` and scaling helpers in `KubectlClusterReader`.
+- Existing watched target matching and de-duplication behavior in `makePodDetailsSection`.
+
+**Test scenarios:**
+- Happy path: watched Pod receives all CPU/memory usage/request/limit values and keeps matching namespace/scoping.
+- Edge case: usage unavailable + request/limit present still shows known request/limit in full help context.
+- Edge case: request/limit missing + usage present still shows raw usage without fabricated percent.
+- Edge case: malformed pod metrics or disabled metrics endpoint does not fail snapshot and keeps tracked Pod rows.
+- Integration: pod metrics/API failure does not affect `sectionFailures`-driven state transitions.
+
+**Verification:**
+- `readSnapshot` remains available for normal pods and preserves existing fallback behavior for unavailable resources.
+
+- [x] **Unit 3: Map resource compact and full text in row model generation**
+
+**Goal:** Build concise in-row resource labels plus complete accessibility/help payloads with explicit missing markers.
+
+**Requirements:** R6-R16, R18, R20, R21, R22, R23, R24
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `KubebarCore/Services/HealthEvaluator.swift`
+- Test: `KubebarTests/Models/MenuDisplayModelTests.swift`
+
+**Approach:**
+- Add compact resource formatter for Pod rows with precedence per requirement: CPU request-first, Memory limit-first.
+- Keep full help text include namespace/name, state, ready counts, full usage/request/limit with explicit `-` markers.
+- Keep issue text priority unchanged; ensure accessibility/help includes both compact and expanded data.
+- Ensure issue line remains above resource line in row assembly.
+
+**Patterns to follow:**
+- Existing help/accessibility construction for node rows and pod issue selection.
+- Existing percentage formatting helpers where applicable.
+
+**Test scenarios:**
+- Edge case: usage missing -> `CPU - · Mem -` in compact row and matching explicit text in help.
+- Edge case: CPU usage known, no CPU request/limit basis -> compact `CPU <raw>`.
+- Edge case: mixed missing request/limit values show only available basis or raw fallback without fake percentages.
+- Integration: Pod row with issue retains issue line priority above resource line.
+- Integration: resource-only failures keep pod row state and overall cluster state unchanged.
+
+**Verification:**
+- `display.podTab.sections` rows include compact resource text and full help strings without impacting state logic.
+
+- [x] **Unit 4: Render resource line and keyboard/help output in Pods tab rows**
+
+**Goal:** Show compact resource line on pod rows while preserving issue order and density rules.
+
+**Requirements:** R6, R9, R11, R12, R13, R14, R15, R16, R21, R30
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `Kubebar/Views/PodsTabView.swift`
+- Test: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift` (indirect fixture expectations) if row copy expectations are updated
+
+**Approach:**
+- Add second text line in `PodRowView` for compact resource text.
+- Keep ready label and issue line intact; issue remains higher priority than resource in layout.
+- Ensure resource line truncates before issue line when constrained and help/focus still retains full values.
+- Keep `.help` and `.accessibilityLabel` tied to full value strings from model.
+
+**Patterns to follow:**
+- Existing compact row patterns in `PodRowView` and existing `.help` / `.focusable()` usage.
+
+**Test scenarios:**
+- UI behavior: issue present row still displays issue first and resource text below.
+- Integration: unavailable resource values render as `-` without widening row unexpectedly.
+- Accessibility: focused/hover text retains full values for missing and complete cases.
+
+**Verification:**
+- Pod row UI can still scroll/fit existing Pods tab layout while keeping `Pods` tab usability.
+
+- [x] **Unit 5: Expand regression coverage for read and display matrix**
+
+**Goal:** Lock down resource-fallback behavior, partial/missing cases, and non-regression of existing Pod state classification.
+
+**Requirements:** R17-R23, R25, R28, R30, R31
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Test: `KubebarTests/Services/KubectlClusterReaderTests.swift`
+- Test: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- Test: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+
+**Approach:**
+- Add reader tests for: request-only, limit-only, mixed, and missing pod metrics; malformed resource units.
+- Add model tests for compact formatter outcomes (`CPU req%`, `Memory limit%`, raw fallback, unavailable fallback).
+- Add explicit regression tests that `Bad`/`Watch`/`OK` state remains unchanged when only resource data is unavailable.
+- Add/adjust QA fixture tests if any visible pod-tab copy changes.
+
+**Patterns to follow:**
+- Existing fixture-driven test style in reader and menu model suites.
+
+**Test scenarios:**
+- Regression: failed/restarting/not-ready classification remains unchanged when resource data is missing.
+- Regression: pods tab empty/no watched pods still keeps `podsTab.emptyMessage` path distinct from unavailable.
+- Integration: resource text values are present in `help`/accessibility-derived model fields.
+
+**Verification:**
+- All existing Pod-related and overview tests pass alongside new resource-specific scenarios.
+
+- [x] **Unit 6: Update runtime notes for pod resource failure behavior**
+
+**Goal:** Document that resource display data can be unavailable without becoming a health failure.
+
+**Requirements:** R24, R25
+
+**Dependencies:** Unit 5
+
+**Files:**
+- Modify: `docs/architecture/runtime-invariants.md`
+
+**Approach:**
+- Add or refine wording for Pods-tab row context: missing resource numbers stay visible as unavailable, not fake healthy.
+- Keep health vocabulary rules unchanged and cross-link resource-only failure handling to `sectionFailures` behavior.
+
+**Test scenarios:**
+- Test expectation: none (documentation only).
+
+**Verification:**
+- Runtime invariant file includes this behavior so follow-up changes preserve it.
+
+## System-Wide Impact
+
+- **Interaction graph:** `KubectlClusterReader` adds pod metrics/request-limit parsing into `PodDetail`; `HealthEvaluator` formats and injects resource text into `PodItemDisplay`; `PodsTabView` consumes new row fields.
+- **Error propagation:** Pod metric or resource decode issues surface in row-level availability markers, not global cluster state changes.
+- **State lifecycle risks:** partial data should not block `podDetailsSection` row generation; tracked-item health remains source-of-truth.
+- **API surface parity:** no external API contract changes; only local types and UI behavior changes.
+- **Integration coverage:** reader + model + QA coverage across filtered watched Pods and unavailable-data scenarios.
+- **Unchanged invariants:** no health-state expansion, no container-level UI drilldown, no new external data dependencies.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Pod resource parsing fails for mixed or vendor-variant units | Keep per-dimension optional aggregation and explicit unavailable markers, avoid global failure.
+| Added pod-metrics read increases read-time overhead | Keep concurrent read model and reuse existing command runner timeout and error handling.
+| Layout crowding in Pods tab | Limit compact text to short format and enforce truncation while preserving issue-first priority.


### PR DESCRIPTION
## Summary
- Add Pod CPU and memory usage/request/limit summaries to row data and render them in the Pods tab
- Keep health state unchanged while exposing full resource details in help and accessibility text
- Handle missing, malformed, and duplicate pod metrics safely with explicit unavailable markers
- Add regression coverage for reader, display, and layout behavior

## Testing
- `swift test`
- `./scripts/swift-quality-gate.sh local`