### PR TITLE
fix(release): add 0.3.0 changelog notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-19
+
+### Added
+- Add a Settings toggle for Start at Login so users can launch Kubebar automatically after signing in.
+
 ## [0.2.4] - 2026-05-15
 
 ### Added

--- a/changelog.d/start-at-login-setting.added.md
+++ b/changelog.d/start-at-login-setting.added.md
@@ -1,2 +1,0 @@
-Add a Settings toggle for Start at Login so users can launch Kubebar
-automatically after signing in.


### PR DESCRIPTION
## Summary

- Release notes for Kubebar 0.3.0 now include the Start at Login setting users receive in this release.
- Finalizes the existing changelog fragment into `CHANGELOG.md` so the tag release workflow can extract notes.
- Removes the consumed `changelog.d` fragment to keep future release preparation clean.

## User Impact

Users will see accurate 0.3.0 release notes describing the Start at Login setting. No app runtime behavior changes in this PR.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Changelog

- [x] Added or updated a user-facing changelog entry in `changelog.d/`
- [ ] Not user-facing; changelog entry not needed

Changelog text:
Add a Settings toggle for Start at Login so users can launch Kubebar automatically after signing in.

## Linked Issue

None.

## Validation

- [ ] Linter passes with zero warnings
- [ ] Formatter produces no changes
- [x] Build succeeds
- [x] Relevant tests pass: `./scripts/extract-release-notes.sh 0.3.0`, `./scripts/test-changelog-tools.sh`, `/usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local`
- [x] Manual testing: verified `extract-release-notes.sh 0.3.0` emits the 0.3.0 release note instead of failing with a missing finalized section.

## Security Impact

None.

## Blast Radius

Release notes and release workflow input for tag `v0.3.0`. App code, runtime behavior, Kubernetes access, settings behavior, and build settings are unchanged.

## Rollback Plan

Revert commit `7d46a81` to remove the finalized 0.3.0 changelog section and restore the changelog fragment.

---

**Review track**: A (docs/tests/chore)
