### PR TITLE
fix(k9s): move list handoffs to group-level entries

### DIFF
--- a/.imm/memory/current_iteration.json
+++ b/.imm/memory/current_iteration.json
@@ -1,8 +1,312 @@
 {
-  "completed_steps": [],
-  "active_step": null,
-  "last_review": null,
-  "validated_plan_snapshot": null,
-  "history": [],
-  "requires_replan": false
+  "steps": {
+    "1": {
+      "step_id": "U1",
+      "state": "closed",
+      "result": "k9s list-level handoffs use group-level entries.",
+      "verification": "/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local",
+      "test_scenarios": [
+        "Pods namespace section exposes one k9s action for that namespace",
+        "Pod rows do not expose k9s actions",
+        "Nodes summary or header exposes one k9s action",
+        "Node rows do not expose k9s actions",
+        "Overview handoff remains visible in Bad QA state",
+        "app-owned context and resource view launcher tests remain green",
+        "Computer Use bad QA check confirms entry placement"
+      ],
+      "depends_on": [],
+      "agent_hint": null,
+      "activated_at": "2026-05-15T09:56:44Z",
+      "execution_evidence": {
+        "changed_files": [
+          "KubebarCore/Models/MenuDisplayModel.swift",
+          "KubebarCore/Services/HealthEvaluator.swift",
+          "Kubebar/Views/PodsTabView.swift",
+          "Kubebar/Views/NodeDetailsView.swift",
+          "KubebarCore/QA/MenuStateFixtureCatalog.swift",
+          "KubebarTests/Models/MenuDisplayModelTests.swift",
+          "KubebarTests/QA/MenuStateFixtureCatalogTests.swift",
+          "docs/architecture/runtime-invariants.md"
+        ],
+        "verification_command": "/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter MenuDisplayModelTests/listLevelResourcesExposeGroupLevelK9sHandoffTargets; /usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter \"MenuDisplayModelTests|MenuStateFixtureCatalogTests|K9sHandoffLauncherTests|K9sHandoffCoordinatorTests\"; /usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local; /usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/compile-and-run.sh --qa-state bad; Computer Use visible check",
+        "verification_result": "passed. RED confirmed missing PodNamespaceDisplay.k9sHandoff and NodeTabDisplay.k9sHandoff before implementation. GREEN targeted test passed. Related 85-test filter passed. Full swift-quality-gate local passed with 197 tests. compile-and-run bad launched QA app. Computer Use confirmed Overview still exposes Open qa-payments in k9s, Pods namespace headers expose Open <namespace> Pods in k9s while Pod rows do not, and Nodes summary exposes Open Nodes in k9s while Node rows do not.",
+        "notes": "List-level k9s landing points now match group-level UI entry placement; app-owned context launcher behavior left unchanged.",
+        "recorded_at": "2026-05-15T10:05:17Z"
+      },
+      "closed_at": "2026-05-15T10:05:42Z"
+    }
+  },
+  "last_review": {
+    "decision": "pass",
+    "evidence": "U1 ready_for_review evidence covers all seven scenarios: RED compile gap for new group-level fields, GREEN targeted model test, related 85-test filter, full swift-quality-gate local with 197 tests, compile-and-run bad QA launch, and Computer Use visible check for Overview, Pods namespace headers, Nodes summary, and no Pod/Node row buttons. imm-plan origin coverage complete with 9/9 mapped.",
+    "artifacts": "KubebarTests/Models/MenuDisplayModelTests.swift,KubebarTests/QA/MenuStateFixtureCatalogTests.swift,docs/architecture/runtime-invariants.md,Computer Use state for bad QA menu",
+    "notes": "",
+    "step_number": 1,
+    "step_id": "U1"
+  },
+  "history": [
+    {
+      "at": "2026-05-15T07:44:25Z",
+      "action": "sync_plan_from_imm_plan",
+      "details": {
+        "plan_path": "docs/plans/2026-05-15-001-feat-k9s-resource-handoff-plan.md",
+        "plan_signature": "cdb213490454716726ceb8148f75d13bf744631ebd4d0c0ed83677673dc0a2c3",
+        "plan_summary": "Resource rows can open the matching target in k9s.",
+        "same_plan": false
+      }
+    },
+    {
+      "at": "2026-05-15T07:44:59Z",
+      "action": "schema_migration_v1_to_v2",
+      "details": {
+        "migrated_completed_steps": [],
+        "migrated_active_step": null
+      }
+    },
+    {
+      "at": "2026-05-15T07:44:59Z",
+      "action": "sync_plan_from_imm_plan",
+      "details": {
+        "plan_path": "docs/plans/2026-05-15-001-feat-k9s-resource-handoff-plan.md",
+        "plan_signature": "cab110ecfa490ae49451ef16e86eebb7239bc1ecea3a14ff6e1892bc933a656c",
+        "plan_summary": "Resource rows can open the matching target in k9s.",
+        "same_plan": true
+      }
+    },
+    {
+      "at": "2026-05-15T07:46:29Z",
+      "action": "activate_step",
+      "details": {
+        "plan_path": "docs/plans/2026-05-15-001-feat-k9s-resource-handoff-plan.md",
+        "step_number": 1,
+        "step_id": "U1"
+      }
+    },
+    {
+      "at": "2026-05-15T07:53:17Z",
+      "action": "record_execution_evidence",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "changed_files": [
+          "KubebarCore/Models/MenuDisplayModel.swift",
+          "KubebarCore/Services/HealthEvaluator.swift",
+          "KubebarTests/Models/MenuDisplayModelTests.swift"
+        ]
+      }
+    },
+    {
+      "at": "2026-05-15T07:53:42Z",
+      "action": "review_step",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "decision": "pass"
+      }
+    },
+    {
+      "at": "2026-05-15T07:53:56Z",
+      "action": "activate_step",
+      "details": {
+        "plan_path": "docs/plans/2026-05-15-001-feat-k9s-resource-handoff-plan.md",
+        "step_number": 2,
+        "step_id": "U2"
+      }
+    },
+    {
+      "at": "2026-05-15T07:56:44Z",
+      "action": "record_execution_evidence",
+      "details": {
+        "step_number": 2,
+        "step_id": "U2",
+        "changed_files": [
+          "KubebarCore/Services/K9sHandoffLauncher.swift",
+          "KubebarCore/Services/K9sHandoffCoordinator.swift",
+          "KubebarTests/Services/K9sHandoffLauncherTests.swift",
+          "KubebarTests/Services/K9sHandoffCoordinatorTests.swift"
+        ]
+      }
+    },
+    {
+      "at": "2026-05-15T07:56:58Z",
+      "action": "review_step",
+      "details": {
+        "step_number": 2,
+        "step_id": "U2",
+        "decision": "pass"
+      }
+    },
+    {
+      "at": "2026-05-15T07:57:13Z",
+      "action": "activate_step",
+      "details": {
+        "plan_path": "docs/plans/2026-05-15-001-feat-k9s-resource-handoff-plan.md",
+        "step_number": 3,
+        "step_id": "U3"
+      }
+    },
+    {
+      "at": "2026-05-15T08:05:08Z",
+      "action": "record_execution_evidence",
+      "details": {
+        "step_number": 3,
+        "step_id": "U3",
+        "changed_files": [
+          "Kubebar/Views/MenuBarRootView.swift",
+          "Kubebar/Views/OverviewTabView.swift",
+          "Kubebar/Views/StatusSummaryView.swift",
+          "Kubebar/Views/NodesTabView.swift",
+          "Kubebar/Views/NodeDetailsView.swift",
+          "Kubebar/Views/PodsTabView.swift",
+          "Kubebar/Views/WatchlistSectionView.swift",
+          "Kubebar/MenuBarViewModel.swift",
+          "Kubebar/KubebarApp.swift",
+          "KubebarCore/QA/MenuStateFixtureCatalog.swift",
+          "KubebarTests/QA/MenuStateFixtureCatalogTests.swift",
+          "docs/architecture/runtime-invariants.md"
+        ]
+      }
+    },
+    {
+      "at": "2026-05-15T08:05:34Z",
+      "action": "review_step",
+      "details": {
+        "step_number": 3,
+        "step_id": "U3",
+        "decision": "pass"
+      }
+    },
+    {
+      "at": "2026-05-15T08:35:27Z",
+      "action": "sync_plan_reset_completed_steps",
+      "details": {
+        "from_plan": "docs/plans/2026-05-15-001-feat-k9s-resource-handoff-plan.md",
+        "to_plan": "docs/plans/2026-05-15-002-fix-k9s-handoff-entry-semantics-plan.md",
+        "reason": "Plan switched; reset completion state."
+      }
+    },
+    {
+      "at": "2026-05-15T08:35:27Z",
+      "action": "sync_plan_from_imm_plan",
+      "details": {
+        "plan_path": "docs/plans/2026-05-15-002-fix-k9s-handoff-entry-semantics-plan.md",
+        "plan_signature": "2b26a140be1cd1bf4ff506445434b557e6f5f528b870610e3f97ff9c4a73bc46",
+        "plan_summary": "k9s handoff entries follow the corrected landing contract.",
+        "same_plan": false
+      }
+    },
+    {
+      "at": "2026-05-15T08:40:42Z",
+      "action": "activate_step",
+      "details": {
+        "plan_path": "docs/plans/2026-05-15-002-fix-k9s-handoff-entry-semantics-plan.md",
+        "step_number": 1,
+        "step_id": "U1"
+      }
+    },
+    {
+      "at": "2026-05-15T08:45:36Z",
+      "action": "record_execution_evidence",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "changed_files": [
+          "KubebarCore/Models/MenuDisplayModel.swift",
+          "KubebarCore/Services/HealthEvaluator.swift",
+          "KubebarCore/Services/K9sHandoffLauncher.swift",
+          "KubebarCore/Services/K9sHandoffCoordinator.swift",
+          "Kubebar/Views/StatusSummaryView.swift",
+          "KubebarCore/QA/MenuStateFixtureCatalog.swift",
+          "KubebarTests/Models/MenuDisplayModelTests.swift",
+          "KubebarTests/Services/K9sHandoffLauncherTests.swift",
+          "KubebarTests/Services/K9sHandoffCoordinatorTests.swift",
+          "KubebarTests/QA/MenuStateFixtureCatalogTests.swift",
+          "docs/architecture/runtime-invariants.md"
+        ]
+      }
+    },
+    {
+      "at": "2026-05-15T08:45:57Z",
+      "action": "review_step",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "decision": "pass"
+      }
+    },
+    {
+      "at": "2026-05-15T09:48:03Z",
+      "action": "sync_plan_reset_completed_steps",
+      "details": {
+        "from_plan": "docs/plans/2026-05-15-002-fix-k9s-handoff-entry-semantics-plan.md",
+        "to_plan": "docs/plans/2026-05-15-003-fix-k9s-handoff-entry-placement-plan.md",
+        "reason": "Plan switched; reset completion state."
+      }
+    },
+    {
+      "at": "2026-05-15T09:48:03Z",
+      "action": "sync_plan_from_imm_plan",
+      "details": {
+        "plan_path": "docs/plans/2026-05-15-003-fix-k9s-handoff-entry-placement-plan.md",
+        "plan_signature": "f08b04669341b5f086d1bf0f6680547fc0a0422fec6080cdb99e079cb413cbbe",
+        "plan_summary": "k9s list-level handoffs use group-level entries.",
+        "same_plan": false
+      }
+    },
+    {
+      "at": "2026-05-15T09:56:44Z",
+      "action": "activate_step",
+      "details": {
+        "plan_path": "docs/plans/2026-05-15-003-fix-k9s-handoff-entry-placement-plan.md",
+        "step_number": 1,
+        "step_id": "U1"
+      }
+    },
+    {
+      "at": "2026-05-15T10:05:17Z",
+      "action": "record_execution_evidence",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "changed_files": [
+          "KubebarCore/Models/MenuDisplayModel.swift",
+          "KubebarCore/Services/HealthEvaluator.swift",
+          "Kubebar/Views/PodsTabView.swift",
+          "Kubebar/Views/NodeDetailsView.swift",
+          "KubebarCore/QA/MenuStateFixtureCatalog.swift",
+          "KubebarTests/Models/MenuDisplayModelTests.swift",
+          "KubebarTests/QA/MenuStateFixtureCatalogTests.swift",
+          "docs/architecture/runtime-invariants.md"
+        ]
+      }
+    },
+    {
+      "at": "2026-05-15T10:05:42Z",
+      "action": "review_step",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "decision": "pass"
+      }
+    }
+  ],
+  "requires_replan": false,
+  "schema_version": 2,
+  "plan_path": "docs/plans/2026-05-15-003-fix-k9s-handoff-entry-placement-plan.md",
+  "plan_summary": "k9s list-level handoffs use group-level entries.",
+  "plan_signature": "f08b04669341b5f086d1bf0f6680547fc0a0422fec6080cdb99e079cb413cbbe",
+  "plan_last_validated_at": "2026-05-15T10:05:32Z",
+  "validated_plan_snapshot": {
+    "plan_path": "docs/plans/2026-05-15-003-fix-k9s-handoff-entry-placement-plan.md",
+    "plan_signature": "f08b04669341b5f086d1bf0f6680547fc0a0422fec6080cdb99e079cb413cbbe",
+    "steps": [
+      {
+        "number": 1,
+        "step_id": "U1",
+        "result": "k9s list-level handoffs use group-level entries.",
+        "verification": "/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local",
+        "depends_on": []
+      }
+    ]
+  }
 }

--- a/.imm/specs/2026-05-15-k9s-handoff-entry-corrections.md
+++ b/.imm/specs/2026-05-15-k9s-handoff-entry-corrections.md
@@ -1,0 +1,75 @@
+---
+title: k9s handoff entry corrections
+date: 2026-05-15
+status: planned
+origin: imm-brainstorm manual validation feedback
+---
+
+# k9s Handoff Entry Corrections
+
+## Summary
+
+Manual validation found three mismatches in the new `Open in k9s` surface:
+the Overview error area can lose the handoff entry, Node rows open the Nodes
+view rather than a specific Node, and Pod rows open the Pods view for a
+namespace rather than a specific Pod.
+
+This correction keeps the handoff valuable while making the UI honest about
+where `k9s` lands. Kubebar remains a glanceable Kubernetes health tool.
+`k9s` remains the external deep inspection tool.
+
+## Goals
+
+- Overview error or abnormal status copy keeps a visible, reachable k9s handoff
+  entry when a valid fresh target exists.
+- Node row handoff is described and modeled as a Nodes view/list entry, not an
+  exact Node jump.
+- Pod row handoff is described and modeled as a namespace Pods view/list entry,
+  not an exact Pod jump.
+- All handoffs continue to use Kubebar's app-owned Kubernetes context.
+- Button labels, help text, accessibility labels, and failure feedback match
+  the actual `k9s` landing point.
+
+## Non-Goals
+
+- No k9s interactive keyboard automation for exact positioning.
+- No logs, describe, edit, exec, delete, port-forward, restart, or mutation
+  actions.
+- No Recent Warnings handoff in this slice.
+- No change to Health category evaluation.
+- No embedded terminal or command transcript display.
+
+## Requirements
+
+- R1. `MenuDisplayModel` remains the source of truth for every handoff
+  affordance.
+- R2. Overview must not hide a valid handoff action when the top status area
+  shows Watch or Bad error details.
+- R3. Node row handoff targets must not carry or expose copy that promises
+  exact Node positioning.
+- R4. Pod row handoff targets must not carry or expose copy that promises exact
+  Pod positioning.
+- R5. Pod row handoff copy must make the namespace-level Pods view/list landing
+  point clear.
+- R6. All handoffs must launch with app-owned context and namespace arguments
+  when applicable.
+- R7. Stale, setup, unavailable, or incomplete target states must continue to
+  omit misleading handoff actions.
+- R8. Failure copy must identify the intended stable entry point and must not
+  expose stderr, command lines, kubeconfig paths, or command output.
+- R9. QA fixtures or tests must cover the Overview state that previously lost
+  the handoff entry.
+
+## Verification Expectations
+
+- Display-model or evaluator tests prove Node and Pod row handoff targets use
+  stable list-level semantics.
+- Launcher tests prove app-owned context and namespace arguments are preserved
+  while Node and Pod commands no longer imply exact resource positioning.
+- View, view-model, or QA fixture tests prove Overview Watch or Bad error
+  detail states keep a visible handoff entry.
+- QA metadata describes the corrected Node and Pod landing points.
+- `./scripts/swift-quality-gate.sh local` passes before the correction is
+  complete.
+- Visible-app smoke checks the Overview, Pods, and Nodes handoff copy in a Bad
+  or Watch QA state.

--- a/.imm/specs/2026-05-15-k9s-handoff-entry-placement.md
+++ b/.imm/specs/2026-05-15-k9s-handoff-entry-placement.md
@@ -1,0 +1,72 @@
+---
+title: k9s handoff entry placement
+date: 2026-05-15
+status: planned
+origin: imm-brainstorm manual validation feedback
+---
+
+# k9s Handoff Entry Placement
+
+## Summary
+
+Manual validation confirmed that Pod and Node handoff targets now describe
+stable list-level `k9s` landing points, but their buttons still sit on concrete
+Pod and Node rows. That placement makes the user expect a specific resource
+jump even though `k9s` opens the namespace Pods view/list or the global Nodes
+view/list.
+
+This correction moves list-level handoff affordances to list-level UI
+locations. Kubebar remains a glanceable Kubernetes health tool. `k9s` remains
+the external inspection tool.
+
+## Goals
+
+- Pods tab exposes one k9s entry per namespace section, near the namespace
+  header.
+- Pod rows no longer show a k9s button that implies exact Pod positioning.
+- Nodes tab exposes one k9s entry near the Nodes readiness summary.
+- Node rows no longer show a k9s button that implies exact Node positioning.
+- Button labels, help text, accessibility labels, and QA expectations match
+  the stable list-level `k9s` landing point.
+- All entries continue to use Kubebar's app-owned Kubernetes context.
+
+## Non-Goals
+
+- No k9s interactive keyboard automation for exact Pod or Node positioning.
+- No logs, describe, edit, exec, delete, port-forward, restart, or mutation
+  actions.
+- No Recent Warnings handoff.
+- No change to Health category evaluation.
+- No change to resource usage visualization.
+
+## Requirements
+
+- R1. `MenuDisplayModel` remains the source of truth for k9s handoff
+  affordances.
+- R2. Namespace Pods handoff must be rendered at the namespace section level,
+  not on each Pod row.
+- R3. Nodes handoff must be rendered at the Nodes tab summary or header level,
+  not on each Node row.
+- R4. Row-level Pod and Node k9s buttons must be removed or hidden when the
+  target is list-level.
+- R5. User-facing copy and accessibility labels must describe `namespace Pods`
+  or `Nodes`, not a concrete Pod or Node.
+- R6. App-owned context and namespace/resource view launch arguments must be
+  preserved.
+- R7. Stale, setup, unavailable, or incomplete target states must not expose a
+  misleading handoff.
+- R8. QA fixtures or visible validation must cover the Bad state for Overview,
+  Pods, and Nodes entry placement.
+
+## Verification Expectations
+
+- Tests or fixture checks prove Pod handoff metadata appears at namespace
+  section scope and no longer appears as row-level actions.
+- Tests or fixture checks prove Node handoff metadata appears at tab summary
+  scope and no longer appears as row-level actions.
+- Existing launcher tests continue to prove app-owned context and resource
+  view arguments.
+- `./scripts/swift-quality-gate.sh local` passes.
+- A `bad` QA visible check verifies the Overview action remains visible, Pods
+  section-level action is near the namespace header, and Nodes action is near
+  the summary/header rather than on each row.

--- a/.imm/specs/2026-05-15-k9s-resource-handoff.md
+++ b/.imm/specs/2026-05-15-k9s-resource-handoff.md
@@ -1,0 +1,78 @@
+---
+title: k9s resource handoff
+date: 2026-05-15
+status: planned
+origin: imm-brainstorm handoff
+---
+
+# k9s Resource Handoff
+
+## Summary
+
+Kubebar already has a narrow `Open in k9s` action from the Overview top status
+detail. That action only opens `k9s` for the app-owned context and namespace.
+It does not help when the user is already looking at a concrete Pod, Node, or
+watched workload row and wants to continue in `k9s`.
+
+This feature expands the external handoff surface from a single Overview action
+to resource-level entry points in existing rows. Kubebar remains the
+glanceable status tool. `k9s` remains the deeper inspection tool.
+
+## Goals
+
+- Watchlist rows can open `k9s` for their namespace or workload target.
+- Pods tab rows can open `k9s` for the corresponding Pod.
+- Nodes tab rows can open `k9s` for the corresponding Node.
+- All handoffs use Kubebar's app-owned Kubernetes context.
+- Handoff feedback remains safe, short, and separate from Health category.
+
+## Non-Goals
+
+- No embedded terminal.
+- No logs, describe, edit, exec, delete, port-forward, or restart actions.
+- No raw command transcript display.
+- No Kubernetes watch streams.
+- No Recent Warnings handoff in this slice.
+- No resource-pressure alerting or historical resource dashboard.
+- No change to how `OK`, `Watch`, `Bad`, or `Stale` are evaluated.
+
+## Requirements
+
+- R1. `MenuDisplayModel` remains the only rendering input for k9s handoff
+  affordances.
+- R2. A handoff target must carry the app-owned context and enough safe target
+  data to open `k9s` without the view inferring Kubernetes semantics.
+- R3. Namespace handoff opens `k9s` with explicit context and namespace.
+- R4. Workload handoff opens the matching workload kind in its namespace when a
+  stable shallow `k9s` command shape exists.
+- R5. Pod handoff opens the Pod view in the Pod namespace and filters or
+  positions to the Pod name when supported by a stable shallow `k9s` command
+  shape.
+- R6. Node handoff opens the Node view and filters or positions to the Node
+  name when supported by a stable shallow `k9s` command shape.
+- R7. If exact filtering or positioning is not stable, the handoff must still
+  land on the closest safe resource view instead of simulating interactive
+  keystrokes.
+- R8. Stale, setup, unavailable, or target-incomplete states must not show a
+  broken or misleading handoff.
+- R9. Handoff UI must be deliberate button-style action, not automatic launch
+  or accidental primary-row activation.
+- R10. Launch state and failures must not alter Health category.
+- R11. Failure copy must identify the intended target using safe display text
+  and must not expose stderr, shell text, kubeconfig paths, or command output.
+- R12. Handoff affordances must be reachable by keyboard and understandable by
+  accessibility labels.
+
+## Verification Expectations
+
+- Display-model tests cover namespace, workload, Pod, and Node handoff targets.
+- Launcher tests cover explicit context, namespace, resource view, optional
+  filter values, and special-character safety.
+- Coordinator or view-model tests cover opening, duplicate activation, target
+  changes, and failure feedback.
+- UI or view-adjacent tests cover row-level deliberate actions and
+  accessibility labels.
+- `./scripts/swift-quality-gate.sh local` passes before implementation is
+  complete.
+- A visible-app smoke check confirms row affordances fit without crowding
+  first-scan resource information when local macOS launch is available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-05-15
+
+### Added
+- Add `Open in k9s` handoffs for fresh attention rows, Pod namespace groups, and the Nodes summary.
+
+### Fixed
+- Keep Pod and Node k9s handoff buttons at the list level they actually open, avoiding misleading row-level resource jumps.
+
 ## [0.2.3] - 2026-05-14
 
 ### Added

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,25 +2,24 @@
 
 ## Current State
 
-- Plan: `docs/plans/2026-05-14-002-feat-pod-resource-readability-plan.md`
+- Plan: `docs/plans/2026-05-15-003-fix-k9s-handoff-entry-placement-plan.md`
 - Status: complete
-- Completed steps: U1 `Pods tab resource details are easier to scan.`
+- Completed steps: U1 `k9s list-level handoffs use group-level entries.`
 - Latest review: pass
 
 ## Verification
 
 - `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local`
-- `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer KUBEBAR_QA_STATE=watch ./scripts/compile-and-run.sh`
+- `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/compile-and-run.sh --qa-state bad`
+- Computer Use Bad QA visible check
 
 ## Notes
 
-- Pod resource row labels now use readable basis wording such as `of request`
-  and `of limit` instead of abbreviation-only `req` text.
-- Pod help/accessibility resource detail now spells out CPU and Memory usage,
-  request, and limit values; missing values show as `unavailable` instead of
-  slash triples like `-/-/-`.
-- Health category behavior and separate CPU/memory progress values are
-  preserved.
-- Automated UI introspection could not read the menu bar app window; visible
-  smoke evidence is successful `watch` QA-state launch plus model coverage.
+- Overview Watch/Bad QA fixtures retain an `Open in k9s` handoff target.
+- Pod namespace headers now expose namespace Pods view/list handoffs.
+- Pod rows no longer expose list-level k9s handoffs.
+- Nodes summary now exposes the Nodes view/list handoff.
+- Node rows no longer expose list-level k9s handoffs.
+- Launcher arguments keep app-owned context and namespace/resource view values.
+- Stale/setup/unavailable gating remains covered.
 - No known blockers.

--- a/Kubebar/KubebarApp.swift
+++ b/Kubebar/KubebarApp.swift
@@ -93,7 +93,7 @@ private struct QAFixtureMenuRootView: View {
             onRefresh: {},
             onPrepareSettings: {},
             k9sHandoffState: .idle,
-            onOpenK9sHandoff: {},
+            onOpenK9sHandoff: { _ in },
             onQuit: { NSApplication.shared.terminate(nil) }
         )
     }

--- a/Kubebar/MenuBarViewModel.swift
+++ b/Kubebar/MenuBarViewModel.swift
@@ -377,19 +377,7 @@ final class MenuBarViewModel: ObservableObject {
     }
 
     private var availableK9sHandoffs: [OverviewK9sHandoff] {
-        var handoffs: [OverviewK9sHandoff] = []
-
-        if let overviewHandoff = display.overview.k9sHandoff {
-            handoffs.append(overviewHandoff)
-        }
-
-        handoffs += display.visibleWatchItems.compactMap(\.k9sHandoff)
-        handoffs += display.nodeTab.rows.compactMap(\.k9sHandoff)
-        handoffs += display.podTab.sections.flatMap { section in
-            section.rows.compactMap(\.k9sHandoff)
-        }
-
-        return handoffs
+        display.k9sHandoffs
     }
 
     private func scheduleFreshnessTimer(now: Date = Date()) {

--- a/Kubebar/MenuBarViewModel.swift
+++ b/Kubebar/MenuBarViewModel.swift
@@ -68,7 +68,7 @@ final class MenuBarViewModel: ObservableObject {
         self.k9sHandoffCoordinator.onStateChange = { [weak self] state in
             self?.k9sHandoffState = state
         }
-        self.k9sHandoffCoordinator.resetIfTargetUnavailable(display.overview.k9sHandoff)
+        resetK9sHandoffStateForCurrentDisplay()
 
         if runtimeState.isShowingSetup {
             loadContextsIfNeeded()
@@ -326,7 +326,7 @@ final class MenuBarViewModel: ObservableObject {
         snapshot = result.snapshot
         display = result.display
         staleReason = result.display.staleBanner?.reason
-        k9sHandoffCoordinator.resetIfTargetUnavailable(display.overview.k9sHandoff)
+        resetK9sHandoffStateForCurrentDisplay()
         k9sHandoffState = k9sHandoffCoordinator.state
         scheduleFreshnessTimer()
     }
@@ -355,12 +355,41 @@ final class MenuBarViewModel: ObservableObject {
         }
 
         staleReason = display.staleBanner?.reason
-        k9sHandoffCoordinator.resetIfTargetUnavailable(display.overview.k9sHandoff)
+        resetK9sHandoffStateForCurrentDisplay()
         k9sHandoffState = k9sHandoffCoordinator.state
     }
 
     func openK9sHandoff() {
         k9sHandoffCoordinator.open(for: display.overview.k9sHandoff)
+    }
+
+    func openK9sHandoff(_ handoff: OverviewK9sHandoff) {
+        k9sHandoffCoordinator.open(for: handoff)
+    }
+
+    private func resetK9sHandoffStateForCurrentDisplay() {
+        guard let target = k9sHandoffCoordinator.state.target else {
+            return
+        }
+
+        let availableTarget = availableK9sHandoffs.first { $0 == target }
+        k9sHandoffCoordinator.resetIfTargetUnavailable(availableTarget)
+    }
+
+    private var availableK9sHandoffs: [OverviewK9sHandoff] {
+        var handoffs: [OverviewK9sHandoff] = []
+
+        if let overviewHandoff = display.overview.k9sHandoff {
+            handoffs.append(overviewHandoff)
+        }
+
+        handoffs += display.visibleWatchItems.compactMap(\.k9sHandoff)
+        handoffs += display.nodeTab.rows.compactMap(\.k9sHandoff)
+        handoffs += display.podTab.sections.flatMap { section in
+            section.rows.compactMap(\.k9sHandoff)
+        }
+
+        return handoffs
     }
 
     private func scheduleFreshnessTimer(now: Date = Date()) {

--- a/Kubebar/Views/MenuBarRootView.swift
+++ b/Kubebar/Views/MenuBarRootView.swift
@@ -9,7 +9,7 @@ struct MenuBarRootView: View {
     let onRefresh: () -> Void
     let onPrepareSettings: () -> Void
     let k9sHandoffState: K9sHandoffLaunchState
-    let onOpenK9sHandoff: () -> Void
+    let onOpenK9sHandoff: (OverviewK9sHandoff) -> Void
     let onQuit: () -> Void
     @Environment(\.openSettings) private var openSettings
     @State private var selectedTab: MenuTab = .overview
@@ -128,9 +128,18 @@ struct MenuBarRootView: View {
                 onOpenK9sHandoff: onOpenK9sHandoff
             )
         case .nodes:
-            NodesTabView(display: display)
+            NodesTabView(
+                display: display,
+                k9sHandoffState: k9sHandoffState,
+                onOpenK9sHandoff: onOpenK9sHandoff
+            )
         case .pods:
-            PodsTabView(display: display, itemsMaxHeight: podItemsMaxHeight)
+            PodsTabView(
+                display: display,
+                itemsMaxHeight: podItemsMaxHeight,
+                k9sHandoffState: k9sHandoffState,
+                onOpenK9sHandoff: onOpenK9sHandoff
+            )
         case .events:
             EventsTabView(display: display)
         }

--- a/Kubebar/Views/NodeDetailsView.swift
+++ b/Kubebar/Views/NodeDetailsView.swift
@@ -3,6 +3,8 @@ import KubebarCore
 
 struct NodeDetailsView: View {
     let display: NodeTabDisplay
+    let k9sHandoffState: K9sHandoffLaunchState
+    let onOpenK9sHandoff: (OverviewK9sHandoff) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -24,11 +26,28 @@ struct NodeDetailsView: View {
 
     private var summary: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("Node readiness")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Node readiness")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Spacer(minLength: 8)
+
+                if let handoff = display.k9sHandoff {
+                    openK9sButton(for: handoff)
+                }
+            }
 
             readableText(display.unavailableMessage ?? display.summary)
+
+            if let feedbackMessage {
+                Text(feedbackMessage)
+                    .font(.caption)
+                    .foregroundStyle(feedbackColor)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(Text(feedbackMessage))
+            }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(display.unavailableMessage ?? display.summary)
@@ -43,6 +62,33 @@ struct NodeDetailsView: View {
             .truncationMode(.middle)
             .help(Text(value))
             .accessibilityLabel(value)
+    }
+
+    private func openK9sButton(for handoff: OverviewK9sHandoff) -> some View {
+        Button {
+            onOpenK9sHandoff(handoff)
+        } label: {
+            Image(systemName: "arrow.right")
+                .font(.caption)
+        }
+        .buttonStyle(.borderless)
+        .controlSize(.small)
+        .help(Text(handoff.helpText))
+        .accessibilityLabel(handoff.accessibilityLabel)
+        .accessibilityHint(Text(handoff.buttonLabel(for: k9sHandoffState)))
+        .disabled(k9sHandoffState.blocksNewHandoff(for: handoff))
+    }
+
+    private var feedbackMessage: String? {
+        display.k9sHandoff.flatMap(k9sHandoffState.feedbackMessage)
+    }
+
+    private var feedbackColor: Color {
+        if case .failed = k9sHandoffState {
+            return .red
+        }
+
+        return .secondary
     }
 }
 
@@ -61,6 +107,28 @@ private struct NodeRowView: View {
     }
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            nodeContent
+        }
+        .padding(isErrorState ? Style.errorPadding : 0)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            if isErrorState {
+                RoundedRectangle(cornerRadius: Style.errorCornerRadius)
+                    .fill(Color.red.opacity(Style.errorBackgroundOpacity))
+            }
+        }
+        .overlay {
+            if isErrorState {
+                RoundedRectangle(cornerRadius: Style.errorCornerRadius)
+                    .strokeBorder(Color.red.opacity(Style.errorBorderOpacity), lineWidth: 1)
+            }
+        }
+        .help(Text(row.helpText))
+        .accessibilityElement(children: .contain)
+    }
+
+    private var nodeContent: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(row.name)
@@ -89,21 +157,7 @@ private struct NodeRowView: View {
             }
             .padding(.top, 2)
         }
-        .padding(isErrorState ? Style.errorPadding : 0)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background {
-            if isErrorState {
-                RoundedRectangle(cornerRadius: Style.errorCornerRadius)
-                    .fill(Color.red.opacity(Style.errorBackgroundOpacity))
-            }
-        }
-        .overlay {
-            if isErrorState {
-                RoundedRectangle(cornerRadius: Style.errorCornerRadius)
-                    .strokeBorder(Color.red.opacity(Style.errorBorderOpacity), lineWidth: 1)
-            }
-        }
-        .help(Text(row.helpText))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(row.accessibilityLabel)
         .focusable()

--- a/Kubebar/Views/NodesTabView.swift
+++ b/Kubebar/Views/NodesTabView.swift
@@ -3,11 +3,17 @@ import KubebarCore
 
 struct NodesTabView: View {
     let display: MenuDisplayModel
+    let k9sHandoffState: K9sHandoffLaunchState
+    let onOpenK9sHandoff: (OverviewK9sHandoff) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             StaleBannerView(banner: display.staleBanner)
-            NodeDetailsView(display: display.nodeTab)
+            NodeDetailsView(
+                display: display.nodeTab,
+                k9sHandoffState: k9sHandoffState,
+                onOpenK9sHandoff: onOpenK9sHandoff
+            )
         }
     }
 }

--- a/Kubebar/Views/OverviewTabView.swift
+++ b/Kubebar/Views/OverviewTabView.swift
@@ -4,7 +4,7 @@ import KubebarCore
 struct OverviewTabView: View {
     let display: MenuDisplayModel
     let k9sHandoffState: K9sHandoffLaunchState
-    let onOpenK9sHandoff: () -> Void
+    let onOpenK9sHandoff: (OverviewK9sHandoff) -> Void
 
     private let columns = [
         GridItem(.flexible(), spacing: 8),

--- a/Kubebar/Views/PodsTabView.swift
+++ b/Kubebar/Views/PodsTabView.swift
@@ -4,11 +4,20 @@ import KubebarCore
 struct PodsTabView: View {
     let display: MenuDisplayModel
     let itemsMaxHeight: CGFloat
+    let k9sHandoffState: K9sHandoffLaunchState
+    let onOpenK9sHandoff: (OverviewK9sHandoff) -> Void
     @State private var podItemsContentHeight: CGFloat = 0
 
-    init(display: MenuDisplayModel, itemsMaxHeight: CGFloat = Layout.defaultItemsMaxHeight) {
+    init(
+        display: MenuDisplayModel,
+        itemsMaxHeight: CGFloat = Layout.defaultItemsMaxHeight,
+        k9sHandoffState: K9sHandoffLaunchState,
+        onOpenK9sHandoff: @escaping (OverviewK9sHandoff) -> Void
+    ) {
         self.display = display
         self.itemsMaxHeight = itemsMaxHeight
+        self.k9sHandoffState = k9sHandoffState
+        self.onOpenK9sHandoff = onOpenK9sHandoff
     }
 
     var body: some View {
@@ -66,7 +75,11 @@ struct PodsTabView: View {
     private var podItemsContent: some View {
         VStack(alignment: .leading, spacing: 12) {
             ForEach(display.podTab.sections) { section in
-                PodNamespaceSectionView(section: section)
+                PodNamespaceSectionView(
+                    section: section,
+                    k9sHandoffState: k9sHandoffState,
+                    onOpenK9sHandoff: onOpenK9sHandoff
+                )
             }
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -99,19 +112,38 @@ struct PodsTabView: View {
 
 private struct PodNamespaceSectionView: View {
     let section: PodNamespaceDisplay
+    let k9sHandoffState: K9sHandoffLaunchState
+    let onOpenK9sHandoff: (OverviewK9sHandoff) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Label(section.namespace, systemImage: "folder.fill")
-                .font(.caption.weight(.bold))
-                .foregroundStyle(.primary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .help(Text(section.namespace))
-                .accessibilityLabel(section.namespace)
-                .padding(.vertical, 4)
-                .padding(.horizontal, 6)
-                .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 4))
+            HStack(alignment: .center, spacing: 8) {
+                Label(section.namespace, systemImage: "folder.fill")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(Text(section.namespace))
+                    .accessibilityLabel(section.namespace)
+
+                Spacer(minLength: 8)
+
+                if let handoff = section.k9sHandoff {
+                    openK9sButton(for: handoff)
+                }
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 6)
+            .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 4))
+
+            if let feedbackMessage {
+                Text(feedbackMessage)
+                    .font(.caption)
+                    .foregroundStyle(feedbackColor)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(Text(feedbackMessage))
+            }
 
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(section.rows) { row in
@@ -119,6 +151,33 @@ private struct PodNamespaceSectionView: View {
                 }
             }
         }
+    }
+
+    private func openK9sButton(for handoff: OverviewK9sHandoff) -> some View {
+        Button {
+            onOpenK9sHandoff(handoff)
+        } label: {
+            Image(systemName: "arrow.right")
+                .font(.caption)
+        }
+        .buttonStyle(.borderless)
+        .controlSize(.small)
+        .help(Text(handoff.helpText))
+        .accessibilityLabel(handoff.accessibilityLabel)
+        .accessibilityHint(Text(handoff.buttonLabel(for: k9sHandoffState)))
+        .disabled(k9sHandoffState.blocksNewHandoff(for: handoff))
+    }
+
+    private var feedbackMessage: String? {
+        section.k9sHandoff.flatMap(k9sHandoffState.feedbackMessage)
+    }
+
+    private var feedbackColor: Color {
+        if case .failed = k9sHandoffState {
+            return .red
+        }
+
+        return .secondary
     }
 }
 
@@ -142,74 +201,79 @@ private struct PodRowView: View {
     }
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Circle()
-                .fill(statusColor)
-                .frame(width: 7, height: 7)
-                .opacity(shouldPulse && isPulsing ? 0.4 : 1.0)
-                .animation(shouldPulse ? Animation.easeInOut(duration: 0.8).repeatForever() : .default, value: isPulsing)
-                .onAppear {
-                    updatePulse()
-                }
-                .onChange(of: shouldPulse) { _, _ in
-                    updatePulse()
-                }
-                .accessibilityHidden(true)
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 7, height: 7)
+                    .opacity(shouldPulse && isPulsing ? 0.4 : 1.0)
+                    .animation(shouldPulse ? Animation.easeInOut(duration: 0.8).repeatForever() : .default, value: isPulsing)
+                    .onAppear {
+                        updatePulse()
+                    }
+                    .onChange(of: shouldPulse) { _, _ in
+                        updatePulse()
+                    }
+                    .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text(row.name)
-                        .font(.caption.weight(.semibold))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .help(Text(row.name))
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(row.name)
+                            .font(.caption.weight(.semibold))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .help(Text(row.name))
 
-                    Spacer(minLength: 8)
+                        Spacer(minLength: 8)
 
-                    Text(row.readyLabel)
-                        .font(.caption.weight(.semibold))
-                        .monospacedDigit()
-                        .foregroundStyle(.primary.opacity(0.7))
-                        .lineLimit(1)
-                }
+                        Text(row.readyLabel)
+                            .font(.caption.weight(.semibold))
+                            .monospacedDigit()
+                            .foregroundStyle(.primary.opacity(0.7))
+                            .lineLimit(1)
+                    }
 
-                if let issueText = row.issueText {
-                    Text(issueText)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .help(Text(issueText))
-                }
-
-                if !row.resourceLabel.isEmpty {
-                    HStack(spacing: 4) {
-                        Text(row.resourceLabel)
+                    if let issueText = row.issueText {
+                        Text(issueText)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .truncationMode(.middle)
-                            .help(Text(row.resourceLabel))
+                            .help(Text(issueText))
+                    }
 
-                        ResourceProgressPair(
-                            cpuProgress: row.cpuProgress,
-                            memoryProgress: row.memoryProgress
-                        )
-                        .padding(.leading, 2)
+                    if !row.resourceLabel.isEmpty {
+                        HStack(spacing: 4) {
+                            Text(row.resourceLabel)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .help(Text(row.resourceLabel))
+
+                            ResourceProgressPair(
+                                cpuProgress: row.cpuProgress,
+                                memoryProgress: row.memoryProgress
+                            )
+                            .padding(.leading, 2)
+                        }
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(row.accessibilityLabel)
+                .focusable()
+
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .help(Text(row.helpText))
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(row.accessibilityLabel)
-        .focusable()
+        .accessibilityElement(children: .contain)
     }
 
     private func updatePulse() {
         isPulsing = shouldPulse
     }
+
 }
 
 private struct ResourceProgressPair: View {

--- a/Kubebar/Views/StatusSummaryView.swift
+++ b/Kubebar/Views/StatusSummaryView.swift
@@ -4,7 +4,7 @@ import KubebarCore
 struct StatusSummaryView: View {
     let display: MenuDisplayModel
     let k9sHandoffState: K9sHandoffLaunchState
-    let onOpenK9sHandoff: () -> Void
+    let onOpenK9sHandoff: (OverviewK9sHandoff) -> Void
 
     private var presentation: MenuBarStatusPresentation {
         MenuBarStatusPresentation(state: display.state)
@@ -33,6 +33,8 @@ struct StatusSummaryView: View {
                 }
                 .font(.subheadline)
                 .help(Text(display.overview.statusHelpText))
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(display.overview.statusAccessibilityLabel)
             }
 
             if let handoff = display.overview.k9sHandoff {
@@ -40,12 +42,9 @@ struct StatusSummaryView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     handoffStatusRow(text: message, for: handoff)
                 }
-                .accessibilityElement(children: .contain)
-                .accessibilityLabel("Open watched target in k9s")
             }
         }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(display.overview.statusAccessibilityLabel)
+        .accessibilityElement(children: .contain)
         .focusable()
     }
 
@@ -64,7 +63,9 @@ struct StatusSummaryView: View {
     }
 
     private func openK9sButton(for handoff: OverviewK9sHandoff) -> some View {
-        Button(action: onOpenK9sHandoff) {
+        Button {
+            onOpenK9sHandoff(handoff)
+        } label: {
             Image(systemName: "arrow.right")
                 .font(.caption)
         }
@@ -74,13 +75,13 @@ struct StatusSummaryView: View {
         .help(Text(handoff.helpText))
         .accessibilityLabel(handoff.accessibilityLabel)
         .accessibilityHint(Text(handoff.buttonLabel(for: k9sHandoffState)))
-        .disabled(k9sHandoffState.isOpeningForSameTarget(handoff))
+        .disabled(k9sHandoffState.blocksNewHandoff(for: handoff))
     }
 }
 
-private extension OverviewK9sHandoff {
+extension OverviewK9sHandoff {
     func buttonLabel(for state: K9sHandoffLaunchState) -> String {
-        if state.isOpeningForSameTarget(self) {
+        if state.blocksNewHandoff(for: self) {
             return "Opening in k9s..."
         }
 

--- a/Kubebar/Views/WatchlistSectionView.swift
+++ b/Kubebar/Views/WatchlistSectionView.swift
@@ -3,6 +3,8 @@ import KubebarCore
 
 struct WatchlistSectionView: View {
     let display: MenuDisplayModel
+    let k9sHandoffState: K9sHandoffLaunchState
+    let onOpenK9sHandoff: (OverviewK9sHandoff) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -36,37 +38,91 @@ struct WatchlistSectionView: View {
                     TrackedItemDetailView(item: item)
                 },
                 label: {
-                    WatchlistRowView(item: item)
+                    WatchlistRowView(
+                        item: item,
+                        k9sHandoffState: k9sHandoffState,
+                        onOpenK9sHandoff: onOpenK9sHandoff
+                    )
                 }
             )
         } else {
-            WatchlistRowView(item: item)
-                .focusable()
+            WatchlistRowView(
+                item: item,
+                k9sHandoffState: k9sHandoffState,
+                onOpenK9sHandoff: onOpenK9sHandoff
+            )
         }
     }
 }
 
 private struct WatchlistRowView: View {
     let item: WatchItemDisplay
+    let k9sHandoffState: K9sHandoffLaunchState
+    let onOpenK9sHandoff: (OverviewK9sHandoff) -> Void
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(item.title)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .help(Text(item.title))
-                    .accessibilityLabel(item.title)
-                Text(item.reason)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.title)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .help(Text(item.title))
+                        .accessibilityLabel(item.title)
+                    Text(item.reason)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .accessibilityElement(children: .combine)
+                .focusable()
+
+                Spacer()
+
+                Text(item.state.label)
+                    .font(.caption.weight(.semibold))
+
+                if let handoff = item.k9sHandoff {
+                    openK9sButton(for: handoff)
+                }
             }
 
-            Spacer()
-
-            Text(item.state.label)
-                .font(.caption.weight(.semibold))
+            if let feedbackMessage {
+                Text(feedbackMessage)
+                    .font(.caption)
+                    .foregroundStyle(feedbackColor)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(Text(feedbackMessage))
+            }
         }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func openK9sButton(for handoff: OverviewK9sHandoff) -> some View {
+        Button {
+            onOpenK9sHandoff(handoff)
+        } label: {
+            Image(systemName: "arrow.right")
+                .font(.caption)
+        }
+        .buttonStyle(.borderless)
+        .controlSize(.small)
+        .help(Text(handoff.helpText))
+        .accessibilityLabel(handoff.accessibilityLabel)
+        .accessibilityHint(Text(handoff.buttonLabel(for: k9sHandoffState)))
+        .disabled(k9sHandoffState.blocksNewHandoff(for: handoff))
+    }
+
+    private var feedbackMessage: String? {
+        item.k9sHandoff.flatMap(k9sHandoffState.feedbackMessage)
+    }
+
+    private var feedbackColor: Color {
+        if case .failed = k9sHandoffState {
+            return .red
+        }
+
+        return .secondary
     }
 }

--- a/KubebarCore/Models/MenuDisplayModel.swift
+++ b/KubebarCore/Models/MenuDisplayModel.swift
@@ -607,6 +607,26 @@ public struct MenuDisplayModel: Equatable, Sendable {
         )
     }
 
+    public var k9sHandoffs: [OverviewK9sHandoff] {
+        var handoffs: [OverviewK9sHandoff] = []
+
+        if let overviewHandoff = overview.k9sHandoff {
+            handoffs.append(overviewHandoff)
+        }
+
+        handoffs += visibleWatchItems.compactMap(\.k9sHandoff)
+        if let nodeTabHandoff = nodeTab.k9sHandoff {
+            handoffs.append(nodeTabHandoff)
+        }
+        handoffs += nodeTab.rows.compactMap(\.k9sHandoff)
+        handoffs += podTab.sections.compactMap(\.k9sHandoff)
+        handoffs += podTab.sections.flatMap { section in
+            section.rows.compactMap(\.k9sHandoff)
+        }
+
+        return handoffs
+    }
+
     private static func makeOverview(
         contextName: String,
         state: ClusterHealthState,

--- a/KubebarCore/Models/MenuDisplayModel.swift
+++ b/KubebarCore/Models/MenuDisplayModel.swift
@@ -143,19 +143,22 @@ public struct WatchItemDisplay: Equatable, Sendable, Identifiable {
     public let state: ClusterHealthState
     public let reason: String
     public let detail: WatchItemDetailDisplay
+    public let k9sHandoff: OverviewK9sHandoff?
 
     public init(
         id: String,
         title: String,
         state: ClusterHealthState,
         reason: String,
-        detail: WatchItemDetailDisplay? = nil
+        detail: WatchItemDetailDisplay? = nil,
+        k9sHandoff: OverviewK9sHandoff? = nil
     ) {
         self.id = id
         self.title = title
         self.state = state
         self.reason = reason
         self.detail = detail ?? WatchItemDetailDisplay(stateLabel: state.label, reason: reason)
+        self.k9sHandoff = k9sHandoff
     }
 }
 
@@ -176,13 +179,59 @@ public struct OverviewNoticeDisplay: Equatable, Sendable, Identifiable {
     }
 }
 
+public enum K9sResourceTarget: Equatable, Sendable {
+    case namespace(String)
+    case workload(namespace: String, name: String, kind: WorkloadKind)
+    case podList(namespace: String)
+    case nodeList
+
+    public var namespace: String? {
+        switch self {
+        case let .namespace(namespace):
+            namespace
+        case let .workload(namespace, _, _):
+            namespace
+        case let .podList(namespace):
+            namespace
+        case .nodeList:
+            nil
+        }
+    }
+
+    public var displayName: String {
+        switch self {
+        case let .namespace(namespace):
+            namespace
+        case let .workload(namespace, name, _):
+            "\(namespace)/\(name)"
+        case let .podList(namespace):
+            "\(namespace) Pods"
+        case .nodeList:
+            "Nodes"
+        }
+    }
+}
+
 public struct K9sHandoffTarget: Equatable, Sendable {
     public let contextName: String
-    public let namespace: String
+    public let resource: K9sResourceTarget
 
     public init(contextName: String, namespace: String) {
         self.contextName = contextName
-        self.namespace = namespace
+        self.resource = .namespace(namespace)
+    }
+
+    public init(contextName: String, resource: K9sResourceTarget) {
+        self.contextName = contextName
+        self.resource = resource
+    }
+
+    public var namespace: String {
+        resource.namespace ?? ""
+    }
+
+    public var displayName: String {
+        resource.displayName
     }
 }
 
@@ -222,6 +271,7 @@ public struct NodeItemDisplay: Equatable, Sendable, Identifiable {
     public let issueText: String?
     public let helpText: String
     public let accessibilityLabel: String
+    public let k9sHandoff: OverviewK9sHandoff?
 
     public init(
         name: String,
@@ -233,7 +283,8 @@ public struct NodeItemDisplay: Equatable, Sendable, Identifiable {
         memoryProgress: Double? = nil,
         issueText: String? = nil,
         helpText: String,
-        accessibilityLabel: String
+        accessibilityLabel: String,
+        k9sHandoff: OverviewK9sHandoff? = nil
     ) {
         self.id = name
         self.name = name
@@ -246,6 +297,7 @@ public struct NodeItemDisplay: Equatable, Sendable, Identifiable {
         self.issueText = issueText
         self.helpText = helpText
         self.accessibilityLabel = accessibilityLabel
+        self.k9sHandoff = k9sHandoff
     }
 }
 
@@ -255,19 +307,22 @@ public struct NodeTabDisplay: Equatable, Sendable {
     public let showsEmptyMessage: Bool
     public let unavailableMessage: String?
     public let emptyMessage: String
+    public let k9sHandoff: OverviewK9sHandoff?
 
     public init(
         summary: String,
         rows: [NodeItemDisplay] = [],
         showsEmptyMessage: Bool = false,
         unavailableMessage: String? = nil,
-        emptyMessage: String = "No node data yet. Refresh or check Settings."
+        emptyMessage: String = "No node data yet. Refresh or check Settings.",
+        k9sHandoff: OverviewK9sHandoff? = nil
     ) {
         self.summary = summary
         self.rows = rows
         self.showsEmptyMessage = showsEmptyMessage
         self.unavailableMessage = unavailableMessage
         self.emptyMessage = emptyMessage
+        self.k9sHandoff = k9sHandoff
     }
 }
 
@@ -300,6 +355,7 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
     public let issueText: String?
     public let helpText: String
     public let accessibilityLabel: String
+    public let k9sHandoff: OverviewK9sHandoff?
 
     public var resourceProgress: Double? {
         [cpuProgress, memoryProgress].compactMap(\.self).max()
@@ -315,7 +371,8 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
         memoryProgress: Double? = nil,
         issueText: String? = nil,
         helpText: String,
-        accessibilityLabel: String
+        accessibilityLabel: String,
+        k9sHandoff: OverviewK9sHandoff? = nil
     ) {
         self.id = "\(namespace)/\(name)"
         self.namespace = namespace
@@ -328,6 +385,7 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
         self.issueText = issueText
         self.helpText = helpText
         self.accessibilityLabel = accessibilityLabel
+        self.k9sHandoff = k9sHandoff
     }
 
     public init(
@@ -339,7 +397,8 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
         resourceProgress: Double?,
         issueText: String? = nil,
         helpText: String,
-        accessibilityLabel: String
+        accessibilityLabel: String,
+        k9sHandoff: OverviewK9sHandoff? = nil
     ) {
         self.init(
             namespace: namespace,
@@ -351,7 +410,8 @@ public struct PodItemDisplay: Equatable, Sendable, Identifiable {
             memoryProgress: resourceProgress,
             issueText: issueText,
             helpText: helpText,
-            accessibilityLabel: accessibilityLabel
+            accessibilityLabel: accessibilityLabel,
+            k9sHandoff: k9sHandoff
         )
     }
 }
@@ -360,11 +420,17 @@ public struct PodNamespaceDisplay: Equatable, Sendable, Identifiable {
     public let id: String
     public let namespace: String
     public let rows: [PodItemDisplay]
+    public let k9sHandoff: OverviewK9sHandoff?
 
-    public init(namespace: String, rows: [PodItemDisplay]) {
+    public init(
+        namespace: String,
+        rows: [PodItemDisplay],
+        k9sHandoff: OverviewK9sHandoff? = nil
+    ) {
         self.id = namespace
         self.namespace = namespace
         self.rows = rows
+        self.k9sHandoff = k9sHandoff
     }
 }
 

--- a/KubebarCore/QA/MenuStateFixtureCatalog.swift
+++ b/KubebarCore/QA/MenuStateFixtureCatalog.swift
@@ -77,8 +77,9 @@ public enum MenuStateFixtureCatalog {
                 expectedBehavior: "Overview shows Watch with a pinned BackOff warning row."
                     + " The top detail includes a direct `Open in k9s` action for qa-api."
                     + " Hovering the top status explains the restarting qa-api Pod."
-                    + " Pods tab shows the watched Pod first with yellow dot, 0/1, and gray issue text.",
-                limitations: "Requires visible menu inspection to confirm reason-first warning copy, pinned marker, and card readability."
+                    + " Pods tab shows the watched Pod first with yellow dot, 0/1, and gray issue text."
+                    + " Pods namespace headers open the namespace Pods view/list in k9s.",
+                limitations: "Requires visible menu inspection to confirm reason-first warning copy, pinned marker, card readability, and namespace-header Pods k9s buttons."
             )
         case .bad:
             return makeFixture(
@@ -87,8 +88,10 @@ public enum MenuStateFixtureCatalog {
                 expectedBehavior: "Overview shows Bad and prioritizes the broken tracked target in the top row."
                     + " The top detail includes a direct `Open in k9s` action for qa-payments."
                     + " Hovering the top status names the affected qa-payments Pods."
-                    + " Pods tab shows failed Pods first with red dots and issue text.",
-                limitations: "Requires visible menu inspection to confirm top-row priority and card state."
+                    + " Pods tab shows failed Pods first with red dots and issue text."
+                    + " Pods namespace headers open the namespace Pods view/list in k9s."
+                    + " Nodes summary opens the Nodes view/list in k9s.",
+                limitations: "Requires visible menu inspection to confirm top-row priority, card state, namespace-header Pods buttons, and Nodes summary button."
             )
         case .staleRefreshFailure:
             return makeFixture(

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -71,12 +71,20 @@ public struct HealthEvaluator: Sendable {
         now: Date,
         staleAfterSeconds: Int?
     ) -> MenuDisplayModel {
-        let sortedItems = sortByAttention(snapshot.trackedItems)
-        let visibleLimit = visibleWatchItemLimit(for: sortedItems)
-        let visibleItems = sortedItems.prefix(visibleLimit).map { makeDisplayItem($0, now: now) }
-        let hiddenCount = max(0, sortedItems.count - visibleItems.count)
         let freshnessReason = staleAgeOutReason(for: snapshot, now: now, staleAfterSeconds: staleAfterSeconds)
         let resolvedState = stateOverride ?? (freshnessReason == nil ? evaluateState(snapshot) : .stale)
+        let allowsK9sHandoff = resolvedState != .stale
+        let sortedItems = sortByAttention(snapshot.trackedItems)
+        let visibleLimit = visibleWatchItemLimit(for: sortedItems)
+        let visibleItems = sortedItems.prefix(visibleLimit).map {
+            makeDisplayItem(
+                $0,
+                contextName: snapshot.contextName,
+                allowsK9sHandoff: allowsK9sHandoff,
+                now: now
+            )
+        }
+        let hiddenCount = max(0, sortedItems.count - visibleItems.count)
         let pinnedWarningIDs = pinnedWarningIDs(from: snapshot.trackedItems)
         let warningEventSummaries = makeWarningEventSummaries(
             from: snapshot.warningEventsSection.value ?? [],
@@ -131,8 +139,13 @@ public struct HealthEvaluator: Sendable {
                 totalWarningRows: overviewWarningRows.count,
                 k9sHandoff: k9sHandoffTarget(from: snapshot, state: resolvedState)
             ),
-            nodeTab: makeNodeTab(from: snapshot, sectionNotices: sectionNotices),
-            podTab: makePodTab(from: snapshot, visibleItems: Array(visibleItems), sectionNotices: sectionNotices),
+            nodeTab: makeNodeTab(from: snapshot, sectionNotices: sectionNotices, allowsK9sHandoff: allowsK9sHandoff),
+            podTab: makePodTab(
+                from: snapshot,
+                visibleItems: Array(visibleItems),
+                sectionNotices: sectionNotices,
+                allowsK9sHandoff: allowsK9sHandoff
+            ),
             eventsTab: makeEventsTab(from: snapshot, rows: warningEventSummaries, sectionNotices: sectionNotices)
         )
     }
@@ -286,12 +299,7 @@ public struct HealthEvaluator: Sendable {
             return nil
         }
 
-        return OverviewK9sHandoff(
-            target: target,
-            actionLabel: "Open in k9s",
-            helpText: "Open watched target in k9s",
-            accessibilityLabel: "Open watched target in k9s"
-        )
+        return k9sHandoff(for: target)
     }
 
     private func handoffTarget(for target: WatchTarget, contextName: String) -> K9sHandoffTarget? {
@@ -307,13 +315,76 @@ public struct HealthEvaluator: Sendable {
                 return nil
             }
 
-            return K9sHandoffTarget(contextName: normalizedContextName, namespace: normalizedNamespace)
-        case let .workload(namespace: namespace, _, _):
-            guard let normalizedNamespace = normalizedText(namespace), !normalizedNamespace.isEmpty else {
+            return K9sHandoffTarget(contextName: normalizedContextName, resource: .namespace(normalizedNamespace))
+        case let .workload(namespace: namespace, name, kind):
+            guard let normalizedNamespace = normalizedText(namespace), !normalizedNamespace.isEmpty,
+                  let normalizedName = normalizedText(name), !normalizedName.isEmpty
+            else {
                 return nil
             }
 
-            return K9sHandoffTarget(contextName: normalizedContextName, namespace: normalizedNamespace)
+            return K9sHandoffTarget(
+                contextName: normalizedContextName,
+                resource: .workload(namespace: normalizedNamespace, name: normalizedName, kind: kind)
+            )
+        }
+    }
+
+    private func k9sHandoff(for target: K9sHandoffTarget?) -> OverviewK9sHandoff? {
+        guard let target else {
+            return nil
+        }
+
+        return OverviewK9sHandoff(
+            target: target,
+            actionLabel: "Open in k9s",
+            helpText: "Open \(target.displayName) in k9s",
+            accessibilityLabel: "Open \(target.displayName) in k9s"
+        )
+    }
+
+    private func resourceHandoff(
+        contextName: String,
+        resource: K9sResourceTarget,
+        allowsK9sHandoff: Bool
+    ) -> OverviewK9sHandoff? {
+        guard allowsK9sHandoff,
+              let normalizedContextName = normalizedText(contextName), !normalizedContextName.isEmpty,
+              normalizedContextName != "Not configured",
+              let normalizedResource = normalizedResourceTarget(resource)
+        else {
+            return nil
+        }
+
+        return k9sHandoff(
+            for: K9sHandoffTarget(contextName: normalizedContextName, resource: normalizedResource)
+        )
+    }
+
+    private func normalizedResourceTarget(_ resource: K9sResourceTarget) -> K9sResourceTarget? {
+        switch resource {
+        case let .namespace(namespace):
+            guard let namespace = normalizedText(namespace), !namespace.isEmpty else {
+                return nil
+            }
+
+            return .namespace(namespace)
+        case let .workload(namespace, name, kind):
+            guard let namespace = normalizedText(namespace), !namespace.isEmpty,
+                  let name = normalizedText(name), !name.isEmpty
+            else {
+                return nil
+            }
+
+            return .workload(namespace: namespace, name: name, kind: kind)
+        case let .podList(namespace):
+            guard let namespace = normalizedText(namespace), !namespace.isEmpty else {
+                return nil
+            }
+
+            return .podList(namespace: namespace)
+        case .nodeList:
+            return .nodeList
         }
     }
 
@@ -469,15 +540,26 @@ public struct HealthEvaluator: Sendable {
         return String(format: "%.1f", rounded)
     }
 
-    private func makeNodeTab(from snapshot: ClusterSnapshot, sectionNotices: [SectionAvailabilityDisplay]) -> NodeTabDisplay {
-        NodeTabDisplay(
+    private func makeNodeTab(
+        from snapshot: ClusterSnapshot,
+        sectionNotices: [SectionAvailabilityDisplay],
+        allowsK9sHandoff: Bool
+    ) -> NodeTabDisplay {
+        let rows = makeNodeRows(from: snapshot)
+
+        return NodeTabDisplay(
             summary: snapshot.nodesSection.value.map { "\($0.ready)/\($0.total) nodes ready" } ?? "- nodes ready",
-            rows: makeNodeRows(from: snapshot),
+            rows: rows,
             showsEmptyMessage: snapshot.nodesSection.value?.total == 0,
             unavailableMessage: tabUnavailableMessage(
                 sectionID: SnapshotSectionName.nodes.rawValue,
                 prefix: "Node data unavailable",
                 sectionNotices: sectionNotices
+            ),
+            k9sHandoff: rows.isEmpty ? nil : resourceHandoff(
+                contextName: snapshot.contextName,
+                resource: .nodeList,
+                allowsK9sHandoff: allowsK9sHandoff
             )
         )
     }
@@ -495,7 +577,9 @@ public struct HealthEvaluator: Sendable {
 
                 return left.name < right.name
             }
-            .map(makeNodeRow)
+            .map {
+                makeNodeRow(from: $0)
+            }
     }
 
     private func makeNodeRow(from detail: NodeDetail) -> NodeItemDisplay {
@@ -569,10 +653,17 @@ public struct HealthEvaluator: Sendable {
     private func makePodTab(
         from snapshot: ClusterSnapshot,
         visibleItems: [WatchItemDisplay],
-        sectionNotices: [SectionAvailabilityDisplay]
+        sectionNotices: [SectionAvailabilityDisplay],
+        allowsK9sHandoff: Bool
     ) -> PodTabDisplay {
         let podDetails = snapshot.podDetailsSection.value
-        let sections = podDetails.map(makePodSections) ?? []
+        let sections = podDetails.map {
+            makePodSections(
+                from: $0,
+                contextName: snapshot.contextName,
+                allowsK9sHandoff: allowsK9sHandoff
+            )
+        } ?? []
 
         return PodTabDisplay(
             summary: podTabSummary(from: snapshot, podDetails: podDetails),
@@ -614,8 +705,17 @@ public struct HealthEvaluator: Sendable {
         return "No pod data yet. Refresh or check Settings."
     }
 
-    private func makePodSections(from podDetails: [PodDetail]) -> [PodNamespaceDisplay] {
-        let rowsByNamespace = Dictionary(grouping: podDetails.map(makePodRow), by: \.namespace)
+    private func makePodSections(
+        from podDetails: [PodDetail],
+        contextName: String,
+        allowsK9sHandoff: Bool
+    ) -> [PodNamespaceDisplay] {
+        let rowsByNamespace = Dictionary(
+            grouping: podDetails.map {
+                makePodRow(from: $0)
+            },
+            by: \.namespace
+        )
 
         return rowsByNamespace
             .map { namespace, rows in
@@ -630,7 +730,12 @@ public struct HealthEvaluator: Sendable {
                         }
 
                         return left.name < right.name
-                    }
+                    },
+                    k9sHandoff: resourceHandoff(
+                        contextName: contextName,
+                        resource: .podList(namespace: namespace),
+                        allowsK9sHandoff: allowsK9sHandoff
+                    )
                 )
             }
             .sorted { left, right in
@@ -1027,7 +1132,12 @@ public struct HealthEvaluator: Sendable {
         }
     }
 
-    private func makeDisplayItem(_ item: TrackedItemStatus, now: Date) -> WatchItemDisplay {
+    private func makeDisplayItem(
+        _ item: TrackedItemStatus,
+        contextName: String,
+        allowsK9sHandoff: Bool,
+        now: Date
+    ) -> WatchItemDisplay {
         WatchItemDisplay(
             id: item.target.displayTitle,
             title: item.target.displayTitle,
@@ -1039,8 +1149,22 @@ public struct HealthEvaluator: Sendable {
                 affectedPodCount: item.affectedPodCount,
                 examplePodNames: Array(item.examplePodNames.prefix(3)),
                 latestWarning: item.latestWarning.map { makeWarningEventDisplay(from: $0, now: now) }
+            ),
+            k9sHandoff: resourceHandoff(
+                contextName: contextName,
+                resource: k9sResourceTarget(for: item.target),
+                allowsK9sHandoff: allowsK9sHandoff
             )
         )
+    }
+
+    private func k9sResourceTarget(for target: WatchTarget) -> K9sResourceTarget {
+        switch target {
+        case let .namespace(namespace):
+            .namespace(namespace)
+        case let .workload(namespace, name, kind):
+            .workload(namespace: namespace, name: name, kind: kind)
+        }
     }
 
     private func makeWarningEventSummaries(
@@ -1314,7 +1438,11 @@ public struct HealthEvaluator: Sendable {
             return nil
         }
 
-        return makePodSections(from: podDetails)
+        return makePodSections(
+            from: podDetails,
+            contextName: snapshot.contextName,
+            allowsK9sHandoff: false
+        )
             .lazy
             .compactMap { section in
                 section.rows.first { $0.state != .ready }?.helpText

--- a/KubebarCore/Services/K9sHandoffCoordinator.swift
+++ b/KubebarCore/Services/K9sHandoffCoordinator.swift
@@ -46,6 +46,10 @@ public extension K9sHandoffLaunchState {
         }
     }
 
+    func blocksNewHandoff(for _: OverviewK9sHandoff) -> Bool {
+        isOpening
+    }
+
     func feedbackMessage(for handoff: OverviewK9sHandoff) -> String? {
         switch self {
         case .idle:
@@ -86,7 +90,7 @@ public final class K9sHandoffCoordinator {
         launchTask = Task(priority: .userInitiated) { [weak self, launcher = launcher] in
             do {
                 try await Task.detached(priority: .userInitiated) {
-                    try launcher.launch(contextName: launchTarget.contextName, namespace: launchTarget.namespace)
+                    try launcher.launch(target: launchTarget)
                 }.value
 
                 self?.completeLaunch()
@@ -124,7 +128,7 @@ public final class K9sHandoffCoordinator {
         transition(
             to: .failed(
                 target: handoff,
-                message: "Could not open k9s for \(handoff.target.contextName)/\(handoff.target.namespace)"
+                message: "Could not open k9s for \(handoff.target.contextName)/\(handoff.target.displayName)"
             )
         )
     }

--- a/KubebarCore/Services/K9sHandoffLauncher.swift
+++ b/KubebarCore/Services/K9sHandoffLauncher.swift
@@ -5,7 +5,7 @@ public enum K9sHandoffLauncherError: Error, Equatable, Sendable {
 }
 
 public protocol K9sHandoffLaunching: Sendable {
-    func launch(contextName: String, namespace: String) throws
+    func launch(target: K9sHandoffTarget) throws
 }
 
 public final class K9sHandoffLauncher: K9sHandoffLaunching {
@@ -15,7 +15,7 @@ public final class K9sHandoffLauncher: K9sHandoffLaunching {
         self.runner = runner
     }
 
-    public func launch(contextName: String, namespace: String) throws {
+    public func launch(target: K9sHandoffTarget) throws {
         let path = ProcessCommandRunner.launchEnvironment(base: ProcessInfo.processInfo.environment)["PATH"]
             ?? "/usr/bin:/bin:/usr/sbin:/sbin"
 
@@ -24,8 +24,9 @@ public final class K9sHandoffLauncher: K9sHandoffLaunching {
             arguments: [
                 "-e",
                 launchScript(),
-                contextName,
-                namespace,
+                target.contextName,
+                target.resource.namespace ?? "",
+                resourceCommand(for: target.resource) ?? "",
                 path
             ],
             timeoutSeconds: 12
@@ -36,15 +37,39 @@ public final class K9sHandoffLauncher: K9sHandoffLaunching {
         }
     }
 
+    public func launch(contextName: String, namespace: String) throws {
+        try launch(target: K9sHandoffTarget(contextName: contextName, namespace: namespace))
+    }
+
+    private func resourceCommand(for resource: K9sResourceTarget) -> String? {
+        switch resource {
+        case .namespace:
+            nil
+        case let .workload(_, _, kind):
+            kind.kubectlResource
+        case .podList:
+            "pods"
+        case .nodeList:
+            "nodes"
+        }
+    }
+
     private func launchScript() -> String {
         """
         on run argv
             set contextName to item 1 of argv
             set namespaceName to item 2 of argv
-            set pathEnvironment to item 3 of argv
+            set resourceCommand to item 3 of argv
+            set pathEnvironment to item 4 of argv
 
             tell application "Terminal"
-                set k9sCommand to "export PATH=" & quoted form of pathEnvironment & "; exec k9s --context " & quoted form of contextName & " -n " & quoted form of namespaceName
+                set k9sCommand to "export PATH=" & quoted form of pathEnvironment & "; exec k9s --context " & quoted form of contextName
+                if namespaceName is not "" then
+                    set k9sCommand to k9sCommand & " -n " & quoted form of namespaceName
+                end if
+                if resourceCommand is not "" then
+                    set k9sCommand to k9sCommand & " -c " & quoted form of resourceCommand
+                end if
                 if (count of windows) is greater than 0 then
                     do script k9sCommand in front window
                 else

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -199,6 +199,92 @@ struct MenuDisplayModelTests {
         #expect(staleDisplay.overview.k9sHandoff == nil)
     }
 
+    @Test("list-level resources expose group-level k9s handoff targets")
+    func listLevelResourcesExposeGroupLevelK9sHandoffTargets() throws {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 2, total: 3)),
+            nodeDetailsSection: .available([
+                nodeDetail(name: "worker-a", isReady: false, issueReason: "KubeletNotReady")
+            ]),
+            podsSection: .available(PodSummary(ready: 0, running: 1, total: 1)),
+            podDetailsSection: .available([
+                podDetail(
+                    namespace: "api",
+                    name: "checkout-7f9d",
+                    readyContainerCount: 0,
+                    totalContainerCount: 1,
+                    waitingReason: "CrashLoopBackOff",
+                    isNotReady: true
+                )
+            ]),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([
+                TrackedItemStatus(
+                    target: .workload(namespace: "api", name: "checkout", kind: .deployment),
+                    state: .bad,
+                    reason: "1 pod restarting"
+                )
+            ]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 120))
+        let watchItem = try #require(display.visibleWatchItems.first)
+        let podSection = try #require(display.podTab.sections.first)
+        let podRow = try #require(podSection.rows.first)
+        let nodeRow = try #require(display.nodeTab.rows.first)
+
+        #expect(watchItem.k9sHandoff?.target.contextName == "prod")
+        #expect(watchItem.k9sHandoff?.target.resource == .workload(namespace: "api", name: "checkout", kind: .deployment))
+        #expect(podSection.k9sHandoff?.target.resource == .podList(namespace: "api"))
+        #expect(podSection.k9sHandoff?.helpText == "Open api Pods in k9s")
+        #expect(podSection.k9sHandoff?.accessibilityLabel == "Open api Pods in k9s")
+        #expect(podRow.k9sHandoff == nil)
+        #expect(display.nodeTab.k9sHandoff?.target.resource == .nodeList)
+        #expect(display.nodeTab.k9sHandoff?.helpText == "Open Nodes in k9s")
+        #expect(display.nodeTab.k9sHandoff?.accessibilityLabel == "Open Nodes in k9s")
+        #expect(nodeRow.k9sHandoff == nil)
+    }
+
+    @Test("stale resource rows do not expose k9s handoff targets")
+    func staleResourceRowsDoNotExposeK9sHandoffTargets() throws {
+        let previous = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 2, total: 3)),
+            nodeDetailsSection: .available([
+                nodeDetail(name: "worker-a", isReady: false, issueReason: "KubeletNotReady")
+            ]),
+            podsSection: .available(PodSummary(ready: 0, running: 1, total: 1)),
+            podDetailsSection: .available([
+                podDetail(namespace: "api", name: "checkout-7f9d", readyContainerCount: 0, totalContainerCount: 1)
+            ]),
+            warningEventsSection: .available([]),
+            workloadsSection: .available([
+                TrackedItemStatus(target: .namespace("api"), state: .bad, reason: "1 pod unavailable")
+            ]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(
+            snapshot: nil,
+            previousSnapshot: previous,
+            failure: nil,
+            now: Date(timeIntervalSince1970: 130),
+            staleAfterSeconds: 10
+        )
+        let watchItem = try #require(display.visibleWatchItems.first)
+        let podRow = try #require(display.podTab.sections.first?.rows.first)
+        let nodeRow = try #require(display.nodeTab.rows.first)
+
+        #expect(display.state == .stale)
+        #expect(watchItem.k9sHandoff == nil)
+        #expect(display.podTab.sections.first?.k9sHandoff == nil)
+        #expect(podRow.k9sHandoff == nil)
+        #expect(display.nodeTab.k9sHandoff == nil)
+        #expect(nodeRow.k9sHandoff == nil)
+    }
+
     @Test("tracked item status help includes expanded detail")
     func trackedItemStatusHelpIncludesExpandedDetail() {
         let latestWarning = warningEvent(

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -245,6 +245,8 @@ struct MenuDisplayModelTests {
         #expect(display.nodeTab.k9sHandoff?.helpText == "Open Nodes in k9s")
         #expect(display.nodeTab.k9sHandoff?.accessibilityLabel == "Open Nodes in k9s")
         #expect(nodeRow.k9sHandoff == nil)
+        #expect(display.k9sHandoffs.contains { $0.target.resource == .podList(namespace: "api") })
+        #expect(display.k9sHandoffs.contains { $0.target.resource == .nodeList })
     }
 
     @Test("stale resource rows do not expose k9s handoff targets")

--- a/KubebarTests/QA/MenuStateFixtureCatalogTests.swift
+++ b/KubebarTests/QA/MenuStateFixtureCatalogTests.swift
@@ -104,6 +104,22 @@ struct MenuStateFixtureCatalogTests {
         #expect(warning?.accessibilityLabel.contains("Tracked object warning, BackOff") == true)
     }
 
+    @Test("attention fixtures describe group level k9s actions")
+    func attentionFixturesDescribeGroupLevelK9sActions() {
+        let watch = MenuStateFixtureCatalog.fixture(for: .watch)
+        let bad = MenuStateFixtureCatalog.fixture(for: .bad)
+
+        #expect(watch.display.overview.k9sHandoff != nil)
+        #expect(bad.display.overview.k9sHandoff != nil)
+        #expect(watch.display.podTab.sections.first?.k9sHandoff != nil)
+        #expect(watch.display.podTab.sections.first?.rows.allSatisfy { $0.k9sHandoff == nil } == true)
+        #expect(bad.display.nodeTab.k9sHandoff != nil)
+        #expect(bad.display.nodeTab.rows.allSatisfy { $0.k9sHandoff == nil } == true)
+        #expect(watch.expectedBehavior.contains("Pods namespace headers open the namespace Pods view/list in k9s"))
+        #expect(bad.expectedBehavior.contains("Pods namespace headers open the namespace Pods view/list in k9s"))
+        #expect(bad.expectedBehavior.contains("Nodes summary opens the Nodes view/list in k9s"))
+    }
+
     @Test("first use and empty watchlist remain distinct setup states")
     func firstUseAndEmptyWatchlistRemainDistinctSetupStates() {
         let firstUse = MenuStateFixtureCatalog.fixture(for: .firstUse)

--- a/KubebarTests/Services/K9sHandoffCoordinatorTests.swift
+++ b/KubebarTests/Services/K9sHandoffCoordinatorTests.swift
@@ -24,6 +24,7 @@ struct K9sHandoffCoordinatorTests {
         #expect(await waitForState(coordinator, expected: .idle, timeout: .seconds(1)))
         #expect(coordinator.state == .idle)
         #expect(launcher.callCount == 1)
+        #expect(launcher.targets == [target.target])
     }
 
     @Test("repeated activation while opening does not retry launch")
@@ -62,6 +63,23 @@ struct K9sHandoffCoordinatorTests {
         launcher.release()
         #expect(await waitForState(coordinator, expected: .failed(target: target, message: "Could not open k9s for prod/api"), timeout: .seconds(1)))
         #expect(coordinator.state == .failed(target: target, message: "Could not open k9s for prod/api"))
+    }
+
+    @Test("failure copy names stable list entry targets")
+    func failureCopyNamesStableListEntryTargets() async {
+        let launcher = ControlledLauncher(result: .failure(K9sHandoffLauncherError.failed), delayNanoseconds: 100_000_000)
+        let coordinator = K9sHandoffCoordinator(launcher: launcher)
+        let target = OverviewK9sHandoff(
+            target: K9sHandoffTarget(contextName: "prod", resource: .podList(namespace: "api")),
+            actionLabel: "Open in k9s",
+            helpText: "Open api Pods in k9s",
+            accessibilityLabel: "Open api Pods in k9s"
+        )
+
+        coordinator.open(for: target)
+        launcher.release()
+
+        #expect(await waitForState(coordinator, expected: .failed(target: target, message: "Could not open k9s for prod/api Pods"), timeout: .seconds(1)))
     }
 
     @Test("state clears when target disappears")
@@ -132,6 +150,27 @@ struct K9sHandoffCoordinatorTests {
         #expect(!openingState.isOpeningForSameTarget(otherTarget))
         #expect(!K9sHandoffLaunchState.idle.isOpeningForSameTarget(matchingTarget))
     }
+
+    @Test("opening state blocks every handoff button")
+    func openingStateBlocksEveryHandoffButton() {
+        let matchingTarget = OverviewK9sHandoff(
+            target: K9sHandoffTarget(contextName: "prod", namespace: "api"),
+            actionLabel: "Open in k9s",
+            helpText: "Open watched target in k9s",
+            accessibilityLabel: "Open watched target in k9s"
+        )
+        let otherTarget = OverviewK9sHandoff(
+            target: K9sHandoffTarget(contextName: "stage", namespace: "api"),
+            actionLabel: "Open in k9s",
+            helpText: "Open watched target in k9s",
+            accessibilityLabel: "Open watched target in k9s"
+        )
+        let openingState = K9sHandoffLaunchState.opening(target: matchingTarget)
+
+        #expect(openingState.blocksNewHandoff(for: matchingTarget))
+        #expect(openingState.blocksNewHandoff(for: otherTarget))
+        #expect(!K9sHandoffLaunchState.idle.blocksNewHandoff(for: matchingTarget))
+    }
 }
 
 private final class ControlledLauncher: K9sHandoffLaunching, @unchecked Sendable {
@@ -139,6 +178,7 @@ private final class ControlledLauncher: K9sHandoffLaunching, @unchecked Sendable
     private let delayNanoseconds: UInt64
     private let releaseGate = DispatchSemaphore(value: 0)
     private(set) var callCount = 0
+    private(set) var targets: [K9sHandoffTarget] = []
 
     init(
         result: Result<Void, Error> = .success(()),
@@ -148,10 +188,9 @@ private final class ControlledLauncher: K9sHandoffLaunching, @unchecked Sendable
         self.delayNanoseconds = delayNanoseconds
     }
 
-    func launch(contextName: String, namespace: String) throws {
-        _ = contextName
-        _ = namespace
+    func launch(target: K9sHandoffTarget) throws {
         callCount += 1
+        targets.append(target)
 
         if delayNanoseconds > 0 {
             releaseGate.wait()

--- a/KubebarTests/Services/K9sHandoffLauncherTests.swift
+++ b/KubebarTests/Services/K9sHandoffLauncherTests.swift
@@ -9,15 +9,16 @@ struct K9sHandoffLauncherTests {
         let runner = FakeCommandRunner()
         let launcher = K9sHandoffLauncher(runner: runner)
 
-        try launcher.launch(contextName: "prod", namespace: "api")
+        try launcher.launch(target: K9sHandoffTarget(contextName: "prod", namespace: "api"))
 
         let request = try #require(runner.request)
         #expect(request.executable == "osascript")
-        #expect(request.arguments.count == 5)
+        #expect(request.arguments.count == 6)
         #expect(request.arguments[0] == "-e")
         #expect(request.arguments[2] == "prod")
         #expect(request.arguments[3] == "api")
-        #expect(request.arguments[4].contains("/usr/bin"))
+        #expect(request.arguments[4] == "")
+        #expect(request.arguments[5].contains("/usr/bin"))
     }
 
     @Test("launch avoids opening a separate blank terminal window")
@@ -25,13 +26,65 @@ struct K9sHandoffLauncherTests {
         let runner = FakeCommandRunner()
         let launcher = K9sHandoffLauncher(runner: runner)
 
-        try launcher.launch(contextName: "prod", namespace: "api")
+        try launcher.launch(target: K9sHandoffTarget(contextName: "prod", namespace: "api"))
 
         let request = try #require(runner.request)
         let script = request.arguments[1]
         #expect(!script.contains("activate"))
         #expect(script.contains("if (count of windows) is greater than 0"))
         #expect(script.contains("do script k9sCommand in front window"))
+    }
+
+    @Test("launch passes resource command for typed targets")
+    func launchPassesResourceCommandForTypedTargets() throws {
+        let runner = FakeCommandRunner()
+        let launcher = K9sHandoffLauncher(runner: runner)
+
+        try launcher.launch(
+            target: K9sHandoffTarget(
+                contextName: "prod",
+                resource: .workload(namespace: "api", name: "checkout", kind: .deployment)
+            )
+        )
+
+        let request = try #require(runner.request)
+        let script = request.arguments[1]
+        #expect(request.arguments[2] == "prod")
+        #expect(request.arguments[3] == "api")
+        #expect(request.arguments[4] == "deployments")
+        #expect(script.contains(" -c "))
+    }
+
+    @Test("pod launch opens namespace pods list")
+    func podLaunchOpensNamespacePodsList() throws {
+        let runner = FakeCommandRunner()
+        let launcher = K9sHandoffLauncher(runner: runner)
+
+        try launcher.launch(
+            target: K9sHandoffTarget(contextName: "prod", resource: .podList(namespace: "api"))
+        )
+
+        let request = try #require(runner.request)
+        #expect(request.arguments[2] == "prod")
+        #expect(request.arguments[3] == "api")
+        #expect(request.arguments[4] == "pods")
+    }
+
+    @Test("node launch omits namespace and opens nodes list")
+    func nodeLaunchOmitsNamespaceAndOpensNodeResourceView() throws {
+        let runner = FakeCommandRunner()
+        let launcher = K9sHandoffLauncher(runner: runner)
+
+        try launcher.launch(
+            target: K9sHandoffTarget(contextName: "prod", resource: .nodeList)
+        )
+
+        let request = try #require(runner.request)
+        let script = request.arguments[1]
+        #expect(request.arguments[2] == "prod")
+        #expect(request.arguments[3] == "")
+        #expect(request.arguments[4] == "nodes")
+        #expect(script.contains("if namespaceName is not \"\""))
     }
 
     @Test("launch supports special characters in context and namespace")
@@ -41,7 +94,7 @@ struct K9sHandoffLauncherTests {
         let contextName = "prod staging"
         let namespace = "qa/api; rm -rf /"
 
-        try launcher.launch(contextName: contextName, namespace: namespace)
+        try launcher.launch(target: K9sHandoffTarget(contextName: contextName, namespace: namespace))
 
         let request = try #require(runner.request)
         #expect(request.arguments[2] == contextName)
@@ -54,7 +107,7 @@ struct K9sHandoffLauncherTests {
         let launcher = K9sHandoffLauncher(runner: runner)
 
         #expect(throws: K9sHandoffLauncherError.failed) {
-            try launcher.launch(contextName: "prod", namespace: "api")
+            try launcher.launch(target: K9sHandoffTarget(contextName: "prod", namespace: "api"))
         }
     }
 }

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -104,6 +104,11 @@ These are the rules Kubebar must keep true at runtime.
 - Context, namespace, workload, and warning names stay app-owned display
   strings; tooltips and accessibility labels must not expose command
   transcripts or JSON.
+- `Open in k9s` actions are external handoffs only. Overview rows, watchlist
+  rows, Pod namespace headers, and the Nodes summary may expose them only from
+  fresh `MenuDisplayModel` targets, and they must not mutate Kubernetes
+  resources or infer target semantics in views. Pod and Node item rows must not
+  expose list-level handoffs that imply exact resource positioning.
 
 ## Freshness Rules
 

--- a/docs/plans/2026-05-15-001-feat-k9s-resource-handoff-plan.md
+++ b/docs/plans/2026-05-15-001-feat-k9s-resource-handoff-plan.md
@@ -1,0 +1,308 @@
+---
+title: "feat: Add k9s resource handoff"
+type: feat
+status: planned
+date: 2026-05-15
+origin: .imm/specs/2026-05-15-k9s-resource-handoff.md
+---
+
+# feat: Add k9s resource handoff
+
+## Summary
+
+- Summary: Resource rows can open the matching target in k9s.
+
+Expand Kubebar's existing `Open in k9s` handoff from the Overview top status to
+resource-level entry points on existing watchlist, Pod, and Node rows. The
+change should reduce the jump from "I see the affected resource" to "inspect it
+in k9s" while keeping Kubebar a glanceable Kubernetes health surface.
+
+## Task
+
+- Type: feat
+- Scope: k9s resource handoff
+- Owner: imm-work
+- Verification: automated plus visible smoke
+- Brainstorm manifest: BR-REQ-001, BR-REQ-002, BR-REQ-003, BR-REQ-004, BR-DEC-001, BR-DEC-002, BR-OUT-001, BR-DEFER-001, BR-Q-001
+
+## Origin
+
+The user asked to analyze the current k9s jump logic and expand it into entry
+points from resources to viewing the corresponding resources in `k9s`.
+
+`imm-brainstorm` found that the existing handoff is intentionally narrow: it is
+computed in `HealthEvaluator`, stored as `OverviewDisplay.k9sHandoff`, rendered
+only in `StatusSummaryView`, and launched by `K9sHandoffLauncher` with explicit
+`--context` and `-n` values. The launcher currently targets only a namespace,
+even for workload watch targets.
+
+This is a new slice rather than an append to
+`docs/plans/2026-04-23-004-feat-k9s-handoff-plan.md` because that prior plan
+implemented the first namespace-level handoff and explicitly deferred exact
+workload or pod positioning.
+
+## Brainstorm Manifest
+
+- `BR-REQ-001`: Expand k9s handoff target from `context+namespace` to express
+  namespace, workload, Pod, and Node targets.
+- `BR-REQ-002`: Add explicit external k9s entry points in Watchlist, Pods tab,
+  and Nodes tab.
+- `BR-REQ-003`: All entries must use app-owned context and must not depend on
+  Terminal current context.
+- `BR-REQ-004`: Stale, setup, and incomplete target states must not show
+  misleading k9s entries.
+- `BR-DEC-001`: Entry is a deliberate button or action, not automatic launch.
+- `BR-DEC-002`: k9s remains the external deep inspection tool; Kubebar does not
+  add deeper troubleshooting UI.
+- `BR-OUT-001`: Logs, embedded terminal, command transcripts, watch streams,
+  and resource mutation actions are out of scope.
+- `BR-DEFER-001`: Recent Warnings handoff is deferred.
+- `BR-Q-001`: Exact target positioning should prefer resource view plus filter;
+  if k9s does not provide a stable shallow command, do not simulate keyboard
+  navigation.
+
+## Brainstorm Trace
+
+| Item | Status | Target | Reason |
+| --- | --- | --- | --- |
+| BR-REQ-001 | covered_by_step | U1 | Typed targets are represented in MenuDisplayModel. |
+| BR-REQ-002 | covered_by_step | U3 | Row affordances are the UI outcome. |
+| BR-REQ-003 | covered_by_step | U2 | The launcher keeps explicit app-owned context. |
+| BR-REQ-004 | covered_by_step | U1 | Eligibility is represented before views render actions. |
+| BR-DEC-001 | captured_as_decision | Decisions | Row entry remains deliberate. |
+| BR-DEC-002 | captured_as_decision | Scope Boundaries | Kubebar stays glanceable and k9s remains external. |
+| BR-OUT-001 | out_of_scope | Scope Boundaries | This slice only opens k9s views and excludes deep actions. |
+| BR-DEFER-001 | deferred | Scope Boundaries | Recent Warnings handoff stays deferred to avoid widening the first slice. |
+| BR-Q-001 | resolved_as_assumption | Assumptions | Use stable k9s resource view plus filter when available. |
+
+## Research
+
+- `CONTEXT.md` defines Kubebar as a native macOS menu bar app for glanceable
+  Kubernetes health, and Resource usage visualization as display-only current
+  snapshot indicators.
+- `docs/architecture/runtime-invariants.md` requires `MenuDisplayModel` as the
+  only menu rendering input, app-owned context as source of truth, no raw
+  command transcripts, and deep troubleshooting out of version 1.
+- `docs/brainstorms/2026-04-23-kubebar-k9s-handoff-requirements.md` required
+  namespace-level handoff first and allowed exact workload or pod positioning
+  only if it stayed inside a shallow external handoff boundary.
+- `docs/plans/2026-04-23-004-feat-k9s-handoff-plan.md` deferred exact
+  workload or pod positioning after the initial namespace-level handoff.
+- `docs/solutions/rejected-decisions/pod-resource-history-alerting-2026-05-14.md`
+  rejects expanding resource display work into dashboards, history, or alerts;
+  this plan avoids that by adding only external handoff actions.
+- `KubebarCore/Models/MenuDisplayModel.swift` currently has
+  `K9sHandoffTarget` with only `contextName` and `namespace`.
+- `KubebarCore/Services/K9sHandoffLauncher.swift` launches Terminal with
+  `k9s --context <context> -n <namespace>` through an injectable
+  `CommandRunning` boundary.
+- `KubebarCore/Services/K9sHandoffCoordinator.swift` already models idle,
+  opening, and failed launch state for a matching handoff target.
+- `Kubebar/Views/StatusSummaryView.swift` is the only current handoff
+  affordance.
+- `Kubebar/Views/PodsTabView.swift` and `Kubebar/Views/NodeDetailsView.swift`
+  render concrete Pod and Node rows from display-model data but have no action
+  callbacks today.
+- k9s command docs confirm `--context`, `-n`, and `-c` can launch into an
+  explicit context, namespace, and resource view. The docs also describe
+  resource filters in interactive command mode, so implementation should avoid
+  brittle interactive keystroke automation unless a stable CLI form is proven:
+  https://k9scli.io/topics/commands/
+
+## Decisions
+
+- Treat this as three outcome steps: typed target model, launcher and state
+  support, then row-level UI affordances.
+- Preserve the existing Overview handoff behavior while generalizing its target
+  shape.
+- Keep handoff targets as display-model values, not raw Kubernetes records or
+  view-inferred command fragments.
+- Add only deliberate icon/button actions on rows; row text remains primarily
+  informational.
+- Prefer stable `k9s` launch arguments: context, namespace when applicable,
+  resource view, and optional safe filter. Do not simulate k9s keyboard input.
+- Keep launch feedback state separate from Health category.
+- Defer Recent Warnings handoff.
+
+## Assumptions
+
+- Existing display fixtures and unit tests can cover target eligibility without
+  live Kubernetes access.
+- k9s resource view aliases for supported built-in kinds are stable enough for
+  launcher tests when represented as structured values.
+- If exact name filtering is not reliable through launch arguments, opening the
+  closest resource view is still a useful, safe handoff.
+- Existing `CONTEXT.md` vocabulary is sufficient; no new canonical term is
+  needed.
+
+## Scope Boundaries
+
+- In scope: typed k9s handoff targets, launcher argument construction,
+  coordinator/view-model support for multiple row targets, Watchlist row
+  actions, Pods tab row actions, Nodes tab row actions, focused tests, and
+  runtime documentation updates.
+- Out of scope: Recent Warnings handoff, embedded terminal, logs/describe/edit
+  shortcuts, exec, delete, port-forward, restart, command transcript display,
+  watch streams, resource alerting, metrics history, and external monitoring
+  integrations.
+
+## Implementation Units
+
+### Step 1
+
+- Step ID: U1
+- Result: Resource handoff targets are represented in MenuDisplayModel.
+- Verification: /usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local
+- Depends on: None
+- Test scenarios: Overview namespace handoff still works; workload target carries kind and name; Pod rows carry namespace and Pod name; Node rows carry Node name without namespace; stale and unavailable displays omit broken handoffs
+
+**Goal:** Generalize the display-model handoff contract so views can render
+safe row-level actions without deciding Kubernetes target semantics.
+
+**Execution note:** test-first
+
+**Requirements:** R1-R8, R10-R12
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `KubebarCore/Models/MenuDisplayModel.swift`
+- Modify: `KubebarCore/Services/HealthEvaluator.swift`
+- Modify: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- Reference: `.imm/specs/2026-05-15-k9s-resource-handoff.md`
+- Reference: `docs/architecture/runtime-invariants.md`
+
+**Approach:**
+- Replace the namespace-only handoff target with a typed target that can
+  represent namespace, workload, Pod, and Node resources while preserving safe
+  display labels.
+- Keep `OverviewDisplay.k9sHandoff` compatible at the behavior level by
+  mapping its current namespace target into the new target shape.
+- Add optional handoff values to `WatchItemDisplay`, `PodItemDisplay`, and
+  `NodeItemDisplay` only when the current display data is fresh and target
+  fields are complete.
+- Use `HealthEvaluator` to populate handoff targets; SwiftUI views should only
+  render the provided actions.
+- Keep raw command strings and executable details out of the display model.
+
+**Verification:**
+- `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local`
+
+**failure_behavior:** If adding targets to every row risks noisy UI or unclear
+eligibility, keep the model support complete but gate visibility in U3 to the
+least crowded rows first.
+
+**security_considerations:** Handoff values are safe display strings and local
+target identifiers only. No Secrets are queried, no raw command output is
+stored, and no cluster data leaves the app.
+
+### Step 2
+
+- Step ID: U2
+- Result: Typed resource handoffs open through the k9s launch flow.
+- Verification: /usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local
+- Depends on: 1
+- Test scenarios: namespace target launches with explicit context and namespace; workload target includes resource view and name when stable; Pod target opens pod view in namespace; Node target opens node view without namespace fallback; special characters stay safely quoted; launch failure message names the intended target without raw stderr
+
+**Goal:** Extend the existing injectable launch boundary and coordinator so any
+typed resource handoff target can be opened with safe feedback.
+
+**Execution note:** characterization-first
+
+**Requirements:** R2-R7, R10-R11
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `KubebarCore/Services/K9sHandoffLauncher.swift`
+- Modify: `KubebarCore/Services/K9sHandoffCoordinator.swift`
+- Modify: `Kubebar/MenuBarViewModel.swift`
+- Modify: `KubebarTests/Services/K9sHandoffLauncherTests.swift`
+- Modify: `KubebarTests/Services/K9sHandoffCoordinatorTests.swift`
+- Reference: `KubebarCore/Services/CommandRunner.swift`
+
+**Approach:**
+- Change the launcher protocol to accept the typed handoff target rather than
+  separate context and namespace strings.
+- Build k9s invocation from structured target values: explicit context,
+  optional namespace, resource view, and optional resource name filter.
+- Keep AppleScript or Terminal bridge details contained inside
+  `K9sHandoffLauncher`.
+- Preserve duplicate-activation protection and target-specific feedback in
+  `K9sHandoffCoordinator`.
+- Update failure copy to identify the intended resource target safely.
+- Avoid interactive keystroke automation. If exact name filtering is unstable,
+  omit the filter and open the closest stable resource view.
+
+**Verification:**
+- `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local`
+
+**failure_behavior:** If a target kind cannot be represented with stable k9s
+arguments, launcher support must degrade to the closest safe context,
+namespace, and resource view rather than inventing an interactive script.
+
+**security_considerations:** The launcher must continue to pass user-controlled
+context and resource names safely through structured arguments or focused
+quoting. Failure output must not expose stderr, command lines, or kubeconfig
+paths.
+
+### Step 3
+
+- Step ID: U3
+- Result: Resource rows expose deliberate k9s handoff actions.
+- Verification: /usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local
+- Depends on: 2
+- Test scenarios: Watchlist workload action opens its target; Pod row action opens the Pod target; Node row action opens the Node target; actions are keyboard and accessibility reachable; rows without handoff targets show no broken action; visible smoke confirms row layout remains scannable
+
+**Goal:** Render compact row-level handoff affordances that let users jump from
+the resource they are looking at to the matching external `k9s` view.
+
+**Verification type:** hitl
+
+**Execution note:** test-first
+
+**Requirements:** R1-R12
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `Kubebar/Views/WatchlistSectionView.swift`
+- Modify: `Kubebar/Views/PodsTabView.swift`
+- Modify: `Kubebar/Views/NodeDetailsView.swift`
+- Modify: `Kubebar/Views/MenuBarRootView.swift`
+- Modify: `Kubebar/Views/OverviewTabView.swift`
+- Modify: `Kubebar/MenuBarViewModel.swift`
+- Modify: `KubebarCore/QA/MenuStateFixtureCatalog.swift`
+- Modify: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+- Modify: `docs/architecture/runtime-invariants.md`
+
+**Approach:**
+- Pass a single `onOpenK9sHandoff` action that accepts a handoff target through
+  the menu view tree.
+- Render small icon-button actions only when the row's display model contains a
+  handoff target.
+- Keep row text, ready counts, issue text, and resource usage visualization as
+  the primary scan surface.
+- Add help and accessibility labels that name the external action and target.
+- Disable or ignore only the matching target while it is opening.
+- Update QA fixture expectations and runtime invariants to document row-level
+  handoff boundaries.
+
+**Verification:**
+- `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local`
+- `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer KUBEBAR_QA_STATE=watch ./scripts/compile-and-run.sh`
+- Inspect Watchlist, Pods tab, and Nodes tab: action icons fit, keyboard focus
+  can reach them, and row text remains readable.
+
+**failure_behavior:** If adding actions to all row types crowds the menu, keep
+the model and launcher support but hide the lowest-value visible affordance
+behind a focused follow-up rather than degrading row readability.
+
+**security_considerations:** UI actions only launch the user's local `k9s` with
+safe target values already present in `MenuDisplayModel`. They must not expose
+raw command output or add mutation shortcuts.
+
+## Validation Notes
+
+- Use the system Immune-Brain CLI:
+  `imm-plan docs/plans/2026-05-15-001-feat-k9s-resource-handoff-plan.md --json`.

--- a/docs/plans/2026-05-15-002-fix-k9s-handoff-entry-semantics-plan.md
+++ b/docs/plans/2026-05-15-002-fix-k9s-handoff-entry-semantics-plan.md
@@ -1,0 +1,200 @@
+---
+title: "fix: Correct k9s handoff entry semantics"
+type: fix
+status: planned
+date: 2026-05-15
+origin: .imm/specs/2026-05-15-k9s-handoff-entry-corrections.md
+---
+
+# fix: Correct k9s handoff entry semantics
+
+## Summary
+
+- Summary: k9s handoff entries follow the corrected landing contract.
+
+Correct the resource handoff slice after manual validation: Overview error
+details must keep the `Open in k9s` entry, Node actions must be honest that
+they open the Nodes view/list, and Pod actions must be honest that they open a
+namespace Pods view/list. The change keeps Kubebar focused on glanceable
+Kubernetes health and uses `k9s` only as an external handoff.
+
+## Task
+
+- Type: fix
+- Scope: k9s handoff entry semantics
+- Owner: imm-work
+- Verification: automated plus visible smoke
+- Brainstorm manifest: BR-REQ-001, BR-REQ-002, BR-REQ-003, BR-REQ-004, BR-REQ-005, BR-DEC-001, BR-OUT-001, BR-DEFER-001, BR-Q-001
+
+## Origin
+
+The user manually validated the previous k9s resource handoff work and found
+three follow-up problems:
+
+- Overview error information can lose the k9s handoff entry.
+- Node row handoff opens the Nodes list, not a specific Node, so the entry
+  point should be adjusted.
+- Pod row handoff opens all Pods under the namespace, so the namespace Pods
+  entry is more accurate than a Pod-specific entry.
+
+This is a new slice rather than an append to
+`docs/plans/2026-05-15-001-feat-k9s-resource-handoff-plan.md` because the
+runtime ledger shows that plan's steps as closed. The new slice corrects the
+visible semantics and QA contract without rewriting completed history.
+
+## Brainstorm Manifest
+
+- `BR-REQ-001`: Overview error/detail area must retain a usable k9s handoff
+  entry.
+- `BR-REQ-002`: Node handoff entry semantics change to Nodes view/list, not
+  exact Node positioning.
+- `BR-REQ-003`: Pod row handoff changes to a namespace-level Pods view/list
+  entry, not exact Pod positioning.
+- `BR-REQ-004`: All entries continue to use app-owned context and do not rely
+  on Terminal current context.
+- `BR-REQ-005`: UI copy, help text, and accessibility labels must accurately
+  describe the actual landing point.
+- `BR-DEC-001`: Do not use k9s interactive keyboard automation to simulate
+  exact positioning.
+- `BR-OUT-001`: Logs, describe, edit, exec, delete, port-forward, and other
+  deep troubleshooting actions are out of scope.
+- `BR-DEFER-001`: Recent Warnings handoff remains deferred.
+- `BR-Q-001`: Planner must confirm the Overview state that loses the entry and
+  put that state into a verification fixture or test.
+
+## Brainstorm Trace
+
+| Item | Status | Target | Reason |
+| --- | --- | --- | --- |
+| BR-REQ-001 | covered_by_step | U1 | U1 requires an Overview Watch or Bad error-detail state to keep a visible handoff. |
+| BR-REQ-002 | covered_by_step | U1 | U1 corrects Node target semantics and copy to Nodes view/list. |
+| BR-REQ-003 | covered_by_step | U1 | U1 corrects Pod target semantics and copy to namespace Pods view/list. |
+| BR-REQ-004 | covered_by_step | U1 | U1 preserves explicit app-owned context and namespace launch arguments. |
+| BR-REQ-005 | covered_by_step | U1 | U1 covers labels, help, accessibility text, and failure copy. |
+| BR-DEC-001 | captured_as_decision | Decisions | Stable launch arguments are allowed; interactive keyboard automation is not. |
+| BR-OUT-001 | out_of_scope | Scope Boundaries | This slice only corrects existing handoff entries and excludes deep actions. |
+| BR-DEFER-001 | deferred | Scope Boundaries | Recent Warnings remains deferred to avoid adding a new entry surface. |
+| BR-Q-001 | covered_by_step | U1 | U1 starts by capturing the Overview lost-entry state in a fixture or test before closing. |
+
+## Research
+
+- `CONTEXT.md` defines Kubebar as a native macOS menu bar app for glanceable
+  Kubernetes health and uses `Health category` for `OK`, `Watch`, `Bad`, and
+  `Stale`.
+- `IMMUNE.md` requires plan before code and small independently verifiable
+  steps.
+- `.imm/memory/current_iteration.json` shows the previous k9s resource handoff
+  plan is closed through U3, so this correction is a new slice.
+- `docs/architecture/runtime-invariants.md` requires menu rendering to use
+  `MenuDisplayModel`, app-owned context as source of truth, no raw command
+  transcripts, and external k9s handoffs only.
+- `KubebarCore/Models/MenuDisplayModel.swift` currently represents resource
+  targets that include Pod and Node names.
+- `KubebarCore/Services/K9sHandoffLauncher.swift` currently launches Pod
+  targets with `-c pods` in a namespace and Node targets with `-c nodes`; it
+  does not pass exact Pod or Node positioning through a stable CLI argument.
+- `Kubebar/Views/StatusSummaryView.swift` renders the Overview handoff inside
+  the top status region, which is the likely surface for the lost-entry
+  Overview state.
+- `KubebarCore/QA/MenuStateFixtureCatalog.swift` already has Watch and Bad QA
+  states that mention Overview and row-level k9s actions; those states are the
+  right place to pin the visible behavior.
+
+## Decisions
+
+- Treat the correction as one outcome step because all three findings share
+  one user-visible result: every handoff entry remains present and truthful.
+- Do not add interactive k9s search, filtering, or keyboard automation.
+- Prefer stable entry targets over exact positioning claims: Nodes view/list
+  for Node rows and namespace Pods view/list for Pod rows.
+- Keep handoff eligibility and target semantics in display-model or evaluator
+  code, not in SwiftUI row views.
+- Preserve existing stale, setup, unavailable, and incomplete-state gating.
+- Update runtime invariants and QA expectations when behavior copy changes.
+
+## Assumptions
+
+- A Watch or Bad QA fixture can reproduce or protect the Overview error-detail
+  state that lost the handoff entry.
+- The current launcher behavior is the source of truth for actual landing
+  points: `-c nodes` opens a Nodes view/list, and `-c pods` with namespace
+  opens the namespace Pods view/list.
+- Existing tests can cover launcher arguments and display-copy semantics
+  without a live Kubernetes cluster.
+
+## Scope Boundaries
+
+- In scope: Overview handoff visibility in error-detail states, Node list-level
+  handoff semantics, namespace Pods list-level handoff semantics, user-facing
+  handoff copy, accessibility labels, failure feedback, QA fixture metadata,
+  tests, and runtime documentation updates.
+- Out of scope: Recent Warnings handoff, exact k9s resource positioning,
+  interactive keyboard automation, embedded terminal, logs/describe/edit
+  shortcuts, exec, delete, port-forward, restart, raw command transcript
+  display, resource mutation, Health category changes, resource usage
+  visualization changes, historical trends, and alerting.
+
+## Implementation Units
+
+### Step 1
+
+- Step ID: U1
+- Result: k9s handoff entries follow the corrected landing contract.
+- Verification: /usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local
+- Verification type: hitl
+- Depends on: None
+- Test scenarios: Overview Watch or Bad error detail keeps a visible Open in k9s entry; Node row action and failure copy describe the Nodes view/list instead of an exact Node; Pod row action and failure copy describe the namespace Pods view/list instead of an exact Pod; app-owned context and namespace arguments remain explicit; stale setup unavailable or incomplete states omit misleading handoffs; QA smoke checks Overview Pods and Nodes wording in a Watch or Bad fixture
+
+**Goal:** Correct the handoff contract so users see an entry where they need it
+and the entry accurately describes the stable `k9s` view it opens.
+
+**Execution note:** test-first
+
+**Requirements:** R1-R9
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `KubebarCore/Models/MenuDisplayModel.swift`
+- Modify: `KubebarCore/Services/HealthEvaluator.swift`
+- Modify: `KubebarCore/Services/K9sHandoffLauncher.swift`
+- Modify: `KubebarCore/Services/K9sHandoffCoordinator.swift`
+- Modify: `Kubebar/MenuBarViewModel.swift`
+- Modify: `Kubebar/Views/StatusSummaryView.swift`
+- Modify: `Kubebar/Views/PodsTabView.swift`
+- Modify: `Kubebar/Views/NodesTabView.swift`
+- Modify: `KubebarCore/QA/MenuStateFixtureCatalog.swift`
+- Modify: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- Modify: `KubebarTests/Services/K9sHandoffLauncherTests.swift`
+- Modify: `KubebarTests/Services/K9sHandoffCoordinatorTests.swift`
+- Modify: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+- Modify: `docs/architecture/runtime-invariants.md`
+- Reference: `.imm/specs/2026-05-15-k9s-handoff-entry-corrections.md`
+
+**Approach:**
+- Add or adjust characterization tests for the Overview Watch or Bad error
+  state before changing the view so the lost-entry regression is pinned.
+- Change Pod and Node target semantics to represent stable list-level entry
+  points instead of exact resource positioning promises.
+- Update action labels, help text, accessibility labels, and failure messages
+  so the copy says what `k9s` actually opens.
+- Keep launcher arguments structured around app-owned context, namespace when
+  applicable, and stable resource views.
+- Ensure SwiftUI views render handoff actions from `MenuDisplayModel` values
+  and do not infer Kubernetes semantics locally.
+- Update QA fixture expected behavior and runtime invariants to match the
+  corrected handoff contract.
+- Run the Swift quality gate and a visible-app smoke check for a Watch or Bad
+  QA state before review.
+
+**Verification:**
+- `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local`
+- `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/compile-and-run.sh --qa-state bad`
+
+**failure_behavior:** If exact Overview loss cannot be reproduced in an
+existing fixture, add the smallest QA fixture or test variant that represents
+the error-detail state before applying the UI correction.
+
+**security_considerations:** The fix only changes local handoff metadata,
+labels, and launch arguments. It must not expose command output, kubeconfig
+paths, stderr, or Secrets.

--- a/docs/plans/2026-05-15-003-fix-k9s-handoff-entry-placement-plan.md
+++ b/docs/plans/2026-05-15-003-fix-k9s-handoff-entry-placement-plan.md
@@ -1,0 +1,191 @@
+---
+title: "fix: Move k9s list entries to group level"
+type: fix
+status: planned
+date: 2026-05-15
+origin: .imm/specs/2026-05-15-k9s-handoff-entry-placement.md
+---
+
+# fix: Move k9s list entries to group level
+
+## Summary
+
+- Summary: k9s list-level handoffs use group-level entries.
+
+Move Pods and Nodes k9s affordances to the UI level that matches their actual
+`k9s` landing point. Pods should expose namespace-level entries on namespace
+sections, and Nodes should expose one list-level entry near the Nodes tab
+summary. Concrete Pod and Node rows should stop implying exact resource
+positioning.
+
+## Task
+
+- Type: fix
+- Scope: k9s handoff entry placement
+- Owner: imm-work
+- Verification: automated plus Computer Use visible check
+- Brainstorm manifest: BR-REQ-001, BR-REQ-002, BR-REQ-003, BR-REQ-004, BR-REQ-005, BR-DEC-001, BR-OUT-001, BR-OUT-002, BR-Q-001
+
+## Origin
+
+The user manually validated the corrected k9s handoff semantics and found a
+remaining mismatch: Pods and Nodes buttons are still positioned on specific
+rows, but their targets open list-level `k9s` resources. The entry placement
+should match the actual landing point.
+
+This is a new slice rather than an append to
+`docs/plans/2026-05-15-002-fix-k9s-handoff-entry-semantics-plan.md` because
+that plan is closed in `.imm/memory/current_iteration.json` with QA pass
+evidence. This slice preserves that closed history and narrows only the
+placement issue found during the next validation pass.
+
+## Brainstorm Manifest
+
+- `BR-REQ-001`: Pods k9s entry must move from Pod row level to namespace group
+  level.
+- `BR-REQ-002`: Nodes k9s entry must move from Node row level to Nodes tab
+  summary/header level.
+- `BR-REQ-003`: Entry position, button copy, help text, and accessibility
+  labels must match the actual `k9s` landing point.
+- `BR-REQ-004`: All entries continue to use app-owned context.
+- `BR-REQ-005`: Row-level Pod and Node entries must no longer imply exact
+  resource jumps.
+- `BR-DEC-001`: Match entry level to existing stable `k9s` list landing
+  points instead of simulating exact positioning.
+- `BR-OUT-001`: Logs, describe, edit, exec, delete, port-forward, and other
+  deep troubleshooting actions are out of scope.
+- `BR-OUT-002`: Health category and resource health judgment are out of scope.
+- `BR-Q-001`: Planner must confirm whether automated view/accessibility
+  coverage is available; otherwise include Bad QA Computer Use validation.
+
+## Brainstorm Trace
+
+| Item | Status | Target | Reason |
+| --- | --- | --- | --- |
+| BR-REQ-001 | covered_by_step | U1 | U1 moves Pods affordances to namespace section scope. |
+| BR-REQ-002 | covered_by_step | U1 | U1 moves Nodes affordance to tab summary/header scope. |
+| BR-REQ-003 | covered_by_step | U1 | U1 updates visible copy, help, accessibility labels, and QA metadata. |
+| BR-REQ-004 | covered_by_step | U1 | U1 keeps the existing display-model targets and launcher contract app-owned. |
+| BR-REQ-005 | covered_by_step | U1 | U1 removes misleading row-level Pod and Node affordances. |
+| BR-DEC-001 | captured_as_decision | Decisions | The fix changes entry placement, not k9s positioning mechanics. |
+| BR-OUT-001 | out_of_scope | Scope Boundaries | This slice only moves handoff entry points and excludes deep actions. |
+| BR-OUT-002 | out_of_scope | Scope Boundaries | Health category logic remains owned by HealthEvaluator and is unchanged. |
+| BR-Q-001 | covered_by_step | U1 | U1 requires automated/fixture checks where practical plus Bad QA Computer Use validation. |
+
+## Research
+
+- `CONTEXT.md` defines Kubebar as a native macOS menu bar app for glanceable
+  Kubernetes health and defines Health category as `OK`, `Watch`, `Bad`, or
+  `Stale`.
+- `.imm/memory/current_iteration.json` shows the previous handoff semantics
+  plan closed with QA pass evidence.
+- Computer Use validation of the Bad QA fixture showed Overview has
+  `Open qa-payments in k9s`, Pods rows have `Open qa-payments Pods in k9s` or
+  `Open qa-api Pods in k9s`, and Nodes rows have `Open Nodes in k9s`.
+- `Kubebar/Views/PodsTabView.swift` currently renders the k9s button inside
+  each `PodRowView`, after row content.
+- `Kubebar/Views/NodeDetailsView.swift` currently renders the k9s button
+  inside each `NodeRowView`, after node content.
+- `K9sResourceTarget` already has list-level targets:
+  `.podList(namespace:)` and `.nodeList`.
+- `K9sHandoffLauncher` already maps `.podList` to `-c pods` with namespace and
+  `.nodeList` to `-c nodes` without namespace.
+- The rejected decision
+  `docs/solutions/rejected-decisions/pod-resource-history-alerting-2026-05-14.md`
+  does not conflict; it rejected history/alert/dashboard expansion, while this
+  slice only moves existing external handoff entry placement.
+
+## Decisions
+
+- Treat this as one outcome step because the user-visible result is one
+  placement contract: list-level handoffs appear at group/list level.
+- Do not change the launcher target semantics introduced by the previous
+  slice.
+- Pods tab should expose namespace-level k9s entry near each namespace header.
+- Nodes tab should expose a single Nodes list-level entry near the summary or
+  header.
+- Pod and Node rows should not render k9s arrows while their target is a
+  list-level view.
+- Keep Overview handoff behavior unchanged.
+
+## Assumptions
+
+- Existing Swift tests can cover display-model and QA fixture expectations for
+  entry scope without live Kubernetes.
+- SwiftUI view layout for menu bar content still needs a visible check; use
+  the Bad QA fixture with Computer Use because it includes both Pods and Nodes
+  handoffs.
+- The current list-level launcher contract is correct and should be preserved.
+
+## Scope Boundaries
+
+- In scope: Pods namespace section entry placement, Nodes tab summary/header
+  entry placement, row-level handoff removal for Pods and Nodes, display-model
+  shape needed for those placements, copy/help/accessibility updates, QA
+  fixture metadata, tests, and runtime invariant updates.
+- Out of scope: Overview handoff changes, Recent Warnings handoff, exact k9s
+  Pod or Node positioning, keyboard automation, embedded terminal,
+  logs/describe/edit/exec/delete/port-forward/restart actions, resource
+  mutation, Health category changes, resource usage visualization changes,
+  history, and alerting.
+
+## Implementation Units
+
+### Step 1
+
+- Step ID: U1
+- Result: k9s list-level handoffs use group-level entries.
+- Verification: /usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local
+- Verification type: hitl
+- Depends on: None
+- Test scenarios: Pods namespace section exposes one k9s action for that namespace; Pod rows do not expose k9s actions; Nodes summary or header exposes one k9s action; Node rows do not expose k9s actions; Overview handoff remains visible in Bad QA state; app-owned context and resource view launcher tests remain green; Computer Use bad QA check confirms entry placement
+
+**Goal:** Align Pods and Nodes handoff affordance placement with the stable
+list-level `k9s` resource views they open.
+
+**Execution note:** test-first
+
+**Requirements:** R1-R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `KubebarCore/Models/MenuDisplayModel.swift`
+- Modify: `KubebarCore/Services/HealthEvaluator.swift`
+- Modify: `Kubebar/Views/PodsTabView.swift`
+- Modify: `Kubebar/Views/NodeDetailsView.swift`
+- Modify: `KubebarCore/QA/MenuStateFixtureCatalog.swift`
+- Modify: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- Modify: `KubebarTests/QA/MenuStateFixtureCatalogTests.swift`
+- Modify: `docs/architecture/runtime-invariants.md`
+- Reference: `KubebarCore/Services/K9sHandoffLauncher.swift`
+- Reference: `.imm/specs/2026-05-15-k9s-handoff-entry-placement.md`
+
+**Approach:**
+- Add failing tests or fixture assertions that encode section/header-level
+  handoff ownership and absence of row-level Pod/Node actions.
+- Move Pod list handoff data from rows to namespace section displays, or add a
+  section-level handoff while clearing row-level handoffs.
+- Move Node list handoff data from rows to the Nodes tab display, or add a
+  tab-level handoff while clearing row-level handoffs.
+- Render compact k9s buttons beside the namespace section label and Nodes
+  readiness summary/header.
+- Update help text, accessibility labels, QA expected behavior, and runtime
+  invariants to state that Pods and Nodes handoffs are group/list entries.
+- Preserve existing launcher behavior and stale/unavailable gating.
+- Run the Swift quality gate and a Bad QA visible check with Computer Use.
+
+**Verification:**
+- `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local`
+- `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/compile-and-run.sh --qa-state bad`
+- Computer Use visible check on the Bad QA fixture: Overview keeps its action,
+  Pods actions appear on namespace sections, and Nodes action appears on the
+  Nodes summary/header.
+
+**failure_behavior:** If SwiftUI view-level assertions cannot directly inspect
+the final button positions, keep automated display-model and QA fixture tests
+for ownership and require Computer Use evidence before QA pass.
+
+**security_considerations:** The change only moves local UI affordances and
+does not add data transmission, Secrets access, raw command output, or
+Kubernetes mutation.


### PR DESCRIPTION
## Summary
- Pods 的 `Open in k9s` 入口从 Pod 行移到 namespace 标题。
- Nodes 的 `Open in k9s` 入口从 Node 行移到 Nodes summary。
- 保留 Overview 的手动跳转入口，并同步更新 display model、fixture、文档和计划状态。

## User Impact
- 用户会在 Pods / Nodes 的组级标题上看到 k9s 入口，而不是在每一行上看到容易误解的跳转按钮。
- Overview 的 Bad QA 状态仍保留可见的 k9s 入口。

## Changelog
- 用户可见变更：Pods 和 Nodes 的 k9s 入口改为组级入口，避免将跳转目标误解为具体资源行。

## Validation
- 新增并更新了单元测试，覆盖 Pods namespace 级入口、Nodes summary 级入口，以及 Pod / Node 行不再暴露入口。
- 运行了相关 Swift 测试集和完整 `swift quality gate`，结果通过。
- 用 Bad QA fixture 做了本地可见验收，确认 Overview / Pods / Nodes 的入口位置符合预期。

## Security Impact
- None

## Blast Radius
- `MenuDisplayModel` 与 `HealthEvaluator` 的 k9s handoff 映射
- Pods / Nodes 视图的入口渲染位置
- QA fixture、运行时约束文档、相关测试

## Rollback Plan
- 回退这次提交即可恢复到行级 k9s 入口行为，同时撤销对应的测试、fixture 和文档更新。