### PR TITLE
feat(kubebar): add resource usage visualization

### DIFF
--- a/.imm/memory/MEMORY.md
+++ b/.imm/memory/MEMORY.md
@@ -1,0 +1,12 @@
+# MEMORY.md - Immune-Brain Memory Index
+
+## Current Status
+- Latest summary: Project bootstrap initialized.
+- Todo: Start with `imm-brainstorm` or `imm-planner` for the first real task.
+- Last sync: Not started.
+
+## Task History
+- No task history yet.
+
+## Knowledge Index
+- No reusable project learnings recorded yet.

--- a/.imm/memory/current_iteration.json
+++ b/.imm/memory/current_iteration.json
@@ -1,0 +1,101 @@
+{
+  "steps": {
+    "1": {
+      "step_id": "U1",
+      "state": "rework_needed",
+      "result": "Resource usage appears visually scannable.",
+      "verification": "./scripts/swift-quality-gate.sh local",
+      "depends_on": [],
+      "test_scenarios": [
+        "Overview progress values match metrics",
+        "missing metrics stay unavailable",
+        "node zero usage yields zero progress",
+        "pod CPU basis follows request then limit",
+        "pod memory basis follows limit then request",
+        "resource progress preserves health category"
+      ],
+      "agent_hint": null,
+      "activated_at": "2026-05-12T14:34:32Z"
+    }
+  },
+  "last_review": {
+    "decision": "rework",
+    "evidence": "swift build passed; ./scripts/swift-quality-gate.sh local did not pass because xcodebuild requires full Xcode while active developer directory is CommandLineTools; swift test --filter MenuDisplayModelTests did not run because the Testing module is unavailable in this toolchain.",
+    "artifacts": "",
+    "notes": "Required verification is not available in this environment, so the step cannot be closed here. Rerun the quality gate on a full Xcode/Swift Testing environment; if it passes, review can be changed to pass.",
+    "step_number": 1,
+    "step_id": "U1"
+  },
+  "history": [
+    {
+      "at": "2026-05-12T14:34:15Z",
+      "action": "sync_plan_from_imm_plan",
+      "details": {
+        "plan_path": "docs/plans/2026-05-12-001-feat-resource-usage-visualization-plan.md",
+        "plan_signature": "f082335e1461ab20945a43f952e98549f0db5904e4aaf5a9ebd0f82aa5a81b1c",
+        "plan_summary": "Resource usage becomes visually scannable.",
+        "same_plan": false
+      }
+    },
+    {
+      "at": "2026-05-12T14:34:23Z",
+      "action": "schema_migration_v1_to_v2",
+      "details": {
+        "migrated_completed_steps": [],
+        "migrated_active_step": null
+      }
+    },
+    {
+      "at": "2026-05-12T14:34:32Z",
+      "action": "activate_step",
+      "details": {
+        "plan_path": "docs/plans/2026-05-12-001-feat-resource-usage-visualization-plan.md",
+        "step_number": 1,
+        "step_id": "U1"
+      }
+    },
+    {
+      "at": "2026-05-12T14:40:12Z",
+      "action": "record_execution_evidence",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "changed_files": [
+          "KubebarCore/Models/MenuDisplayModel.swift",
+          "KubebarCore/Services/HealthEvaluator.swift",
+          "Kubebar/Views/PodsTabView.swift",
+          "KubebarTests/Models/MenuDisplayModelTests.swift",
+          "docs/architecture/runtime-invariants.md"
+        ]
+      }
+    },
+    {
+      "at": "2026-05-12T14:40:38Z",
+      "action": "review_step",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "decision": "rework"
+      }
+    }
+  ],
+  "requires_replan": false,
+  "schema_version": 2,
+  "plan_path": "docs/plans/2026-05-12-001-feat-resource-usage-visualization-plan.md",
+  "plan_summary": "Resource usage becomes visually scannable.",
+  "plan_signature": "f082335e1461ab20945a43f952e98549f0db5904e4aaf5a9ebd0f82aa5a81b1c",
+  "plan_last_validated_at": "2026-05-12T14:34:15Z",
+  "validated_plan_snapshot": {
+    "plan_path": "docs/plans/2026-05-12-001-feat-resource-usage-visualization-plan.md",
+    "plan_signature": "f082335e1461ab20945a43f952e98549f0db5904e4aaf5a9ebd0f82aa5a81b1c",
+    "steps": [
+      {
+        "number": 1,
+        "step_id": "U1",
+        "result": "Resource usage appears visually scannable.",
+        "verification": "./scripts/swift-quality-gate.sh local",
+        "depends_on": []
+      }
+    ]
+  }
+}

--- a/.imm/memory/current_iteration.json
+++ b/.imm/memory/current_iteration.json
@@ -2,7 +2,7 @@
   "steps": {
     "1": {
       "step_id": "U1",
-      "state": "rework_needed",
+      "state": "closed",
       "result": "Resource usage appears visually scannable.",
       "verification": "./scripts/swift-quality-gate.sh local",
       "depends_on": [],
@@ -15,14 +15,26 @@
         "resource progress preserves health category"
       ],
       "agent_hint": null,
-      "activated_at": "2026-05-12T14:34:32Z"
+      "activated_at": "2026-05-12T14:34:32Z",
+      "execution_evidence": {
+        "changed_files": [
+          "KubebarCore/Models/MenuDisplayModel.swift",
+          "KubebarCore/Services/HealthEvaluator.swift",
+          "KubebarTests/Models/MenuDisplayModelTests.swift"
+        ],
+        "verification_command": "gh pr checks 35",
+        "verification_result": "PR #35 checks passed: Swift Quality Gate, Regression test enforcement, Scope labels, Size / Risk / Tier.",
+        "notes": "Addressed Gemini comments by restoring legacy PodItemDisplay.resourceProgress compatibility and refactoring percentage formatting through the shared progress helper.",
+        "recorded_at": "2026-05-12T15:29:08Z"
+      },
+      "closed_at": "2026-05-12T15:29:16Z"
     }
   },
   "last_review": {
-    "decision": "rework",
-    "evidence": "swift build passed; ./scripts/swift-quality-gate.sh local did not pass because xcodebuild requires full Xcode while active developer directory is CommandLineTools; swift test --filter MenuDisplayModelTests did not run because the Testing module is unavailable in this toolchain.",
-    "artifacts": "",
-    "notes": "Required verification is not available in this environment, so the step cannot be closed here. Rerun the quality gate on a full Xcode/Swift Testing environment; if it passes, review can be changed to pass.",
+    "decision": "pass",
+    "evidence": "PR #35 checks passed after commit 1b84f0d: Swift Quality Gate, Regression test enforcement, Scope labels, Size / Risk / Tier.",
+    "artifacts": "https://github.com/nexttylabs/kubebar/pull/35",
+    "notes": "Gemini comments addressed: legacy resourceProgress compatibility restored and percentage/resourcePercentage now reuse progress helper.",
     "step_number": 1,
     "step_id": "U1"
   },
@@ -76,6 +88,28 @@
         "step_number": 1,
         "step_id": "U1",
         "decision": "rework"
+      }
+    },
+    {
+      "at": "2026-05-12T15:29:08Z",
+      "action": "record_execution_evidence",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "changed_files": [
+          "KubebarCore/Models/MenuDisplayModel.swift",
+          "KubebarCore/Services/HealthEvaluator.swift",
+          "KubebarTests/Models/MenuDisplayModelTests.swift"
+        ]
+      }
+    },
+    {
+      "at": "2026-05-12T15:29:16Z",
+      "action": "review_step",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "decision": "pass"
       }
     }
   ],

--- a/.imm/specs/2026-05-12-resource-usage-visualization.md
+++ b/.imm/specs/2026-05-12-resource-usage-visualization.md
@@ -1,0 +1,74 @@
+---
+title: Resource usage visualization
+date: 2026-05-12
+status: planned
+origin: imm-brainstorm handoff
+---
+
+# Resource Usage Visualization
+
+## Summary
+
+Kubebar already reads CPU and memory usage for Overview cards, node rows, and
+Pod rows, and the UI already has an `InlineProgressBar` component. The missing
+piece is a complete display-model contract that consistently provides
+current-snapshot progress values wherever resource usage is shown.
+
+This feature adds lightweight resource visualization, meaning compact progress
+bars or equivalent current-use indicators next to existing CPU and memory text.
+It must improve scanability without turning Kubebar into a dashboard.
+
+## Goals
+
+- Overview CPU and Memory cards show visual usage alongside the existing text.
+- Nodes tab rows show visual CPU and Memory usage for each node when metrics
+  are available.
+- Pods tab rows show CPU and Memory resource pressure clearly enough to scan
+  without hiding readiness or issue text.
+- Missing metrics remain explicit unavailable values and never look like `0`.
+- Resource visualization remains informational and does not affect health
+  categories.
+
+## Non-Goals
+
+- No historical charts, sparklines, trends, or time-series storage.
+- No Prometheus, Grafana, or external monitoring dependency.
+- No resource-pressure alerting.
+- No changes to `OK`, `Watch`, `Bad`, or `Stale` evaluation.
+- No per-container Pod resource breakdown.
+
+## Requirements
+
+- R1. `MenuDisplayModel` remains the only rendering input for resource
+  visualization.
+- R2. `HealthEvaluator` computes resource progress values from already-owned
+  snapshot data.
+- R3. Progress values are unavailable when either usage or comparison basis is
+  missing or invalid.
+- R4. Valid zero usage produces a real `0` progress value.
+- R5. Progress values are clamped for rendering so over-basis usage does not
+  break layout.
+- R6. Overview CPU and Memory progress use node usage over allocatable values.
+- R7. Node CPU and Memory progress use per-node usage over allocatable values.
+- R8. Pod CPU progress follows the existing compact text basis order: request,
+  then limit.
+- R9. Pod Memory progress follows the existing compact text basis order: limit,
+  then request.
+- R10. Pods must not collapse CPU and Memory into one ambiguous pressure value
+  unless the plan explicitly records why a single value is better.
+- R11. Help and accessibility labels keep full resource text available.
+- R12. UI layout preserves current row density: resource visuals may shrink or
+  disappear before Pod names, readiness counts, or issue reasons are obscured.
+- R13. Stale data continues to be marked stale; visualization must not make old
+  resource numbers look current.
+
+## Verification Expectations
+
+- Display-model tests cover current, zero, missing, and over-basis progress
+  values for Overview, Nodes, and Pods.
+- UI code consumes display-model progress values without doing Kubernetes
+  health logic in views.
+- The local Swift quality gate passes before the implementation is considered
+  complete.
+- A visible-app smoke check confirms the bars render in the menu without text
+  overlap or confusing unavailable states.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,3 +79,12 @@ scripts/       Local quality checks
 - Add or update tests for behavior changes.
 - Preserve existing defaults unless the task explicitly changes them.
 - Treat auth, secrets, config loading, persistence, build settings, CI, and public or network-facing APIs as high-risk changes.
+
+<!-- IMMUNE-BRAIN:START -->
+This project uses the Immune-Brain workflow.
+
+- Read `IMMUNE.md` before planning or implementation.
+- Start with `imm-brainstorm` when the task is vague.
+- Use `imm-planner` before implementation work.
+- Use `imm-work` to continue one validated step at a time.
+<!-- IMMUNE-BRAIN:END -->

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,21 @@
+# Kubebar Context
+
+## Canonical Terms
+
+- **Kubebar**: a native macOS menu bar app for glanceable Kubernetes health.
+- **Health category**: one of `OK`, `Watch`, `Bad`, or `Stale`; only
+  `HealthEvaluator` decides it.
+- **Resource usage visualization**: lightweight current-snapshot CPU and memory
+  indicators, such as inline progress bars, derived from existing app-owned
+  metrics data.
+- **Progress value**: an optional `Double` display-model value where `nil`
+  means unavailable and numeric values are clamped by the view for rendering.
+- **Unavailable resource data**: missing or invalid CPU or memory usage or
+  comparison basis; it is shown as unavailable, never as healthy zero.
+
+## Vocabulary Guard
+
+In this repository, "chart" for resource usage means lightweight current-state
+visualization inside the menu. It does not mean historical trends, sparklines,
+time-series storage, or an external monitoring dashboard unless a future plan
+explicitly changes that scope.

--- a/IMMUNE.md
+++ b/IMMUNE.md
@@ -1,0 +1,25 @@
+# IMMUNE.md - Immune-Brain Constitution
+
+This project uses the Immune-Brain workflow.
+
+## Core Principles
+
+- Files are the durable memory for important decisions and workflow state.
+- Plan before code. Create or update a spec before changing core behavior.
+- Work in small, independently verifiable steps.
+- Keep changes scoped to the current goal.
+
+## Workflow Order
+
+1. `imm-brainstorm` clarifies the request and boundaries.
+2. `imm-preplan-review` is optional when scope or closure needs one more pass.
+3. `imm-planner` creates the spec and plan.
+4. `imm-work` drives one active step at a time through execution and QA.
+5. `imm-compounder` records reusable learnings after the task closes.
+
+## Project Artifacts
+
+- `.imm/memory/` stores durable workflow memory.
+- `.imm/specs/` stores task specs.
+- `docs/brainstorms/` stores clarified request framing.
+- `docs/plans/` stores validated execution plans.

--- a/Kubebar/Views/PodsTabView.swift
+++ b/Kubebar/Views/PodsTabView.swift
@@ -181,12 +181,12 @@ private struct PodRowView: View {
                             .lineLimit(1)
                             .truncationMode(.middle)
                             .help(Text(row.resourceLabel))
-                            
-                        if let progress = row.resourceProgress {
-                            InlineProgressBar(progress: progress)
-                                .frame(width: 32)
-                                .padding(.leading, 2)
-                        }
+
+                        ResourceProgressPair(
+                            cpuProgress: row.cpuProgress,
+                            memoryProgress: row.memoryProgress
+                        )
+                        .padding(.leading, 2)
                     }
                 }
 
@@ -209,6 +209,26 @@ private struct PodRowView: View {
 
     private func updatePulse() {
         isPulsing = shouldPulse
+    }
+}
+
+private struct ResourceProgressPair: View {
+    let cpuProgress: Double?
+    let memoryProgress: Double?
+
+    var body: some View {
+        HStack(spacing: 3) {
+            if let cpuProgress {
+                InlineProgressBar(progress: cpuProgress)
+                    .frame(width: 26)
+            }
+
+            if let memoryProgress {
+                InlineProgressBar(progress: memoryProgress)
+                    .frame(width: 26)
+            }
+        }
+        .accessibilityHidden(true)
     }
 }
 

--- a/KubebarCore/Models/MenuDisplayModel.swift
+++ b/KubebarCore/Models/MenuDisplayModel.swift
@@ -295,7 +295,8 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
     public let state: PodItemState
     public let readyLabel: String
     public let resourceLabel: String
-    public let resourceProgress: Double?
+    public let cpuProgress: Double?
+    public let memoryProgress: Double?
     public let issueText: String?
     public let helpText: String
     public let accessibilityLabel: String
@@ -306,7 +307,8 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
         state: PodItemState,
         readyLabel: String,
         resourceLabel: String,
-        resourceProgress: Double? = nil,
+        cpuProgress: Double? = nil,
+        memoryProgress: Double? = nil,
         issueText: String? = nil,
         helpText: String,
         accessibilityLabel: String
@@ -317,7 +319,8 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
         self.state = state
         self.readyLabel = readyLabel
         self.resourceLabel = resourceLabel
-        self.resourceProgress = resourceProgress
+        self.cpuProgress = cpuProgress
+        self.memoryProgress = memoryProgress
         self.issueText = issueText
         self.helpText = helpText
         self.accessibilityLabel = accessibilityLabel

--- a/KubebarCore/Models/MenuDisplayModel.swift
+++ b/KubebarCore/Models/MenuDisplayModel.swift
@@ -301,6 +301,10 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
     public let helpText: String
     public let accessibilityLabel: String
 
+    public var resourceProgress: Double? {
+        [cpuProgress, memoryProgress].compactMap(\.self).max()
+    }
+
     public init(
         namespace: String,
         name: String,
@@ -324,6 +328,31 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
         self.issueText = issueText
         self.helpText = helpText
         self.accessibilityLabel = accessibilityLabel
+    }
+
+    public init(
+        namespace: String,
+        name: String,
+        state: PodItemState,
+        readyLabel: String,
+        resourceLabel: String,
+        resourceProgress: Double?,
+        issueText: String? = nil,
+        helpText: String,
+        accessibilityLabel: String
+    ) {
+        self.init(
+            namespace: namespace,
+            name: name,
+            state: state,
+            readyLabel: readyLabel,
+            resourceLabel: resourceLabel,
+            cpuProgress: resourceProgress,
+            memoryProgress: resourceProgress,
+            issueText: issueText,
+            helpText: helpText,
+            accessibilityLabel: accessibilityLabel
+        )
     }
 }
 

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -428,11 +428,11 @@ public struct HealthEvaluator: Sendable {
     }
 
     private func percentage(usage: Int64, allocatable: Int64) -> String {
-        guard allocatable > 0 else {
+        guard let value = progress(usage: usage, basis: allocatable) else {
             return "-"
         }
 
-        let percent = (Double(usage) / Double(allocatable) * 100).rounded()
+        let percent = (value * 100).rounded()
         return "\(Int(percent))%"
     }
 
@@ -866,7 +866,11 @@ public struct HealthEvaluator: Sendable {
     }
 
     private func resourcePercentage(usage: Int64, basis: Int64) -> String {
-        let percent = (Double(usage) / Double(basis) * 100).rounded()
+        guard let value = progress(usage: usage, basis: basis) else {
+            return "-"
+        }
+
+        let percent = (value * 100).rounded()
         return "\(Int(percent))%"
     }
 

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -382,6 +382,7 @@ public struct HealthEvaluator: Sendable {
             detail: detail,
             systemImageName: "cpu",
             state: cardState(for: state),
+            progress: progress(usage: metrics.cpuUsageNanocores, basis: metrics.cpuAllocatableNanocores),
             accessibilityLabel: "CPU \(percent), \(detail)"
         )
     }
@@ -405,6 +406,7 @@ public struct HealthEvaluator: Sendable {
             detail: detail,
             systemImageName: "memorychip",
             state: cardState(for: state),
+            progress: progress(usage: metrics.memoryUsageBytes, basis: metrics.memoryAllocatableBytes),
             accessibilityLabel: "Memory \(percent), \(detail)"
         )
     }
@@ -440,6 +442,14 @@ public struct HealthEvaluator: Sendable {
         }
 
         return percentage(usage: usage, allocatable: allocatable)
+    }
+
+    private func progress(usage: Int64?, basis: Int64?) -> Double? {
+        guard let usage, let basis, basis > 0 else {
+            return nil
+        }
+
+        return Double(usage) / Double(basis)
     }
 
     private func formatCores(_ nanocores: Int64) -> String {
@@ -508,6 +518,8 @@ public struct HealthEvaluator: Sendable {
             statusLabel: statusLabel,
             cpuLabel: cpuLabel,
             memoryLabel: memoryLabel,
+            cpuProgress: progress(usage: detail.cpuUsageNanocores, basis: detail.cpuAllocatableNanocores),
+            memoryProgress: progress(usage: detail.memoryUsageBytes, basis: detail.memoryAllocatableBytes),
             issueText: issueText,
             helpText: helpText,
             accessibilityLabel: helpText
@@ -654,6 +666,8 @@ public struct HealthEvaluator: Sendable {
             state: state,
             readyLabel: readyLabel,
             resourceLabel: resourceLabel,
+            cpuProgress: podCPUProgress(from: detail.resourceSummary),
+            memoryProgress: podMemoryProgress(from: detail.resourceSummary),
             issueText: issueText,
             helpText: helpText,
             accessibilityLabel: helpText
@@ -821,6 +835,34 @@ public struct HealthEvaluator: Sendable {
         }
 
         return "\(name) \(rawFormatter(usage))"
+    }
+
+    private func podCPUProgress(from summary: PodResourceSummary) -> Double? {
+        podResourceProgress(
+            usage: summary.cpuUsageNanocores,
+            primaryBasis: summary.cpuRequestNanocores,
+            secondaryBasis: summary.cpuLimitNanocores
+        )
+    }
+
+    private func podMemoryProgress(from summary: PodResourceSummary) -> Double? {
+        podResourceProgress(
+            usage: summary.memoryUsageBytes,
+            primaryBasis: summary.memoryLimitBytes,
+            secondaryBasis: summary.memoryRequestBytes
+        )
+    }
+
+    private func podResourceProgress(
+        usage: Int64?,
+        primaryBasis: Int64?,
+        secondaryBasis: Int64?
+    ) -> Double? {
+        if let value = progress(usage: usage, basis: primaryBasis) {
+            return value
+        }
+
+        return progress(usage: usage, basis: secondaryBasis)
     }
 
     private func resourcePercentage(usage: Int64, basis: Int64) -> String {

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -35,6 +35,8 @@ struct MenuDisplayModelTests {
         #expect(display.overview.cards.map(\.id) == ["nodes", "pods", "cpu", "memory"])
         #expect(display.overview.cards.map(\.value) == ["3/3", "12/12", "21%", "17%"])
         #expect(display.overview.cards.allSatisfy { $0.state == .current })
+        #expect(display.overview.cards.first(where: { $0.id == "cpu" })?.progress == 750_000_000.0 / 3_500_000_000.0)
+        #expect(display.overview.cards.first(where: { $0.id == "memory" })?.progress == 2_147_483_648.0 / 12_884_901_888.0)
         #expect(display.overview.recentWarningsEmptyMessage == "No current warning events")
         #expect(display.nodeTab.summary == "3/3 nodes ready")
         #expect(display.nodeTab.emptyMessage == "No node data yet. Refresh or check Settings.")
@@ -368,7 +370,9 @@ struct MenuDisplayModelTests {
         #expect(display.overview.statusHelpText == "Metrics unavailable: metrics API unavailable")
         #expect(display.overview.statusAccessibilityLabel.contains("metrics API unavailable"))
         #expect(display.overview.cards.first(where: { $0.id == "cpu" })?.state == .unavailable)
+        #expect(display.overview.cards.first(where: { $0.id == "cpu" })?.progress == nil)
         #expect(display.overview.cards.first(where: { $0.id == "memory" })?.detail == "metrics API unavailable")
+        #expect(display.overview.cards.first(where: { $0.id == "memory" })?.progress == nil)
     }
 
     @Test("node tab rows show sorted readiness and metrics")
@@ -400,9 +404,13 @@ struct MenuDisplayModelTests {
         #expect(rows[0].issueText == "KubeletNotReady: container runtime is down")
         #expect(rows[0].cpuLabel == "25%")
         #expect(rows[0].memoryLabel == "25%")
+        #expect(rows[0].cpuProgress == 0.25)
+        #expect(rows[0].memoryProgress == 0.25)
         #expect(rows[1].statusLabel == "Ready")
         #expect(rows[1].cpuLabel == "-")
         #expect(rows[1].memoryLabel == "-")
+        #expect(rows[1].cpuProgress == nil)
+        #expect(rows[1].memoryProgress == nil)
         #expect(rows[2].statusLabel == "Ready")
         #expect(rows[2].accessibilityLabel == "worker-z, Ready, CPU 25%, Memory 25%")
     }
@@ -426,6 +434,8 @@ struct MenuDisplayModelTests {
 
         #expect(row?.cpuLabel == "0%")
         #expect(row?.memoryLabel == "0%")
+        #expect(row?.cpuProgress == 0)
+        #expect(row?.memoryProgress == 0)
     }
 
     @Test("node tab empty state uses an explicit display flag")
@@ -549,6 +559,8 @@ struct MenuDisplayModelTests {
         let row = try #require(display.podTab.sections.first?.rows.first)
 
         #expect(row.resourceLabel == "CPU 50% req · Mem 25% limit")
+        #expect(row.cpuProgress == 0.5)
+        #expect(row.memoryProgress == 0.25)
     }
 
     @Test("pod rows show resource summary when usage is missing")
@@ -584,6 +596,8 @@ struct MenuDisplayModelTests {
         let row = try #require(display.podTab.sections.first?.rows.first)
 
         #expect(row.resourceLabel == "CPU - · Mem -")
+        #expect(row.cpuProgress == nil)
+        #expect(row.memoryProgress == nil)
         #expect(row.helpText.contains("CPU -/1/2 · Mem -/2/-GiB"))
         #expect(row.accessibilityLabel == row.helpText)
     }
@@ -633,7 +647,47 @@ struct MenuDisplayModelTests {
         let rawOnly = try #require(rows.first { $0.name == "raw-only" })
 
         #expect(fallback.resourceLabel == "CPU 25% limit · Mem 50% req")
+        #expect(fallback.cpuProgress == 0.25)
+        #expect(fallback.memoryProgress == 0.5)
         #expect(rawOnly.resourceLabel == "CPU 120m · Mem 256Mi")
+        #expect(rawOnly.cpuProgress == nil)
+        #expect(rawOnly.memoryProgress == nil)
+    }
+
+    @Test("pod progress can exceed selected resource basis")
+    func podProgressCanExceedSelectedResourceBasis() throws {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 1, total: 1)),
+            podDetailsSection: .available([
+                podDetail(
+                    namespace: "api",
+                    name: "hot-pod",
+                    readyContainerCount: 1,
+                    totalContainerCount: 1,
+                    resourceSummary: PodResourceSummary(
+                        cpuUsageNanocores: 2_000_000_000,
+                        cpuRequestNanocores: 1_000_000_000,
+                        memoryUsageBytes: 6_442_450_944,
+                        memoryLimitBytes: 4_294_967_296
+                    )
+                )
+            ]),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([
+                TrackedItemStatus(target: .namespace("api"), state: .ok, reason: "1/1 pods running")
+            ]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+        let row = try #require(display.podTab.sections.first?.rows.first)
+
+        #expect(row.resourceLabel == "CPU 200% req · Mem 150% limit")
+        #expect(row.cpuProgress == 2)
+        #expect(row.memoryProgress == 1.5)
+        #expect(display.state == .ok)
     }
 
     @Test("pod row help keeps resource markers when all values are unavailable")
@@ -702,6 +756,8 @@ struct MenuDisplayModelTests {
         #expect(row.state == .bad)
         #expect(row.issueText == "CrashLoopBackOff: back-off restarting container")
         #expect(row.resourceLabel == "CPU 50% req · Mem 25% limit")
+        #expect(row.cpuProgress == 0.5)
+        #expect(row.memoryProgress == 0.25)
     }
 
     @Test("pod tab does not mark historical restarts as bad")

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -1061,6 +1061,36 @@ struct MenuDisplayModelTests {
         #expect(WatchItemDetailDisplay(stateLabel: "Watch", reason: "BackOff", latestWarning: warning).hasExpandedContent)
     }
 
+    @Test("pod item display keeps legacy resource progress compatibility")
+    func podItemDisplayKeepsLegacyResourceProgressCompatibility() {
+        let split = PodItemDisplay(
+            namespace: "api",
+            name: "checkout",
+            state: .ready,
+            readyLabel: "1/1",
+            resourceLabel: "CPU 40% req · Mem 70% limit",
+            cpuProgress: 0.4,
+            memoryProgress: 0.7,
+            helpText: "api/checkout",
+            accessibilityLabel: "api/checkout"
+        )
+        let legacy = PodItemDisplay(
+            namespace: "api",
+            name: "checkout",
+            state: .ready,
+            readyLabel: "1/1",
+            resourceLabel: "CPU 60% req · Mem 60% limit",
+            resourceProgress: 0.6,
+            helpText: "api/checkout",
+            accessibilityLabel: "api/checkout"
+        )
+
+        #expect(split.resourceProgress == 0.7)
+        #expect(legacy.cpuProgress == 0.6)
+        #expect(legacy.memoryProgress == 0.6)
+        #expect(legacy.resourceProgress == 0.6)
+    }
+
     @Test("warning event display summary includes occurrence count only when repeated")
     func warningEventDisplaySummaryIncludesOccurrenceCountOnlyWhenRepeated() {
         let single = WarningEventDisplay(

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -39,6 +39,9 @@ These are the rules Kubebar must keep true at runtime.
 - CPU and memory cards use `kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes`
   and node allocatable values. Missing Metrics API data is a card-level
   unavailable state, not a cluster-health failure by itself.
+- Resource usage visualization is display-only. Overview cards, node rows, and
+  Pod rows may show compact progress bars from current snapshot data, but those
+  bars must not decide `OK`, `Watch`, `Bad`, or `Stale`.
 - Nodes tab rows come from `MenuDisplayModel` node display data. They show node
   name, readiness, CPU, and memory without letting the view decide health.
 - Not Ready node rows must be distinguishable without relying on color alone
@@ -61,6 +64,9 @@ These are the rules Kubebar must keep true at runtime.
   include the row status.
 - Missing per-Pod container totals show unavailable values such as `-`; missing
   values must not be rendered as `0`.
+- Pod resource visualization keeps CPU and memory progress separate because
+  CPU uses request then limit as its comparison basis, while memory uses limit
+  then request.
 - Historical restart count alone must not make a Pod item Bad. Current failed,
   waiting, or crash-looping state may make a Pod item Bad.
 - Successfully completed Job Pods are not active readiness failures. They do

--- a/docs/plans/2026-05-12-001-feat-resource-usage-visualization-plan.md
+++ b/docs/plans/2026-05-12-001-feat-resource-usage-visualization-plan.md
@@ -1,0 +1,153 @@
+---
+title: feat: Add resource usage visualization
+type: feat
+status: planned
+date: 2026-05-12
+origin: .imm/specs/2026-05-12-resource-usage-visualization.md
+---
+
+# feat: Add resource usage visualization
+
+## Summary
+
+- Summary: Resource usage becomes visually scannable.
+
+Add lightweight current-snapshot CPU and memory visualization to the existing
+Overview, Nodes, and Pods resource displays. The work completes the existing
+progress-bar contract rather than adding a dashboard: users should be able to
+scan usage pressure faster while health state, stale handling, and unavailable
+metrics semantics stay unchanged.
+
+## Task
+
+- Type: feat
+- Scope: resource usage visualization
+- Owner: imm-work
+- Verification: automated
+
+## Origin
+
+The user asked to analyze current usage display and add charts to improve user
+experience. `imm-brainstorm` narrowed "charts" to lightweight resource usage
+visualization because prior Pod resource requirements explicitly excluded
+charts, trends, and external monitoring dependencies.
+
+## Research
+
+- `docs/architecture/runtime-invariants.md` requires UI to render
+  `MenuDisplayModel`, keeps `HealthEvaluator` as the source of severity, and
+  says missing CPU or memory values must not render as `0`.
+- `docs/brainstorms/2026-04-24-kubebar-pod-resource-display-requirements.md`
+  adds Pod resource text but explicitly excludes charts, history, trends, and
+  sparklines.
+- `docs/plans/2026-04-27-001-feat-ui-ux-improvements-plan.md` already planned
+  resource progress bars, and the code now has `InlineProgressBar` plus progress
+  fields on Overview, Node, and Pod display models.
+- `KubebarCore/Services/HealthEvaluator.swift` currently formats CPU and memory
+  text but does not consistently populate progress values.
+- `Kubebar/Views/OverviewTabView.swift`, `Kubebar/Views/NodeDetailsView.swift`,
+  and `Kubebar/Views/PodsTabView.swift` already contain conditional progress-bar
+  rendering paths.
+- `KubebarCore/Models/MenuDisplayModel.swift` has a single
+  `PodItemDisplay.resourceProgress`, which is ambiguous because Pod resource
+  text has separate CPU and Memory basis rules.
+- No `docs/solutions/` entry with `rejected: true` was found for this approach.
+- `CONTEXT.md` was added to make "resource usage visualization" the canonical
+  term and prevent "chart" from expanding into trends or dashboards.
+
+## Decisions
+
+- Treat this as one outcome unit: resource usage becomes visually scannable
+  across Overview, Nodes, and Pods.
+- Reuse existing metrics reads and display strings; do not add Kubernetes reads.
+- Compute progress in `HealthEvaluator` and pass it through `MenuDisplayModel`.
+- Model Pod CPU and Memory progress separately unless implementation proves a
+  single value is clearer and updates the spec before coding.
+- Keep `InlineProgressBar` as the first implementation vehicle; any visual
+  refinement must stay compact and native-feeling.
+- Clamp progress for rendering, but preserve unavailable values as `nil`.
+- Do not let resource progress affect health category decisions.
+
+## Assumptions
+
+- Existing node and pod metrics snapshots provide enough data to calculate all
+  current-state progress values.
+- A visual progress bar is sufficient for the requested "chart" improvement.
+- The menu should favor scanability and density over richer analytical charts.
+- No security-sensitive data is introduced because no new cluster resources or
+  external services are read.
+
+## Scope Boundaries
+
+- In scope: display-model progress mapping, compact SwiftUI rendering, focused
+  tests, and runtime documentation updates.
+- Out of scope: historical charts, trend lines, metrics storage, new thresholds,
+  alerting, external monitoring integrations, and health-state changes.
+
+## Implementation Units
+
+### Step 1
+
+- Step ID: U1
+- Result: Resource usage appears visually scannable.
+- Verification: ./scripts/swift-quality-gate.sh local
+- Depends on: None
+- Test scenarios: Overview progress values match metrics; missing metrics stay unavailable; node zero usage yields zero progress; pod CPU basis follows request then limit; pod memory basis follows limit then request; resource progress preserves health category
+
+**Goal:** Make CPU and memory usage visually scannable in Overview, Nodes, and
+Pods without changing health evaluation semantics.
+
+**Verification type:** automated
+
+**Execution note:** test-first
+
+**Requirements:** R1-R13
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `KubebarCore/Models/MenuDisplayModel.swift`
+- Modify: `KubebarCore/Services/HealthEvaluator.swift`
+- Modify: `Kubebar/Views/OverviewTabView.swift`
+- Modify: `Kubebar/Views/NodeDetailsView.swift`
+- Modify: `Kubebar/Views/PodsTabView.swift`
+- Modify: `Kubebar/Views/InlineProgressBar.swift`
+- Modify: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- Modify: `docs/architecture/runtime-invariants.md`
+- Reference: `.imm/specs/2026-05-12-resource-usage-visualization.md`
+- Reference: `CONTEXT.md`
+
+**Approach:**
+- Add or refine display-model fields so Overview, Node, and Pod rows can
+  distinguish CPU and Memory progress where both are shown.
+- Add a small progress calculation helper in `HealthEvaluator` that returns
+  `nil` for missing or invalid basis, returns `0` for valid zero usage, and
+  allows rendering to clamp high values.
+- Populate Overview CPU and Memory progress from node metrics over allocatable.
+- Populate node row CPU and Memory progress from per-node usage over
+  allocatable.
+- Populate Pod CPU progress using request then limit, and Pod Memory progress
+  using limit then request, matching existing compact text semantics.
+- Update SwiftUI rows to render compact CPU and Memory visuals without moving
+  names, readiness labels, or issue text out of view.
+- Keep help and accessibility text based on the existing complete resource
+  labels.
+- Update runtime invariants to record that resource visualization is
+  informational and unavailable metrics remain explicit.
+
+**Verification:**
+- `./scripts/swift-quality-gate.sh local`
+- `./scripts/compile-and-run.sh` for a visible-app smoke check when local macOS
+  launch is available.
+
+**failure_behavior:** If progress mapping is partially applied, affected rows
+must continue to show text labels and `nil` progress rather than misleading
+bars.
+
+**security_considerations:** No new Kubernetes resource reads, no Secrets, no
+external telemetry, and no command transcripts in UI.
+
+## Validation Notes
+
+- Use the system Immune-Brain CLI: `imm-plan
+  docs/plans/2026-05-12-001-feat-resource-usage-visualization-plan.md --json`.


### PR DESCRIPTION
## Summary
- Users can now scan CPU and memory usage with inline progress indicators in Overview, Nodes, and Pods.
- Pod resource display now keeps CPU and memory progress separate, while preserving the existing health model and unavailable-data behavior.
- Immune-Brain bootstrap files and the current iteration plan/spec were added so the step can be tracked in the local workflow.

## User Impact
- Users will notice faster glanceability for resource pressure in the menu.
- Missing metrics still show as unavailable instead of looking healthy.
- No health-category behavior changed.

## Changelog
- User-visible change: Add inline CPU and memory usage visualization to the Kubebar menu for Overview, Nodes, and Pods.

## Validation
- `swift build` passed.
- Display-model tests were added for current, missing, zero, and over-basis progress values.
- The full local quality gate could not complete in this environment because `xcodebuild` requires full Xcode and the active developer directory is Command Line Tools; Swift Testing was also unavailable in the current toolchain.

## Security Impact
- None.

## Blast Radius
- `KubebarCore/Models/MenuDisplayModel.swift`
- `KubebarCore/Services/HealthEvaluator.swift`
- `Kubebar/Views/PodsTabView.swift`
- `KubebarTests/Models/MenuDisplayModelTests.swift`
- `docs/architecture/runtime-invariants.md`
- `.imm/` workflow state, `IMMUNE.md`, and `CONTEXT.md`

## Rollback Plan
- Revert the resource-visualization code and test changes in the Swift sources.
- Remove the Immune-Brain bootstrap/spec/plan files if the workflow should not remain in the repo.
- Re-run the build and targeted tests after rollback to confirm the menu returns to text-only resource display.