### PR TITLE
fix(kubectl-cluster-reader): ignore historical restarts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ docs/          Requirements, plans, and architecture notes
 scripts/       Local quality checks
 ```
 
+`docs/solutions/` stores documented solutions to past problems and reusable learnings, organized by category with YAML frontmatter such as `module`, `tags`, and `problem_type`; relevant when implementing or debugging in documented areas.
+
 ## Key Exemplar Files
 
 - [KubebarCore/Services/HealthEvaluator.swift](KubebarCore/Services/HealthEvaluator.swift) — Pure evaluation logic, no side effects

--- a/KubebarCore/Services/KubectlClusterReader.swift
+++ b/KubebarCore/Services/KubectlClusterReader.swift
@@ -1095,8 +1095,8 @@ private struct PodRecord: Decodable, Equatable, Sendable {
     }
 
     var isRestarting: Bool {
-        status.containerStatuses?.contains { status in
-            normalizedReason(status.state?.waiting?.reason) == "crashloopbackoff"
+        status.containerStatuses?.contains { containerStatus in
+            normalizedReason(containerStatus.state?.waiting?.reason) == "crashloopbackoff"
         } ?? false
     }
 

--- a/KubebarCore/Services/KubectlClusterReader.swift
+++ b/KubebarCore/Services/KubectlClusterReader.swift
@@ -1096,8 +1096,7 @@ private struct PodRecord: Decodable, Equatable, Sendable {
 
     var isRestarting: Bool {
         status.containerStatuses?.contains { status in
-            (status.restartCount ?? 0) > 0 ||
-                status.state?.waiting?.reason == "CrashLoopBackOff"
+            normalizedReason(status.state?.waiting?.reason) == "crashloopbackoff"
         } ?? false
     }
 

--- a/KubebarTests/Services/KubectlClusterReaderTests.swift
+++ b/KubebarTests/Services/KubectlClusterReaderTests.swift
@@ -593,9 +593,25 @@ struct KubectlClusterReaderTests {
         let item = snapshot.trackedItems.first
 
         #expect(item?.state == .bad)
-        #expect(item?.reason == "2 pods restarting")
-        #expect(item?.affectedPodCount == 2)
-        #expect(item?.examplePodNames == ["checkout-a", "checkout-b"])
+        #expect(item?.reason == "1 pod restarting")
+        #expect(item?.affectedPodCount == 1)
+        #expect(item?.examplePodNames == ["checkout-b"])
+    }
+
+    @Test("historical restart count does not mark watched workload bad")
+    func historicalRestartCountDoesNotMarkWatchedWorkloadBad() throws {
+        let snapshot = try readSnapshot(
+            pods: historicallyRestartedReadyPodsJSON,
+            warningEvents: emptyListJSON,
+            watchTargets: [.workload(namespace: "api", name: "checkout")]
+        )
+        let item = snapshot.trackedItems.first
+
+        #expect(snapshot.podsSection.value == PodSummary(ready: 2, running: 2, total: 2))
+        #expect(item?.state == .ok)
+        #expect(item?.reason == "2/2 pods running")
+        #expect(item?.affectedPodCount == nil)
+        #expect(item?.examplePodNames.isEmpty == true)
     }
 
     @Test("pending and unready pods merge into not ready reason")
@@ -1194,9 +1210,9 @@ private let failedRestartingAndNotReadyPodsJSON = """
       "metadata": {"namespace": "api", "name": "checkout-restarting", "labels": {"app.kubernetes.io/name": "checkout"}},
       "status": {
         "phase": "Running",
-        "conditions": [{"type": "Ready", "status": "True"}],
+        "conditions": [{"type": "Ready", "status": "False", "reason": "ContainersNotReady"}],
         "containerStatuses": [
-          {"ready": true, "restartCount": 2}
+          {"ready": false, "restartCount": 2, "state": {"waiting": {"reason": "CrashLoopBackOff"}}}
         ]
       }
     },
@@ -1225,9 +1241,9 @@ private let restartingPodsJSON = """
       "metadata": {"namespace": "api", "name": "checkout-b", "labels": {"app.kubernetes.io/name": "checkout"}},
       "status": {
         "phase": "Running",
-        "conditions": [{"type": "Ready", "status": "True"}],
+        "conditions": [{"type": "Ready", "status": "False", "reason": "ContainersNotReady"}],
         "containerStatuses": [
-          {"ready": true, "restartCount": 0, "state": {"waiting": {"reason": "CrashLoopBackOff"}}}
+          {"ready": false, "restartCount": 0, "state": {"waiting": {"reason": "CrashLoopBackOff"}}}
         ]
       }
     },
@@ -1238,6 +1254,33 @@ private let restartingPodsJSON = """
         "conditions": [{"type": "Ready", "status": "True"}],
         "containerStatuses": [
           {"ready": true, "restartCount": 0}
+        ]
+      }
+    }
+  ]
+}
+"""
+
+private let historicallyRestartedReadyPodsJSON = """
+{
+  "items": [
+    {
+      "metadata": {"namespace": "api", "name": "checkout-a", "labels": {"app.kubernetes.io/name": "checkout"}},
+      "status": {
+        "phase": "Running",
+        "conditions": [{"type": "Ready", "status": "True"}],
+        "containerStatuses": [
+          {"ready": true, "restartCount": 1}
+        ]
+      }
+    },
+    {
+      "metadata": {"namespace": "api", "name": "checkout-b", "labels": {"app.kubernetes.io/name": "checkout"}},
+      "status": {
+        "phase": "Running",
+        "conditions": [{"type": "Ready", "status": "True"}],
+        "containerStatuses": [
+          {"ready": true, "restartCount": 3}
         ]
       }
     }
@@ -1408,19 +1451,19 @@ private let cappedRestartingPodsJSON = """
   "items": [
     {
       "metadata": {"namespace": "api", "name": "checkout-d", "labels": {"app.kubernetes.io/name": "checkout"}},
-      "status": {"phase": "Running", "containerStatuses": [{"ready": true, "restartCount": 1}]}
+      "status": {"phase": "Running", "containerStatuses": [{"ready": false, "restartCount": 1, "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]}
     },
     {
       "metadata": {"namespace": "api", "name": "checkout-b", "labels": {"app.kubernetes.io/name": "checkout"}},
-      "status": {"phase": "Running", "containerStatuses": [{"ready": true, "restartCount": 1}]}
+      "status": {"phase": "Running", "containerStatuses": [{"ready": false, "restartCount": 1, "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]}
     },
     {
       "metadata": {"namespace": "api", "name": "checkout-a", "labels": {"app.kubernetes.io/name": "checkout"}},
-      "status": {"phase": "Running", "containerStatuses": [{"ready": true, "restartCount": 1}]}
+      "status": {"phase": "Running", "containerStatuses": [{"ready": false, "restartCount": 1, "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]}
     },
     {
       "metadata": {"namespace": "api", "name": "checkout-c", "labels": {"app.kubernetes.io/name": "checkout"}},
-      "status": {"phase": "Running", "containerStatuses": [{"ready": true, "restartCount": 1}]}
+      "status": {"phase": "Running", "containerStatuses": [{"ready": false, "restartCount": 1, "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]}
     }
   ]
 }

--- a/docs/solutions/logic-errors/historical-pod-restarts-mark-workload-bad-2026-04-28.md
+++ b/docs/solutions/logic-errors/historical-pod-restarts-mark-workload-bad-2026-04-28.md
@@ -1,0 +1,102 @@
+---
+title: Historical Pod Restarts Mark Watched Workloads Bad
+date: "2026-04-28"
+category: "docs/solutions/logic-errors"
+module: "KubectlClusterReader"
+problem_type: "logic_error"
+component: "service_object"
+symptoms:
+  - "Watched workload stayed Bad after a restarted Pod recovered"
+  - "Cluster health stayed Bad even when current Pod state was healthy"
+  - "Historical restartCount values were treated as active restart failures"
+root_cause: "logic_error"
+resolution_type: "code_fix"
+severity: "medium"
+related_components:
+  - "HealthEvaluator"
+  - "MenuDisplayModel"
+  - "KubebarTests"
+tags:
+  - "kubectl-cluster-reader"
+  - "pod-health"
+  - "restart-count"
+  - "crashloopbackoff"
+  - "false-bad-state"
+---
+
+# Historical Pod Restarts Mark Watched Workloads Bad
+
+## Problem
+
+Kubebar kept a watched workload and the overall cluster in `Bad` after a Pod had already recovered from a restart. The health logic treated a cumulative Kubernetes restart counter as if it described a current failure.
+
+## Symptoms
+
+- A Pod that was currently `Running` and `Ready` could still make its watched target `Bad`.
+- Any container with `restartCount > 0` was treated as actively restarting.
+- A one-time past restart could keep the menu bar status unhealthy indefinitely.
+
+## What Didn't Work
+
+- Treating `restartCount` as active restart detection did not work because Kubernetes restart counts are cumulative history, not current state.
+- Session history did not show a previous fix attempt for this exact issue, but it did show the same product rule recurring elsewhere: old or historical state must not be presented as current health. (session history)
+
+Before:
+
+```swift
+var isRestarting: Bool {
+    status.containerStatuses?.contains { status in
+        (status.restartCount ?? 0) > 0 ||
+            status.state?.waiting?.reason == "CrashLoopBackOff"
+    } ?? false
+}
+```
+
+That code incorrectly classified recovered Pods as still restarting.
+
+## Solution
+
+Base active restart detection on the current container waiting state only. A Pod counts as restarting when a container is currently waiting with reason `CrashLoopBackOff`.
+
+After:
+
+```swift
+var isRestarting: Bool {
+    status.containerStatuses?.contains { status in
+        normalizedReason(status.state?.waiting?.reason) == "crashloopbackoff"
+    } ?? false
+}
+```
+
+Tests should cover both sides of the rule:
+
+- Pods with nonzero historical `restartCount`, `Ready=True`, and no current waiting state stay `OK`.
+- Pods currently waiting with `CrashLoopBackOff` still make the watched target `Bad`.
+- Crash-loop fixtures should model the current failure state realistically: not ready and waiting with `CrashLoopBackOff`.
+
+## Why This Works
+
+`restartCount` records past restarts. `CrashLoopBackOff` is a current container state. Separating those signals keeps recovered Pods from poisoning health while preserving the important failure case where a container is actively crash-looping.
+
+This matches the product invariant in `docs/architecture/runtime-invariants.md`: historical restart count alone must not make a Pod item `Bad`, while current failed, waiting, or crash-looping state may.
+
+## Prevention
+
+- Keep health decisions based on current Pod and container state, not cumulative counters alone.
+- Add regression tests for recovered Pods with nonzero restart counts.
+- Model failing Pod fixtures with realistic current status, including `Ready=False` and a waiting reason when testing `CrashLoopBackOff`.
+- When adding new Kubernetes health signals, decide whether each signal describes current state, historical state, terminal state, or unavailable data before mapping it to `OK`, `Watch`, `Bad`, or `Stale`.
+
+## Related Issues
+
+- `docs/architecture/runtime-invariants.md` defines the authoritative runtime rule.
+- `docs/plans/2026-04-22-004-feat-pod-item-menu-ui-plan.md` records the intended Pod row behavior.
+- `docs/brainstorms/2026-04-22-kubebar-pod-item-menu-ui-requirements.md` called out the need to distinguish active restarts from historical restart count.
+- `docs/plans/2026-04-23-002-fix-completed-job-pods-readiness-plan.md` is an adjacent false-health-state fix that separates terminal historical Pod state from active health.
+- `docs/plans/2026-04-22-005-fix-no-matching-pods-health-plan.md` is an adjacent logic fix where missing Pods should not be treated as active failure.
+- GitHub issue #4 is broadly related to actionable workload reasons, including restarting Pods.
+
+## Verification
+
+- `swift test --filter KubectlClusterReaderTests` passed with 42 tests.
+- `./scripts/swift-quality-gate.sh local` passed.


### PR DESCRIPTION
## Summary
- Watched workloads now stay healthy when a Pod only has historical restart counts but is currently ready.
- Active restart detection now relies on current `CrashLoopBackOff` state instead of cumulative restart history.
- Added regression coverage and documented the failure mode in `docs/solutions/`.

## User Impact
- Workloads with recovered Pods no longer show as bad just because a container restarted in the past.
- Users will still see bad status for Pods that are actively crash-looping.

## Changelog
- User-visible change: Pods that have recovered from earlier restarts are no longer reported as bad.

## Validation
- Not run (not requested).
- Added unit test coverage for recovered Pods with nonzero restart counts and for active `CrashLoopBackOff` cases.

## Security Impact
- None

## Blast Radius
- Pod health evaluation in `KubectlClusterReader`
- Watched workload status shown in the menu bar
- Regression documentation under `docs/solutions/`

## Rollback Plan
- Revert this commit to restore the previous restart detection behavior.