### PR TITLE
feat: AI Diagnostic Assistant settings + Settings sidebar refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ xcuserdata/
 .skill-archive/
 DerivedDataLayoutCheck/
 DerivedDataRelease/
+/DerivedData-Launch
+/DerivedData-Launch

--- a/.imm/specs/2026-07-01-ai-diagnostic-assistant-settings.md
+++ b/.imm/specs/2026-07-01-ai-diagnostic-assistant-settings.md
@@ -1,0 +1,50 @@
+# AI Diagnostic Assistant Settings
+
+## Summary
+
+Kubebar will add an app-wide AI Diagnostic Assistant settings slice. Users can choose an AI provider, enter a model, store the provider API key in macOS Keychain, and manually run a safe Test Connection. The current executable slice does not send Kubernetes data for diagnosis; it preserves the confirmed privacy boundary that any later diagnostic payload is limited to user-approved warning text.
+
+## Output Language
+
+Spec and Plan prose are written in English. Code identifiers, schema fields, CLI commands, file paths, provider names, and Immune-Brain fields remain literal.
+
+## Requirements
+
+- R1: Add an `AI Diagnostic Assistant` section to the fixed `App Settings tab`.
+- R2: Support provider choices `OpenAI`, `Anthropic`, `Google Gemini`, and `OpenAI-compatible`.
+- R3: Remove the originally proposed `Ollama` option from the first version.
+- R4: Allow a user-defined `Model ID` for the selected provider.
+- R5: For `OpenAI-compatible`, allow only `Bearer` API key authentication, `Base URL`, and `Model ID`; custom headers are out of scope.
+- R6: Persist only non-secret AI Provider configuration in local app config.
+- R7: Store AI Provider API keys in macOS Keychain, never in `AppConfig` or `config.json`.
+- R8: Provide a manually triggered `Test Connection` action for the saved or edited provider configuration.
+- R9: Test Connection failure feedback must be safe: no raw API key, `Authorization` header, complete response body, raw request, or token-like text may be shown.
+- R10: External AI calls must go through injectable boundaries. SwiftUI views must not construct provider requests or read secrets directly.
+- R11: Test Connection must not send Kubernetes warnings, Pod logs, kubeconfig content, Secrets, raw `kubectl` output, or cluster JSON.
+- R12: Any future AI diagnostic request in this feature area must be manually triggered and limited to warning summary text.
+- R13: AI results and provider state must not affect `HealthEvaluator`, `MenuDisplayModel` health categorization, or the menu bar icon category.
+
+## Non-goals
+
+- No Ollama provider in this version.
+- No automatic or background AI diagnosis.
+- No Pod log submission.
+- No Kubernetes Secret reads or transmission.
+- No full `kubectl` transcript or cluster JSON transmission.
+- No chat history, account system, OAuth, cloud sync, prompt-template system, custom headers, or provider-specific advanced tuning.
+
+## Data and Security Boundaries
+
+`AI Provider configuration` is app-wide and may be saved with other local Settings metadata. `AI Provider API key` is secret material and belongs only in the Keychain credential boundary. Test Connection uses a minimal provider request and must sanitize transport, validation, and provider-error output before any text reaches runtime state or UI.
+
+The current slice only proves that provider configuration and credentials are usable. It does not implement warning explanation. The warning-text diagnostic boundary is preserved for a later plan so the future diagnostic slice cannot expand silently to Pod logs, Secrets, raw command output, or cluster JSON.
+
+## Success Criteria
+
+- Existing configs decode with default AI Provider configuration and no credential requirement.
+- Saving Settings round-trips provider/model/base URL metadata without serializing an API key.
+- Keychain operations are covered through an injectable credential-store protocol and fakes.
+- Test Connection request construction is covered for all four provider choices and validates the `OpenAI-compatible` Bearer/Base URL/Model ID contract.
+- Safe failure tests prove secrets and token-like values are redacted.
+- The App Settings UI exposes provider, model, OpenAI-compatible base URL, API key entry, and a manual Test Connection action.
+- Runtime docs preserve the rule that AI does not affect Health category and diagnostic input remains manually approved warning text only.

--- a/.imm/specs/2026-07-01-settings-sidebar-layout.md
+++ b/.imm/specs/2026-07-01-settings-sidebar-layout.md
@@ -1,0 +1,84 @@
+---
+title: "refactor: Settings sidebar detail layout"
+type: refactor
+status: planned
+date: 2026-07-01
+---
+
+# refactor: Settings sidebar detail layout
+
+## Output Language
+
+Spec prose is English. Schema fields, commands, file paths, Swift identifiers, canonical terms, and Immune-Brain fields stay literal.
+
+## Goal
+
+Redesign Kubebar Settings from a stacked `TabView` form into a clearer macOS-style sidebar/detail layout. The work should make App Settings feel structured instead of appended, give `AI Diagnostic Assistant` its own focused page, and preserve existing Settings behavior and persistence.
+
+## Problem
+
+The current Settings window renders all app-wide settings as one long `App Settings` page and appends `AI Diagnostic Assistant` below General, Kubeconfig, Launch, and Alerts. This makes unrelated concerns look equally weighted, creates a simple stacked-controls feel, and gives AI configuration no local information hierarchy even though it has provider, endpoint, credential, and connection-test concepts.
+
+## Confirmed Direction
+
+- Use a Settings sidebar with App-level pages and Context pages.
+- App pages are `General`, `Kubernetes`, `Notifications`, and `AI Assistant`.
+- Context pages continue to edit exactly one per-context watchlist.
+- `AI Assistant` is a dedicated App page, not a bottom section on a long App Settings page.
+- Keep a standard native macOS visual direction using inherited SwiftUI/system colors and typography.
+- Prioritize structure, spacing, and information hierarchy over decorative styling.
+
+## Requirements
+
+- R1: Replace the one-long-page App Settings presentation with sidebar navigation and a detail pane.
+- R2: Preserve App-level configuration behavior for refresh cadence, explicit kubeconfig paths, Start at Login, Health State Shift Alerts, and AI Provider configuration.
+- R3: Preserve Context Settings behavior for per-context watchlist editing.
+- R4: The Settings footer save action remains stable and predictable; local actions such as `Add Files` and `Test Connection` stay inside their relevant detail page.
+- R5: The `AI Assistant` page groups content as Provider, Endpoint, Credentials, and Connection.
+- R6: The `AI Assistant` page states that Test Connection is manual, API keys live in macOS Keychain, and Kubernetes data is not sent by Test Connection.
+- R7: `OpenAI-compatible` remains the only provider that shows `Base URL`; no custom-header UI is introduced.
+- R8: The detail pane scrolls when content is long while the window footer remains reachable.
+- R9: Form rows keep safe field widths instead of stretching across the full detail pane.
+- R10: The redesign does not change AI safety behavior, provider request behavior, Keychain storage behavior, Health category evaluation, or menu-bar health display.
+
+## Non-goals
+
+- No new AI provider, diagnostic request, warning explanation, chat surface, or automatic diagnosis.
+- No new Keychain behavior beyond preserving the already planned credential flow.
+- No Kubernetes read/write behavior changes.
+- No new visual theme, brand palette, custom icons, animations, or rich marketing-style UI.
+- No rewrite of the menu bar dropdown.
+
+## Page Design Contract
+
+- Page type: macOS Settings / forms.
+- Design tier: Standard.
+- Visual source: existing native SwiftUI Settings-style UI; no root `DESIGN.md` exists.
+- Theme and palette: inherited system appearance.
+- Main structure: sidebar on the left, detail pane on the right, footer at bottom.
+- Sidebar groups: App and Contexts.
+- App detail pages:
+  - `General`: refresh cadence and launch behavior.
+  - `Kubernetes`: kubeconfig discovery and explicit file list.
+  - `Notifications`: Health State Shift Alerts.
+  - `AI Assistant`: optional manual provider configuration and Test Connection.
+- Context detail pages: existing watchlist picker for the selected Kubernetes context.
+- Form bounds: fixed label width around the existing 140pt pattern; field max width approximately 320-380pt; helper text max width approximately 460pt.
+- Window bounds: may grow from the current 640pt width if needed to fit sidebar plus readable detail forms.
+
+## Acceptance Criteria
+
+- Users can navigate App pages and Context pages from a sidebar.
+- AI configuration is no longer visually appended to an unrelated long App Settings page.
+- Existing save behavior still preserves refresh cadence, kubeconfig paths, Start at Login, Health State Shift Alerts, AI Provider metadata, provider API key save semantics, and per-context watchlists.
+- Existing provider picker still excludes `Ollama` and includes `OpenAI-compatible`.
+- `Test Connection` remains a manually pressed local action.
+- Full Swift quality gate passes.
+- A visible Settings smoke check confirms the sidebar/detail hierarchy, AI page grouping, conditional Base URL, and stable footer.
+
+## Risks
+
+- Renaming tab-oriented state to page-oriented state may touch many tests; keep changes mechanical and covered by `SetupFlowStateTests` and `MenuRuntimeStateTests`.
+- Sidebar/detail layout may need a slightly wider window; avoid cramped fields rather than forcing the existing 640pt width.
+- UI-only refactor can accidentally change save semantics; focused state tests must guard completed config behavior.
+- Visible layout quality is partly HITL because no automated SwiftUI snapshot tests exist.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,6 +19,22 @@
   directionally worse Health category or watchlist attention changes. They are
   local app behavior, consume `MenuDisplayModel`, and must not add new health
   rules.
+- **AI Diagnostic Assistant**: an optional app-wide Settings feature for
+  manually testing a configured AI provider and, in a later diagnostic slice,
+  explaining user-approved warning text. It is display/help behavior only and
+  must not change `Health category`.
+- **AI Provider configuration**: non-secret app-wide provider metadata such as
+  provider kind, `Model ID`, and an `OpenAI-compatible` `Base URL`. It belongs
+  in App Settings and may be persisted in local app config.
+- **AI Provider API key**: the secret credential for an AI provider. It must be
+  stored in macOS Keychain, never in `AppConfig`, command output, diagnostics,
+  or visible raw error text.
+- **OpenAI-compatible provider**: a custom endpoint that uses only `Bearer` API
+  key authentication, `Base URL`, and `Model ID` in the first version. Custom
+  headers are out of scope.
+- **Warning text diagnostic input**: a future manually submitted AI diagnostic
+  payload limited to warning summary text. It does not include Pod logs,
+  Kubernetes Secrets, raw `kubectl` output, kubeconfig content, or cluster JSON.
 - **Pod Micro-Logs Drawer**: a user-opened focusable log window for a single
   `Bad` Pod row that streams a bounded `kubectl logs --tail=100 -f` view
   through Kubebar's app-owned context and kubeconfig. It is temporary
@@ -27,10 +43,12 @@
   Pod Micro-Logs Drawer for log output. It should use AppKit text behavior for
   top-left log layout, selection, copy, and scrolling instead of rebuilding a
   text viewer from primitive SwiftUI `ScrollView` and `Text`.
-- **App Settings tab**: the fixed first Settings tab for global app behavior
-  such as refresh cadence, Start at Login, and Health State Shift Alerts. It is
-  not tied to a Kubernetes context.
-- **Context Settings tab**: a Settings tab generated from local context
+- **App Settings page**: one of the fixed App-level Settings pages in the
+  Settings sidebar: `General`, `Kubernetes`, `Notifications`, and `AI Assistant`.
+  They are app-wide behavior such as refresh cadence, Start at Login, Health
+  State Shift Alerts, explicit kubeconfig paths, and AI Diagnostic Assistant
+  configuration, and are not tied to a Kubernetes context.
+- **Context Settings page**: a Settings page generated from local context
   information. It edits the per-context watchlist for exactly one Kubernetes
   context.
 - **Per-context watchlist**: a saved set of watch targets keyed by Kubernetes

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,62 +1,39 @@
 # Kubebar Handoff
 
-**Last updated**: 2026-06-22T08:40:00Z
+**Last updated**: 2026-07-01T11:00:00Z
 
 ## Current State
 
-- Plan: `docs/plans/2026-06-22-002-ci-release-flow-simplification-plan.md`
-- Summary: Release owners can follow a clearer prepare-then-publish path.
-- Status: implementation and local verification complete; ready for review or commit.
-- Completed work:
-  - Simplified `docs/RELEASING.md` so the normal path is prepare release notes, then publish.
-  - Moved changelog candidate generation and publish dry-run into optional validation guidance.
-  - Added a `Release` workflow summary step that states dry-run publish created no tag or GitHub Release.
+- Plan: `docs/plans/2026-07-01-002-refactor-settings-sidebar-layout-plan.md`
+- Summary: Settings redesigned from a stacked TabView into a sidebar/detail layout with a dedicated AI Assistant page; UI polish applied.
+- Status: complete with post-review polish.
+- Completed steps:
+  - U1 (closed): Settings state exposes page-oriented navigation while preserving completed configuration behavior.
+  - U2 (closed): Settings renders a sidebar/detail layout with AI Assistant as a focused App page.
 - Active step: none.
 
 ## Verification
 
-- `imm-plan docs/plans/2026-06-22-002-ci-release-flow-simplification-plan.md --json` passed.
-- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'` passed.
-- `./scripts/test-changelog-tools.sh` passed.
-- `./scripts/test-release-build-version.sh` passed.
+- `swift test --filter SetupFlowStateTests && swift test --filter MenuRuntimeStateTests` passed.
+- `swift build` passed.
+- `./scripts/swift-quality-gate.sh local` passed (318 tests, 31 suites, BUILD SUCCEEDED, TEST SUCCEEDED).
+- `rtk git diff --check` clean.
+- App launches cleanly via `./scripts/compile-and-run.sh`.
+
+## UI Polish Applied
+
+- Replaced invalid `k.stack` SF Symbol with `square.3.layers.3d`.
+- Added keyboard shortcuts `Cmd+1`..`Cmd+4` for App pages.
+- Merged AI Assistant sections into "Provider configuration" and "Connection".
+- Base URL hidden unless provider is `OpenAI-compatible`.
+- App pages show descriptive subtitles instead of active context.
+- Removed unnecessary `maxHeight: .infinity` from detail pane.
+- Widened `SettingsRow` content area to 360pt.
+- Raised window height to 620pt.
+- Added warning icon for contexts with no watchlist selected.
+- Unified sidebar row style: both App pages and Contexts use the same `HStack` helper with a fixed 20pt icon width, identical spacing, and optional trailing warning icon, so icons and text align consistently across the App and Contexts sections.
 
 ## Notes
 
-- `imm-plan --sync` is unavailable in this local CLI, but `imm-plan --json`
-  wrote the validated plan snapshot into `.imm/memory/current_iteration.json`.
-- No real release was published by this work.
-- `v0.5.0` still needs a separate real publish run with `mode=publish`,
-  `version=0.5.0`, and `dry_run=false` after this change is reviewed.
-
-## Compaction Handoff
-
-### Active plan
-
-`docs/plans/2026-06-22-002-ci-release-flow-simplification-plan.md`
-
-### Active step
-
-None. The single planned implementation step has local verification evidence.
-
-### Files in play (compaction priority)
-
-1. `.github/workflows/release.yml` - dry-run publish summary
-2. `docs/RELEASING.md` - simplified release-owner flow
-3. `docs/specs/2026-06-22-release-flow-simplification.md` - scope/spec
-4. `docs/plans/2026-06-22-002-ci-release-flow-simplification-plan.md` - validated plan
-5. `.imm/memory/current_iteration.json` - validated plan snapshot
-
-### Uncommitted work
-
-Modified workflow/docs plus new release simplification spec and plan.
-
-### Decisions this session
-
-- Do not publish `v0.5.0` in this change.
-- Keep dry-run publish available, but label it as optional and non-publishing.
-- Preserve existing tag creation and GitHub Release conditions.
-
-### Next boundary
-
-Review or commit the release-flow simplification, then run the real `v0.5.0`
-publish workflow separately.
+- No automated SwiftUI snapshot tests exist; layout quality is HITL.
+- Native macOS app screenshots require Accessibility consent (not available in this environment).

--- a/Kubebar.xcodeproj/project.pbxproj
+++ b/Kubebar.xcodeproj/project.pbxproj
@@ -7,6 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A20000000000000000000001 /* AIDiagnosticAssistantConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000002 /* AIDiagnosticAssistantConfig.swift */; };
+		A20000000000000000000003 /* AIDiagnosticAssistantState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000004 /* AIDiagnosticAssistantState.swift */; };
+		A20000000000000000000005 /* AIProviderCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000006 /* AIProviderCredentialStore.swift */; };
+		A20000000000000000000007 /* AIProviderConnectionTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000008 /* AIProviderConnectionTester.swift */; };
+		A20000000000000000000009 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000A /* HTTPClient.swift */; };
+		A2000000000000000000000B /* AIProviderCredentialStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000C /* AIProviderCredentialStoreTests.swift */; };
+		A2000000000000000000000D /* AIProviderConnectionTesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000E /* AIProviderConnectionTesterTests.swift */; };
+		A2000000000000000000000F /* KeychainAIProviderCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000010 /* KeychainAIProviderCredentialStore.swift */; };
+		A20000000000000000000011 /* URLSessionHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000012 /* URLSessionHTTPClient.swift */; };
 		0ABC7D9044D83EA481BBB112 /* WatchTargetCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD651CCDAAD62B4E7C090D6F /* WatchTargetCatalog.swift */; };
 		0C5D3D56CEDAB47E9528A4F6 /* WatchlistCandidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CF64AA3581163BEA218DFB /* WatchlistCandidate.swift */; };
 		0D127D20E9DEDC847D33AE77 /* MenuDisplayModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27036F7AEDEFA527AF44A619 /* MenuDisplayModelTests.swift */; };
@@ -134,6 +143,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A20000000000000000000002 /* AIDiagnosticAssistantConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIDiagnosticAssistantConfig.swift; sourceTree = "<group>"; };
+		A20000000000000000000004 /* AIDiagnosticAssistantState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIDiagnosticAssistantState.swift; sourceTree = "<group>"; };
+		A20000000000000000000006 /* AIProviderCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderCredentialStore.swift; sourceTree = "<group>"; };
+		A20000000000000000000008 /* AIProviderConnectionTester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderConnectionTester.swift; sourceTree = "<group>"; };
+		A2000000000000000000000A /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
+		A2000000000000000000000C /* AIProviderCredentialStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderCredentialStoreTests.swift; sourceTree = "<group>"; };
+		A2000000000000000000000E /* AIProviderConnectionTesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderConnectionTesterTests.swift; sourceTree = "<group>"; };
+		A20000000000000000000010 /* KeychainAIProviderCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAIProviderCredentialStore.swift; sourceTree = "<group>"; };
+		A20000000000000000000012 /* URLSessionHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHTTPClient.swift; sourceTree = "<group>"; };
 		039D4A0BD680E236E953D7EF /* StatusSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusSummaryView.swift; sourceTree = "<group>"; };
 		03C2110AF1395713CD29D1E3 /* MenuBarStatusPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentationTests.swift; sourceTree = "<group>"; };
 		044436EFC75907A7253A3A7A /* SettingsRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRootView.swift; sourceTree = "<group>"; };
@@ -310,6 +328,8 @@
 			isa = PBXGroup;
 			children = (
 				684455D1430321334848EB7F /* AppConfigStoreTests.swift */,
+				A2000000000000000000000C /* AIProviderCredentialStoreTests.swift */,
+				A2000000000000000000000E /* AIProviderConnectionTesterTests.swift */,
 				B29566B59D491F95C0EE5504 /* CommandRunnerTests.swift */,
 				8727736B73E1A28F6DC70C66 /* ContextCatalogTests.swift */,
 				BEC71932B945E1D6592AA77E /* FreshnessDisplayScheduleTests.swift */,
@@ -330,6 +350,8 @@
 		83DF995219C93DBAE4855014 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				A20000000000000000000002 /* AIDiagnosticAssistantConfig.swift */,
+				A20000000000000000000004 /* AIDiagnosticAssistantState.swift */,
 				256B0E761A99ACDD9110BC8E /* ClusterHealthState.swift */,
 				7BF8969BAFC7CADA85C406E9 /* ClusterSnapshot.swift */,
 				E4EFC03EAA7FF0C71200678B /* MenuBarStatusPresentation.swift */,
@@ -350,6 +372,9 @@
 			isa = PBXGroup;
 			children = (
 				E3CFEB46C82EDA2D094BDDF0 /* AppConfigStore.swift */,
+				A20000000000000000000006 /* AIProviderCredentialStore.swift */,
+				A20000000000000000000008 /* AIProviderConnectionTester.swift */,
+				A2000000000000000000000A /* HTTPClient.swift */,
 				A59D91E3E139CA91BC232D40 /* CommandRunner.swift */,
 				16B80AFB0373C83CDF78D0BE /* ContextCatalog.swift */,
 				F145C7042CEB53D7185BD7FA /* FreshnessDisplaySchedule.swift */,
@@ -373,6 +398,8 @@
 			children = (
 				A10000000000000000000007 /* LoginItemController.swift */,
 				A1000000000000000000000E /* NetworkReachabilityMonitor.swift */,
+				A20000000000000000000010 /* KeychainAIProviderCredentialStore.swift */,
+				A20000000000000000000012 /* URLSessionHTTPClient.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -547,6 +574,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				3A2ABB50330CBD164F187074 /* AppConfigStoreTests.swift in Sources */,
+				A2000000000000000000000B /* AIProviderCredentialStoreTests.swift in Sources */,
+				A2000000000000000000000D /* AIProviderConnectionTesterTests.swift in Sources */,
 				495D556A6DF84C8C22BB9D63 /* ClusterHealthStateTests.swift in Sources */,
 				2673AA6352855DBB0B87599A /* CommandRunnerTests.swift in Sources */,
 				1956982E5C1832CD17224A14 /* ContextCatalogTests.swift in Sources */,
@@ -577,6 +606,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				279114E96D410FFB2622B97E /* AppConfigStore.swift in Sources */,
+				A20000000000000000000001 /* AIDiagnosticAssistantConfig.swift in Sources */,
+				A20000000000000000000003 /* AIDiagnosticAssistantState.swift in Sources */,
+				A20000000000000000000005 /* AIProviderCredentialStore.swift in Sources */,
+				A20000000000000000000007 /* AIProviderConnectionTester.swift in Sources */,
+				A20000000000000000000009 /* HTTPClient.swift in Sources */,
 				43A2E812863B312A3F47C289 /* ClusterHealthState.swift in Sources */,
 				DC3D760FA2EF2E5789C6CD21 /* ClusterSnapshot.swift in Sources */,
 				3C89297B5C863C683E8D33CA /* CommandRunner.swift in Sources */,
@@ -616,6 +650,8 @@
 				E557AF4691C5FFE49437ADB4 /* EventsTabView.swift in Sources */,
 				323A03773863A8CD97D0BA65 /* InlineProgressBar.swift in Sources */,
 				1E1CA9DB320A0E65272B5E42 /* KubebarApp.swift in Sources */,
+				A2000000000000000000000F /* KeychainAIProviderCredentialStore.swift in Sources */,
+				A20000000000000000000011 /* URLSessionHTTPClient.swift in Sources */,
 				A10000000000000000000003 /* LoginItemController.swift in Sources */,
 				A1000000000000000000000B /* NetworkReachabilityMonitor.swift in Sources */,
 				229B3FE94ACDE1EB70B1869A /* MenuBarRootView.swift in Sources */,

--- a/Kubebar/KubebarApp.swift
+++ b/Kubebar/KubebarApp.swift
@@ -20,6 +20,7 @@ struct KubebarApp: App {
                 onPrepare: viewModel.prepareSettings,
                 onComplete: viewModel.completeSetup,
                 onSelectAppSettings: viewModel.selectAppSettingsTab,
+                onSelectAppPage: viewModel.selectAppPage,
                 onSelectContext: viewModel.selectSetupContext,
                 onRetryTargets: viewModel.retryWatchTargetLoad,
                 onToggleStartAtLogin: viewModel.setStartAtLoginEnabled,
@@ -27,7 +28,12 @@ struct KubebarApp: App {
                 onAddKubeconfigPaths: viewModel.addKubeconfigPaths,
                 onRemoveKubeconfigPath: viewModel.removeKubeconfigPath,
                 onMoveKubeconfigPathUp: viewModel.moveKubeconfigPathUp,
-                onMoveKubeconfigPathDown: viewModel.moveKubeconfigPathDown
+                onMoveKubeconfigPathDown: viewModel.moveKubeconfigPathDown,
+                onUpdateAIProvider: viewModel.updateAIProvider,
+                onUpdateAIModelID: viewModel.updateAIModelID,
+                onUpdateAIBaseURL: viewModel.updateAIBaseURL,
+                onUpdateAIAPIKeyDraft: viewModel.updateAIAPIKeyDraft,
+                onTestAIConnection: viewModel.testAIConnection
             )
         }
     }

--- a/Kubebar/MenuBarViewModel.swift
+++ b/Kubebar/MenuBarViewModel.swift
@@ -61,6 +61,8 @@ final class MenuBarViewModel: ObservableObject {
     private let healthShiftAlertNotifier: any HealthShiftAlertNotifying
     private let networkReachability: any NetworkReachability
     private let podLogStreamer: any PodLogStreaming
+    private let aiCredentialStore: any AIProviderCredentialStoring
+    private let aiConnectionTester: AIProviderConnectionTester?
     private var isNetworkAvailable: Bool = true
     private var healthShiftAlertTracker: HealthShiftAlertTracker
     private var healthShiftAlertSettingsRequestGate: HealthShiftAlertSettingsRequestGate
@@ -70,6 +72,7 @@ final class MenuBarViewModel: ObservableObject {
     /// Delay before resuming automatic refresh after network recovery.
     /// Avoids rapid kubectl calls during unstable Wi-Fi reconnection.
     private static let networkRecoveryDebounceNanoseconds: UInt64 = 2_000_000_000
+    private static let aiCredentialSaveFailureMessage = "Could not save API key. Check macOS Keychain access."
 
     init(
         configStore: AppConfigStore = AppConfigStore(directory: MenuBarViewModel.defaultConfigDirectory),
@@ -83,6 +86,11 @@ final class MenuBarViewModel: ObservableObject {
         healthShiftAlertNotifier: any HealthShiftAlertNotifying = SystemHealthShiftAlertNotifier(),
         networkReachability: any NetworkReachability = NetworkReachabilityMonitor(),
         podLogStreamer: any PodLogStreaming = ProcessPodLogStreamer(),
+        aiCredentialStore: any AIProviderCredentialStoring = KeychainAIProviderCredentialStore(),
+        aiConnectionTester: AIProviderConnectionTester? = AIProviderConnectionTester(
+            credentialStore: KeychainAIProviderCredentialStore(),
+            httpClient: URLSessionHTTPClient()
+        ),
         now: Date = Date()
     ) {
         self.configStore = configStore
@@ -95,6 +103,8 @@ final class MenuBarViewModel: ObservableObject {
         self.healthShiftAlertNotifier = healthShiftAlertNotifier
         self.networkReachability = networkReachability
         self.podLogStreamer = podLogStreamer
+        self.aiCredentialStore = aiCredentialStore
+        self.aiConnectionTester = aiConnectionTester
 
         do {
             self.config = try configStore.load()
@@ -231,6 +241,21 @@ final class MenuBarViewModel: ObservableObject {
 
         do {
             try configStore.save(completedConfig)
+
+            if runtimeState.setupState.aiDiagnosticAssistant.hasAPIKeyDraft {
+                do {
+                    try aiCredentialStore.saveAPIKey(
+                        runtimeState.setupState.aiDiagnosticAssistant.apiKeyDraft,
+                        for: completedConfig.aiDiagnosticAssistant.provider
+                    )
+                } catch {
+                    runtimeState.markConfigurationSaveFailed(Self.aiCredentialSaveFailureMessage)
+                    publishRuntimeState()
+                    return false
+                }
+            }
+
+            runtimeState.setupState.updateAIDiagnosticAssistantAPIKeyDraft("")
             closePodLogDrawer()
             config = completedConfig
             activeContextName = completedConfig.selectedContext
@@ -304,6 +329,47 @@ final class MenuBarViewModel: ObservableObject {
         publishRuntimeState()
     }
 
+    func updateAIProvider(_ provider: AIProvider) {
+        runtimeState.setupState.updateAIDiagnosticAssistant(provider: provider)
+        publishRuntimeState()
+    }
+
+    func updateAIModelID(_ modelID: String) {
+        runtimeState.setupState.updateAIDiagnosticAssistant(modelID: modelID)
+        publishRuntimeState()
+    }
+
+    func updateAIBaseURL(_ baseURL: String) {
+        runtimeState.setupState.updateAIDiagnosticAssistant(baseURL: baseURL)
+        publishRuntimeState()
+    }
+
+    func updateAIAPIKeyDraft(_ draft: String) {
+        runtimeState.setupState.updateAIDiagnosticAssistantAPIKeyDraft(draft)
+        publishRuntimeState()
+    }
+
+    func testAIConnection() {
+        guard let tester = aiConnectionTester else {
+            return
+        }
+
+        let provider = runtimeState.setupState.aiDiagnosticAssistant.config.provider
+        let config = runtimeState.setupState.aiDiagnosticAssistant.config
+        let draft = runtimeState.setupState.aiDiagnosticAssistant.hasAPIKeyDraft
+            ? runtimeState.setupState.aiDiagnosticAssistant.apiKeyDraft
+            : nil
+
+        runtimeState.setupState.applyAIDiagnosticAssistantTestConnectionResult(nil)
+        publishRuntimeState()
+
+        Task {
+            let result = await tester.testConnection(config: config, provider: provider, apiKeyOverride: draft)
+            runtimeState.setupState.applyAIDiagnosticAssistantTestConnectionResult(result)
+            publishRuntimeState()
+        }
+    }
+
     func selectSetupContext(_ context: String?) {
         k9sHandoffCoordinator.clear()
         watchTargetLoadTask?.cancel()
@@ -318,6 +384,12 @@ final class MenuBarViewModel: ObservableObject {
     func selectAppSettingsTab() {
         k9sHandoffCoordinator.clear()
         runtimeState.selectAppSettingsTab()
+        publishRuntimeState()
+    }
+
+    func selectAppPage(_ page: SettingsTabSelection) {
+        k9sHandoffCoordinator.clear()
+        runtimeState.selectAppPage(page)
         publishRuntimeState()
     }
 

--- a/Kubebar/Services/KeychainAIProviderCredentialStore.swift
+++ b/Kubebar/Services/KeychainAIProviderCredentialStore.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Security
+import KubebarCore
+
+/// Production Keychain-backed credential store for AI provider API keys.
+///
+/// Keys are namespaced by `AIProvider` raw value so switching providers
+/// never overwrites another provider's key.
+final class KeychainAIProviderCredentialStore: AIProviderCredentialStoring, @unchecked Sendable {
+    private static let service = "com.nextty.kubebar.ai-provider"
+
+    func loadAPIKey(for provider: AIProvider) throws -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: provider.rawValue,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        switch status {
+        case errSecSuccess:
+            guard let data = result as? Data, let key = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+            return key
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw AIProviderCredentialStoreError.cannotLoad
+        }
+    }
+
+    func saveAPIKey(_ key: String, for provider: AIProvider) throws {
+        let data = Data(key.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: provider.rawValue
+        ]
+
+        let attributes: [String: Any] = [
+            kSecValueData as String: data
+        ]
+
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        switch updateStatus {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if addStatus != errSecSuccess {
+                throw AIProviderCredentialStoreError.cannotSave
+            }
+        default:
+            throw AIProviderCredentialStoreError.cannotSave
+        }
+    }
+
+    func deleteAPIKey(for provider: AIProvider) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: provider.rawValue
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            throw AIProviderCredentialStoreError.cannotDelete
+        }
+    }
+}
+
+enum AIProviderCredentialStoreError: Error, Equatable {
+    case cannotLoad
+    case cannotSave
+    case cannotDelete
+}

--- a/Kubebar/Services/URLSessionHTTPClient.swift
+++ b/Kubebar/Services/URLSessionHTTPClient.swift
@@ -1,0 +1,15 @@
+import Foundation
+import KubebarCore
+
+/// Production HTTP client wrapping `URLSession` for AI provider requests.
+final class URLSessionHTTPClient: HTTPClient, @unchecked Sendable {
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await session.data(for: request)
+    }
+}

--- a/Kubebar/Views/SettingsRootView.swift
+++ b/Kubebar/Views/SettingsRootView.swift
@@ -8,6 +8,7 @@ struct SettingsRootView: View {
     let onPrepare: () -> Void
     let onComplete: () -> Bool
     let onSelectAppSettings: () -> Void
+    let onSelectAppPage: (SettingsTabSelection) -> Void
     let onSelectContext: (String?) -> Void
     let onRetryTargets: () -> Void
     let onToggleStartAtLogin: (Bool) -> Void
@@ -16,6 +17,11 @@ struct SettingsRootView: View {
     let onRemoveKubeconfigPath: (Int) -> Void
     let onMoveKubeconfigPathUp: (Int) -> Void
     let onMoveKubeconfigPathDown: (Int) -> Void
+    let onUpdateAIProvider: (AIProvider) -> Void
+    let onUpdateAIModelID: (String) -> Void
+    let onUpdateAIBaseURL: (String) -> Void
+    let onUpdateAIAPIKeyDraft: (String) -> Void
+    let onTestAIConnection: () -> Void
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -24,6 +30,7 @@ struct SettingsRootView: View {
             primaryActionTitle: state.primaryActionTitle(isEditingExistingConfig: isEditingExistingConfig),
             onComplete: completeAndDismissIfSaved,
             onSelectAppSettings: onSelectAppSettings,
+            onSelectAppPage: onSelectAppPage,
             onSelectContext: onSelectContext,
             onRetryTargets: onRetryTargets,
             onToggleStartAtLogin: onToggleStartAtLogin,
@@ -31,7 +38,12 @@ struct SettingsRootView: View {
             onAddKubeconfigPaths: chooseKubeconfigPaths,
             onRemoveKubeconfigPath: onRemoveKubeconfigPath,
             onMoveKubeconfigPathUp: onMoveKubeconfigPathUp,
-            onMoveKubeconfigPathDown: onMoveKubeconfigPathDown
+            onMoveKubeconfigPathDown: onMoveKubeconfigPathDown,
+            onUpdateAIProvider: onUpdateAIProvider,
+            onUpdateAIModelID: onUpdateAIModelID,
+            onUpdateAIBaseURL: onUpdateAIBaseURL,
+            onUpdateAIAPIKeyDraft: onUpdateAIAPIKeyDraft,
+            onTestAIConnection: onTestAIConnection
         )
         .frame(
             width: SettingsWindowLayout.width,
@@ -68,8 +80,8 @@ struct SettingsRootView: View {
 }
 
 private enum SettingsWindowLayout {
-    static let width: CGFloat = 640
-    static let height: CGFloat = 560
+    static let width: CGFloat = 760
+    static let height: CGFloat = 620
 }
 
 @MainActor

--- a/Kubebar/Views/SetupView.swift
+++ b/Kubebar/Views/SetupView.swift
@@ -6,6 +6,7 @@ struct SetupView: View {
     let primaryActionTitle: String
     let onComplete: () -> Void
     let onSelectAppSettings: () -> Void
+    let onSelectAppPage: (SettingsTabSelection) -> Void
     let onSelectContext: (String?) -> Void
     let onRetryTargets: () -> Void
     let onToggleStartAtLogin: (Bool) -> Void
@@ -14,12 +15,18 @@ struct SetupView: View {
     let onRemoveKubeconfigPath: (Int) -> Void
     let onMoveKubeconfigPathUp: (Int) -> Void
     let onMoveKubeconfigPathDown: (Int) -> Void
+    let onUpdateAIProvider: (AIProvider) -> Void
+    let onUpdateAIModelID: (String) -> Void
+    let onUpdateAIBaseURL: (String) -> Void
+    let onUpdateAIAPIKeyDraft: (String) -> Void
+    let onTestAIConnection: () -> Void
 
     init(
         state: Binding<SetupFlowState>,
         primaryActionTitle: String = "Finish setup",
         onComplete: @escaping () -> Void = {},
         onSelectAppSettings: @escaping () -> Void = {},
+        onSelectAppPage: @escaping (SettingsTabSelection) -> Void = { _ in },
         onSelectContext: @escaping (String?) -> Void = { _ in },
         onRetryTargets: @escaping () -> Void = {},
         onToggleStartAtLogin: @escaping (Bool) -> Void = { _ in },
@@ -27,12 +34,18 @@ struct SetupView: View {
         onAddKubeconfigPaths: @escaping () -> Void = {},
         onRemoveKubeconfigPath: @escaping (Int) -> Void = { _ in },
         onMoveKubeconfigPathUp: @escaping (Int) -> Void = { _ in },
-        onMoveKubeconfigPathDown: @escaping (Int) -> Void = { _ in }
+        onMoveKubeconfigPathDown: @escaping (Int) -> Void = { _ in },
+        onUpdateAIProvider: @escaping (AIProvider) -> Void = { _ in },
+        onUpdateAIModelID: @escaping (String) -> Void = { _ in },
+        onUpdateAIBaseURL: @escaping (String) -> Void = { _ in },
+        onUpdateAIAPIKeyDraft: @escaping (String) -> Void = { _ in },
+        onTestAIConnection: @escaping () -> Void = {}
     ) {
         _state = state
         self.primaryActionTitle = primaryActionTitle
         self.onComplete = onComplete
         self.onSelectAppSettings = onSelectAppSettings
+        self.onSelectAppPage = onSelectAppPage
         self.onSelectContext = onSelectContext
         self.onRetryTargets = onRetryTargets
         self.onToggleStartAtLogin = onToggleStartAtLogin
@@ -41,30 +54,87 @@ struct SetupView: View {
         self.onRemoveKubeconfigPath = onRemoveKubeconfigPath
         self.onMoveKubeconfigPathUp = onMoveKubeconfigPathUp
         self.onMoveKubeconfigPathDown = onMoveKubeconfigPathDown
+        self.onUpdateAIProvider = onUpdateAIProvider
+        self.onUpdateAIModelID = onUpdateAIModelID
+        self.onUpdateAIBaseURL = onUpdateAIBaseURL
+        self.onUpdateAIAPIKeyDraft = onUpdateAIAPIKeyDraft
+        self.onTestAIConnection = onTestAIConnection
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            settingsTabs
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 0) {
+                settingsSidebar
+                Divider()
+                settingsDetail
+            }
             footer
         }
-        .padding(.horizontal, 24)
-        .padding(.top, 18)
-        .padding(.bottom, 16)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
-    private var settingsTabs: some View {
-        TabView(selection: selectedSettingsTabIDBinding) {
-            ForEach(state.settingsTabs, id: \.id) { tab in
-                settingsTabContent(for: tab)
-                    .padding(.top, 12)
-                    .tabItem {
-                        Label(tab.title, systemImage: tab.systemImageName)
-                    }
-                    .tag(tab.id)
-                    .help(Text(tab.helpText))
+    private var settingsSidebar: some View {
+        List(selection: selectedSettingsTabIDBinding) {
+            Section("App") {
+                ForEach(Array(SetupFlowState.appPages.enumerated()), id: \.element.id) { index, page in
+                    sidebarRow(
+                        title: page.title,
+                        icon: page.systemImageName,
+                        tabID: page.id,
+                        help: page.helpText,
+                        warning: false
+                    )
+                    .keyboardShortcut(KeyEquivalent(Character("\(index + 1)")), modifiers: .command)
+                }
             }
+
+            if !state.contextTabs.isEmpty {
+                Section("Contexts") {
+                    ForEach(state.contextTabs, id: \.self) { context in
+                        sidebarRow(
+                            title: context,
+                            icon: "server.rack",
+                            tabID: SettingsTabID.context(context),
+                            help: context,
+                            warning: state.watchlistState(for: context).isNamespaceSelectionEmpty
+                        )
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .frame(width: 180, alignment: .leading)
+    }
+
+    private func sidebarRow(title: String, icon: String, tabID: SettingsTabID, help: String, warning: Bool) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .foregroundStyle(.secondary)
+                .frame(width: 20, alignment: .leading)
+
+            Text(title)
+                .lineLimit(1)
+
+            Spacer()
+
+            if warning {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+                    .help(Text("No namespaces selected"))
+            }
+        }
+        .tag(tabID)
+        .help(Text(help))
+    }
+
+    private var settingsDetail: some View {
+        ScrollView {
+            settingsTabContent(for: selectedSettingsTab)
+                .padding(.horizontal, 24)
+                .padding(.top, 18)
+                .padding(.bottom, 12)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
@@ -72,36 +142,125 @@ struct SetupView: View {
     @ViewBuilder
     private func settingsTabContent(for tab: SettingsTabSelection) -> some View {
         switch tab {
-        case .appSettings:
-            appSettingsContent
+        case .general:
+            generalContent
+        case .kubernetes:
+            kubernetesContent
+        case .notifications:
+            notificationsContent
+        case .aiAssistant:
+            aiAssistantContent
         case let .context(context):
             contextSettingsContent(for: context)
         }
     }
 
-    private var appSettingsContent: some View {
+    private var generalContent: some View {
         SettingsContentPane {
             SettingsPaneHeader(
-                title: "App Settings",
+                title: "General",
                 subtitle: appSettingsSubtitle
             )
 
-            SettingsSection(title: "General") {
+            SettingsSection(title: "Refresh") {
                 SettingsRow(label: "Refresh cadence") {
                     refreshCadencePicker
                 }
             }
 
-            SettingsSection(title: "Kubeconfig") {
-                kubeconfigPathsSection
-            }
-
             SettingsSection(title: "Launch") {
                 startAtLoginToggle
             }
+        }
+    }
+
+    private var kubernetesContent: some View {
+        SettingsContentPane {
+            SettingsPaneHeader(
+                title: "Kubernetes",
+                subtitle: "How Kubebar discovers kubeconfig files for app-owned kubectl reads."
+            )
+
+            SettingsSection(title: "Kubeconfig") {
+                kubeconfigPathsSection
+            }
+        }
+    }
+
+    private var notificationsContent: some View {
+        SettingsContentPane {
+            SettingsPaneHeader(
+                title: "Notifications",
+                subtitle: "Local alerts for meaningful health changes. Alerts never change cluster health."
+            )
 
             SettingsSection(title: "Alerts") {
                 healthShiftAlertsToggle
+            }
+        }
+    }
+
+    private var aiAssistantContent: some View {
+        SettingsContentPane {
+            SettingsPaneHeader(
+                title: "AI Assistant",
+                subtitle: "Optional manual AI provider configuration for diagnostic help."
+            )
+
+            Text("Test Connection sends only a provider ping. Kubernetes data is never sent. API keys are stored in macOS Keychain.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.bottom, 4)
+
+            SettingsSection(title: "Provider configuration") {
+                SettingsRow(label: "Provider") {
+                    Picker("AI Provider", selection: aiProviderBinding) {
+                        Text("OpenAI").tag(AIProvider.openAI)
+                        Text("Anthropic").tag(AIProvider.anthropic)
+                        Text("Google Gemini").tag(AIProvider.gemini)
+                        Text("OpenAI-compatible").tag(AIProvider.openAICompatible)
+                    }
+                    .labelsHidden()
+                    .accessibilityLabel(Text("AI Provider"))
+                }
+
+                SettingsRow(label: "Model ID") {
+                    TextField("gpt-4o-mini", text: aiModelIDBinding)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel(Text("AI Model ID"))
+                }
+
+                if state.aiDiagnosticAssistant.config.provider == .openAICompatible {
+                    SettingsRow(label: "Base URL") {
+                        TextField("https://example.test/v1", text: aiBaseURLBinding)
+                            .textFieldStyle(.roundedBorder)
+                            .accessibilityLabel(Text("AI Base URL"))
+                    }
+                }
+            }
+
+            SettingsSection(title: "Connection") {
+                SettingsRow(label: "API Key") {
+                    SecureField("Leave blank to keep saved key", text: aiAPIKeyDraftBinding)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel(Text("AI API Key"))
+                }
+
+                SettingsRow(label: "Status") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Button("Test Connection", action: onTestAIConnection)
+                            .buttonStyle(.bordered)
+                            .accessibilityLabel(Text("Test AI Connection"))
+
+                        if let message = state.aiDiagnosticAssistant.testConnectionMessage, !message.isEmpty {
+                            Text(message)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
             }
         }
     }
@@ -137,10 +296,9 @@ struct SetupView: View {
                 }
 
                 switch tab {
-                case .appSettings:
-                    state.selectAppSettingsTab()
-                    state.configurationMessage = nil
-                    onSelectAppSettings()
+                case .general, .kubernetes, .notifications, .aiAssistant:
+                    state.selectAppPage(tab)
+                    onSelectAppPage(tab)
                 case let .context(context):
                     onSelectContext(context)
                 }
@@ -150,35 +308,19 @@ struct SetupView: View {
 
     private var footerHelpText: String {
         switch selectedSettingsTab {
-        case .appSettings:
+        case .general, .kubernetes, .notifications, .aiAssistant:
             if let configurationMessage = state.configurationMessage, !configurationMessage.isEmpty {
                 return configurationMessage
             }
 
-            if state.contextTabs.isEmpty {
-                return "No contexts available."
-            }
-
-            if let context = state.selectedContextForCompletedConfig {
-                return "Active context: \(context)"
-            }
-
-            return "Choose a context tab to finish setup."
+            return "App settings apply across all contexts."
         case .context:
             return state.configurationMessage ?? ""
         }
     }
 
     private var appSettingsSubtitle: String {
-        if let context = state.selectedContextForCompletedConfig {
-            return "Active context: \(context)"
-        }
-
-        if state.contextTabs.isEmpty {
-            return "No local contexts available."
-        }
-
-        return "Choose a context tab to finish setup."
+        "Configure app-wide behavior such as refresh cadence and startup."
     }
 
     private var refreshCadencePicker: some View {
@@ -313,7 +455,9 @@ struct SetupView: View {
                 .keyboardShortcut(.defaultAction)
                 .disabled(!state.isConfigured)
         }
-        .padding(.top, 2)
+        .padding(.horizontal, 24)
+        .padding(.top, 8)
+        .padding(.bottom, 16)
     }
 
     private var watchlistBinding: Binding<WatchlistSelectionState> {
@@ -337,6 +481,34 @@ struct SetupView: View {
         )
     }
 
+    private var aiProviderBinding: Binding<AIProvider> {
+        Binding(
+            get: { state.aiDiagnosticAssistant.config.provider },
+            set: { onUpdateAIProvider($0) }
+        )
+    }
+
+    private var aiModelIDBinding: Binding<String> {
+        Binding(
+            get: { state.aiDiagnosticAssistant.config.modelID },
+            set: { onUpdateAIModelID($0) }
+        )
+    }
+
+    private var aiBaseURLBinding: Binding<String> {
+        Binding(
+            get: { state.aiDiagnosticAssistant.config.baseURL ?? "" },
+            set: { onUpdateAIBaseURL($0) }
+        )
+    }
+
+    private var aiAPIKeyDraftBinding: Binding<String> {
+        Binding(
+            get: { state.aiDiagnosticAssistant.apiKeyDraft },
+            set: { onUpdateAIAPIKeyDraft($0) }
+        )
+    }
+
     private var kubeconfigPathsHelpText: String {
         state.usesAutomaticKubeconfigDetection
             ? "Use inherited KUBECONFIG first, then fall back to login shell lookup."
@@ -356,7 +528,7 @@ private struct SettingsContentPane<Content: View>: View {
             content
         }
         .padding(.top, 4)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 }
 
@@ -418,7 +590,7 @@ private struct SettingsRow<Content: View>: View {
                 .frame(width: 140, alignment: .leading)
 
             content
-                .frame(maxWidth: 280, alignment: .leading)
+                .frame(maxWidth: 360, alignment: .leading)
         }
     }
 }

--- a/KubebarCore/Models/AIDiagnosticAssistantConfig.swift
+++ b/KubebarCore/Models/AIDiagnosticAssistantConfig.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Non-secret AI Diagnostic Assistant provider metadata.
+///
+/// `API key` material is intentionally excluded from this value type so it can
+/// never be persisted through `AppConfig` or appear in `config.json`. Secret
+/// credentials belong to the Keychain credential store introduced in a later
+/// step.
+public struct AIDiagnosticAssistantConfig: Codable, Equatable, Sendable {
+    public let provider: AIProvider
+    public var modelID: String
+    public let baseURL: String?
+
+    public init(
+        provider: AIProvider = .openAI,
+        modelID: String = "",
+        baseURL: String? = nil
+    ) {
+        self.provider = provider
+        self.modelID = modelID
+        self.baseURL = baseURL
+    }
+
+    public func with(modelID: String) -> AIDiagnosticAssistantConfig {
+        AIDiagnosticAssistantConfig(
+            provider: provider,
+            modelID: modelID,
+            baseURL: baseURL
+        )
+    }
+
+    public func with(baseURL: String?) -> AIDiagnosticAssistantConfig {
+        AIDiagnosticAssistantConfig(
+            provider: provider,
+            modelID: modelID,
+            baseURL: baseURL
+        )
+    }
+}
+
+/// Supported AI providers for the AI Diagnostic Assistant.
+///
+/// `openAICompatible` targets custom OpenAI-compatible endpoints that use only
+/// Bearer authentication, a Base URL, and a Model ID. `ollama` is intentionally
+/// not included in this version.
+public enum AIProvider: String, Codable, Equatable, Sendable {
+    case openAI
+    case anthropic
+    case gemini
+    case openAICompatible
+}

--- a/KubebarCore/Models/AIDiagnosticAssistantState.swift
+++ b/KubebarCore/Models/AIDiagnosticAssistantState.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// UI-facing state for the AI Diagnostic Assistant Settings section.
+///
+/// Holds the non-secret provider configuration editing fields plus the
+/// transient API key draft and Test Connection result. The API key draft
+/// is never persisted through `AppConfig`; it is saved to the Keychain
+/// credential store only when Settings is saved.
+public struct AIDiagnosticAssistantState: Equatable, Sendable {
+    public var config: AIDiagnosticAssistantConfig
+    public var apiKeyDraft: String
+    public var testConnectionResult: AIProviderConnectionResult?
+
+    public init(
+        config: AIDiagnosticAssistantConfig = AIDiagnosticAssistantConfig(),
+        apiKeyDraft: String = "",
+        testConnectionResult: AIProviderConnectionResult? = nil
+    ) {
+        self.config = config
+        self.apiKeyDraft = apiKeyDraft
+        self.testConnectionResult = testConnectionResult
+    }
+
+    public var hasAPIKeyDraft: Bool {
+        !apiKeyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    public var testConnectionMessage: String? {
+        guard let result = testConnectionResult else {
+            return nil
+        }
+
+        switch result {
+        case .success:
+            return "Connection successful."
+        case let .failed(message):
+            return message
+        }
+    }
+}

--- a/KubebarCore/Models/MenuRuntimeState.swift
+++ b/KubebarCore/Models/MenuRuntimeState.swift
@@ -76,6 +76,10 @@ public struct MenuRuntimeState: Equatable, Sendable {
         setupState.configurationMessage = nil
     }
 
+    public mutating func selectAppPage(_ page: SettingsTabSelection) {
+        setupState.selectAppPage(page)
+    }
+
     public mutating func beginTargetLoading(for context: String) {
         guard setupState.selectedContext == context else {
             return
@@ -140,7 +144,8 @@ public struct MenuRuntimeState: Equatable, Sendable {
             watchlistsByContext: watchlistsByContext,
             refreshIntervalSeconds: setupState.refreshCadence.seconds,
             healthShiftAlertsEnabled: setupState.healthShiftAlerts.isEnabled,
-            kubeconfigPaths: setupState.kubeconfigPaths
+            kubeconfigPaths: setupState.kubeconfigPaths,
+            aiDiagnosticAssistant: setupState.aiDiagnosticAssistant.config
         )
     }
 
@@ -149,7 +154,8 @@ public struct MenuRuntimeState: Equatable, Sendable {
             completedWatchlistsByContext() != Self.namespaceWatchlists(from: config.watchlistsByContext) ||
             setupState.refreshCadence.seconds != config.refreshIntervalSeconds ||
             setupState.healthShiftAlerts.isEnabled != config.healthShiftAlertsEnabled ||
-            setupState.kubeconfigPaths != config.kubeconfigPaths
+            setupState.kubeconfigPaths != config.kubeconfigPaths ||
+            setupState.aiDiagnosticAssistant.config != config.aiDiagnosticAssistant
     }
 
     private func completedWatchlistsByContext() -> [String: [WatchTarget]] {
@@ -170,7 +176,8 @@ public struct MenuRuntimeState: Equatable, Sendable {
             watchlistsByContext: watchlistStates(from: config.watchlistsByContext),
             refreshCadence: config.refreshCadence,
             healthShiftAlerts: HealthShiftAlertsState(isEnabled: config.healthShiftAlertsEnabled),
-            kubeconfigPaths: config.kubeconfigPaths
+            kubeconfigPaths: config.kubeconfigPaths,
+            aiDiagnosticAssistant: AIDiagnosticAssistantState(config: config.aiDiagnosticAssistant)
         )
     }
 

--- a/KubebarCore/Models/SetupFlowState.swift
+++ b/KubebarCore/Models/SetupFlowState.swift
@@ -7,13 +7,22 @@ public enum WatchTargetLoadingState: Equatable, Sendable {
 }
 
 public enum SettingsTabSelection: Equatable, Hashable, Sendable {
-    case appSettings
+    case general
+    case kubernetes
+    case notifications
+    case aiAssistant
     case context(String)
 
     public var id: SettingsTabID {
         switch self {
-        case .appSettings:
-            return .appSettings
+        case .general:
+            return .general
+        case .kubernetes:
+            return .kubernetes
+        case .notifications:
+            return .notifications
+        case .aiAssistant:
+            return .aiAssistant
         case let .context(context):
             return .context(context)
         }
@@ -21,8 +30,14 @@ public enum SettingsTabSelection: Equatable, Hashable, Sendable {
 
     public var title: String {
         switch self {
-        case .appSettings:
-            return "App Settings"
+        case .general:
+            return "General"
+        case .kubernetes:
+            return "Kubernetes"
+        case .notifications:
+            return "Notifications"
+        case .aiAssistant:
+            return "AI Assistant"
         case let .context(context):
             return context
         }
@@ -30,8 +45,14 @@ public enum SettingsTabSelection: Equatable, Hashable, Sendable {
 
     public var helpText: String {
         switch self {
-        case .appSettings:
-            return "App Settings"
+        case .general:
+            return "General app settings"
+        case .kubernetes:
+            return "Kubeconfig discovery"
+        case .notifications:
+            return "Health shift alerts"
+        case .aiAssistant:
+            return "AI Diagnostic Assistant"
         case let .context(context):
             return context
         }
@@ -39,11 +60,21 @@ public enum SettingsTabSelection: Equatable, Hashable, Sendable {
 
     public var systemImageName: String {
         switch self {
-        case .appSettings:
+        case .general:
             return "gearshape"
+        case .kubernetes:
+            return "square.3.layers.3d"
+        case .notifications:
+            return "bell"
+        case .aiAssistant:
+            return "sparkles"
         case .context:
             return "server.rack"
         }
+    }
+
+    public static var appSettings: SettingsTabSelection {
+        .general
     }
 }
 
@@ -54,7 +85,12 @@ public struct SettingsTabID: RawRepresentable, Equatable, Hashable, Sendable {
         self.rawValue = rawValue
     }
 
-    public static let appSettings = SettingsTabID(rawValue: "app-settings")
+    public static let general = SettingsTabID(rawValue: "app-general")
+    public static let kubernetes = SettingsTabID(rawValue: "app-kubernetes")
+    public static let notifications = SettingsTabID(rawValue: "app-notifications")
+    public static let aiAssistant = SettingsTabID(rawValue: "app-ai-assistant")
+
+    public static let appSettings = SettingsTabID.general
 
     public static func context(_ context: String) -> SettingsTabID {
         SettingsTabID(rawValue: "context:\(context)")
@@ -76,6 +112,7 @@ public struct SetupFlowState: Equatable, Sendable {
     public var startAtLogin: StartAtLoginState
     public var healthShiftAlerts: HealthShiftAlertsState
     public var kubeconfigPaths: [String]
+    public var aiDiagnosticAssistant: AIDiagnosticAssistantState
 
     public init(
         selectedContext: String? = nil,
@@ -89,7 +126,8 @@ public struct SetupFlowState: Equatable, Sendable {
         refreshCadence: RefreshCadence = .default,
         startAtLogin: StartAtLoginState = StartAtLoginState(),
         healthShiftAlerts: HealthShiftAlertsState = HealthShiftAlertsState(),
-        kubeconfigPaths: [String] = []
+        kubeconfigPaths: [String] = [],
+        aiDiagnosticAssistant: AIDiagnosticAssistantState = AIDiagnosticAssistantState()
     ) {
         self.selectedContext = selectedContext
         self.appSettingsSelectedContext = appSettingsSelectedContext ?? selectedContext
@@ -117,6 +155,7 @@ public struct SetupFlowState: Equatable, Sendable {
         self.startAtLogin = startAtLogin
         self.healthShiftAlerts = healthShiftAlerts
         self.kubeconfigPaths = kubeconfigPaths
+        self.aiDiagnosticAssistant = aiDiagnosticAssistant
     }
 
     public var isConfigured: Bool {
@@ -131,8 +170,12 @@ public struct SetupFlowState: Equatable, Sendable {
         Set(availableContexts).sorted()
     }
 
+    public static var appPages: [SettingsTabSelection] {
+        [.general, .kubernetes, .notifications, .aiAssistant]
+    }
+
     public var settingsTabs: [SettingsTabSelection] {
-        [.appSettings] + contextTabs.map { .context($0) }
+        Self.appPages + contextTabs.map { .context($0) }
     }
 
     public var selectedSettingsTabID: SettingsTabID {
@@ -145,7 +188,7 @@ public struct SetupFlowState: Equatable, Sendable {
 
     public var selectedContextForCompletedConfig: String? {
         switch selectedSettingsTab {
-        case .appSettings:
+        case .general, .kubernetes, .notifications, .aiAssistant:
             return appSettingsSelectedContext ?? selectedContext
         case .context:
             return selectedContext
@@ -220,13 +263,21 @@ public struct SetupFlowState: Equatable, Sendable {
     public mutating func selectContext(_ context: String?) {
         preserveCurrentWatchlist()
         selectedContext = context
-        selectedSettingsTab = context.map { .context($0) } ?? .appSettings
+        selectedSettingsTab = context.map { .context($0) } ?? .general
         watchlist = context.flatMap { watchlistsByContext[$0] } ?? WatchlistSelectionState()
     }
 
     public mutating func selectAppSettingsTab() {
+        selectAppPage(.general)
+    }
+
+    public mutating func selectAppPage(_ page: SettingsTabSelection) {
+        guard Self.appPages.contains(page) else {
+            return
+        }
         preserveCurrentWatchlist()
-        selectedSettingsTab = .appSettings
+        selectedSettingsTab = page
+        configurationMessage = nil
     }
 
     public mutating func appendKubeconfigPaths(_ paths: [String]) {
@@ -288,6 +339,36 @@ public struct SetupFlowState: Equatable, Sendable {
         selectAppSettingsTab()
         targetLoadingState = .idle
         watchlist.clearAvailableTargets()
+    }
+
+    public mutating func updateAIDiagnosticAssistant(modelID: String) {
+        aiDiagnosticAssistant.config.modelID = modelID
+        configurationMessage = nil
+    }
+
+    public mutating func updateAIDiagnosticAssistant(baseURL: String?) {
+        aiDiagnosticAssistant.config = aiDiagnosticAssistant.config.with(baseURL: baseURL)
+        configurationMessage = nil
+    }
+
+    public mutating func updateAIDiagnosticAssistant(provider: AIProvider) {
+        aiDiagnosticAssistant.config = AIDiagnosticAssistantConfig(
+            provider: provider,
+            modelID: aiDiagnosticAssistant.config.modelID,
+            baseURL: aiDiagnosticAssistant.config.baseURL
+        )
+        aiDiagnosticAssistant.testConnectionResult = nil
+        configurationMessage = nil
+    }
+
+    public mutating func updateAIDiagnosticAssistantAPIKeyDraft(_ draft: String) {
+        aiDiagnosticAssistant.apiKeyDraft = draft
+        configurationMessage = nil
+    }
+
+    public mutating func applyAIDiagnosticAssistantTestConnectionResult(_ result: AIProviderConnectionResult?) {
+        aiDiagnosticAssistant.testConnectionResult = result
+        configurationMessage = nil
     }
 
     public func currentWatchlistsByContext() -> [String: WatchlistSelectionState] {

--- a/KubebarCore/Services/AIProviderConnectionTester.swift
+++ b/KubebarCore/Services/AIProviderConnectionTester.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+/// Result of a manually triggered AI provider Test Connection.
+public enum AIProviderConnectionResult: Equatable, Sendable {
+    case success
+    case failed(String)
+}
+
+/// Tests AI provider connectivity using a minimal chat completion probe.
+///
+/// Test Connection sends a `max_tokens=1` `"ping"` request to the configured
+/// provider. It validates the API key, Model ID, and (for OpenAI-compatible)
+/// Base URL in a single round-trip. It never sends Kubernetes data — no warning
+/// text, Pod logs, kubeconfig content, raw kubectl output, or cluster JSON.
+public struct AIProviderConnectionTester: Sendable {
+    public static let missingAPIKeyMessage = "Add an API key to test the connection."
+    public static let missingModelIDMessage = "Add a model ID to test the connection."
+    public static let missingBaseURLMessage = "Add a Base URL to test the connection."
+    public static let credentialStoreErrorMessage = "Could not read the saved API key. Check macOS Keychain access."
+
+    private let credentialStore: any AIProviderCredentialStoring
+    private let httpClient: any HTTPClient
+
+    public init(credentialStore: any AIProviderCredentialStoring, httpClient: any HTTPClient) {
+        self.credentialStore = credentialStore
+        self.httpClient = httpClient
+    }
+
+    public func testConnection(
+        config: AIDiagnosticAssistantConfig,
+        provider: AIProvider,
+        apiKeyOverride: String? = nil
+    ) async -> AIProviderConnectionResult {
+        guard !config.modelID.isEmpty else {
+            return .failed(Self.missingModelIDMessage)
+        }
+
+        let apiKey: String
+        if let override = apiKeyOverride?.trimmingCharacters(in: .whitespacesAndNewlines), !override.isEmpty {
+            apiKey = override
+        } else {
+            do {
+                guard let stored = try credentialStore.loadAPIKey(for: provider), !stored.isEmpty else {
+                    return .failed(Self.missingAPIKeyMessage)
+                }
+                apiKey = stored
+            } catch {
+                return .failed(Self.credentialStoreErrorMessage)
+            }
+        }
+
+        guard let request = buildRequest(config: config, provider: provider, apiKey: apiKey) else {
+            return .failed(Self.missingBaseURLMessage)
+        }
+
+        do {
+            let (_, response) = try await httpClient.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return .failed("Could not read the provider response.")
+            }
+            return result(for: http.statusCode)
+        } catch {
+            return .failed(Self.transportFailureMessage())
+        }
+    }
+
+    private func buildRequest(
+        config: AIDiagnosticAssistantConfig,
+        provider: AIProvider,
+        apiKey: String
+    ) -> URLRequest? {
+        switch provider {
+        case .openAI:
+            return chatCompletionsRequest(
+                url: "https://api.openai.com/v1/chat/completions",
+                apiKey: apiKey,
+                model: config.modelID,
+                auth: .bearer
+            )
+        case .anthropic:
+            return anthropicRequest(url: "https://api.anthropic.com/v1/messages", apiKey: apiKey, model: config.modelID)
+        case .gemini:
+            return geminiRequest(model: config.modelID, apiKey: apiKey)
+        case .openAICompatible:
+            guard let baseURL = config.baseURL?.trimmingCharacters(in: .whitespacesAndNewlines), !baseURL.isEmpty else {
+                return nil
+            }
+            let normalized = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
+            return chatCompletionsRequest(
+                url: "\(normalized)/chat/completions",
+                apiKey: apiKey,
+                model: config.modelID,
+                auth: .bearer
+            )
+        }
+    }
+
+    private enum AuthScheme {
+        case bearer
+    }
+
+    private func chatCompletionsRequest(
+        url: String,
+        apiKey: String,
+        model: String,
+        auth: AuthScheme
+    ) -> URLRequest? {
+        guard let url = URL(string: url) else { return nil }
+        var request = URLRequest(url: url, timeoutInterval: 30)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if auth == .bearer {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [["role": "user", "content": "ping"]],
+            "max_tokens": 1
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private func anthropicRequest(url: String, apiKey: String, model: String) -> URLRequest? {
+        guard let url = URL(string: url) else { return nil }
+        var request = URLRequest(url: url, timeoutInterval: 30)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 1,
+            "messages": [["role": "user", "content": "ping"]]
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private func geminiRequest(model: String, apiKey: String) -> URLRequest? {
+        guard let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent") else {
+            return nil
+        }
+        var request = URLRequest(url: url, timeoutInterval: 30)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+
+        let body: [String: Any] = [
+            "contents": [["parts": [["text": "ping"]]]],
+            "generationConfig": ["maxOutputTokens": 1]
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private func result(for statusCode: Int) -> AIProviderConnectionResult {
+        switch statusCode {
+        case 200..<300:
+            return .success
+        case 401, 403:
+            return .failed("Authentication failed. Check your API key.")
+        case 400..<500:
+            return .failed("Request failed (HTTP \(statusCode)).")
+        default:
+            return .failed("Provider error (HTTP \(statusCode)). Try again later.")
+        }
+    }
+
+    private static func transportFailureMessage() -> String {
+        "Could not reach the provider. Check your network and Base URL."
+    }
+}

--- a/KubebarCore/Services/AIProviderCredentialStore.swift
+++ b/KubebarCore/Services/AIProviderCredentialStore.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Injectable boundary for storing AI provider API keys in macOS Keychain.
+///
+/// Production access wraps `SecItem` in the app target; tests use an in-memory
+/// fake. Keys are namespaced by `AIProvider` so switching providers never
+/// overwrites another provider's key.
+public protocol AIProviderCredentialStoring: Sendable {
+    func loadAPIKey(for provider: AIProvider) throws -> String?
+    func saveAPIKey(_ key: String, for provider: AIProvider) throws
+    func deleteAPIKey(for provider: AIProvider) throws
+}

--- a/KubebarCore/Services/AppConfigStore.swift
+++ b/KubebarCore/Services/AppConfigStore.swift
@@ -6,6 +6,7 @@ public struct AppConfig: Codable, Equatable, Sendable {
     public let refreshIntervalSeconds: Int
     public let healthShiftAlertsEnabled: Bool
     public let kubeconfigPaths: [String]
+    public let aiDiagnosticAssistant: AIDiagnosticAssistantConfig
 
     private enum CodingKeys: String, CodingKey {
         case selectedContext
@@ -14,6 +15,7 @@ public struct AppConfig: Codable, Equatable, Sendable {
         case refreshIntervalSeconds
         case healthShiftAlertsEnabled
         case kubeconfigPaths
+        case aiDiagnosticAssistant
     }
 
     public init(
@@ -22,7 +24,8 @@ public struct AppConfig: Codable, Equatable, Sendable {
         watchlistsByContext: [String: [WatchTarget]]? = nil,
         refreshIntervalSeconds: Int = RefreshCadence.default.seconds,
         healthShiftAlertsEnabled: Bool = false,
-        kubeconfigPaths: [String] = []
+        kubeconfigPaths: [String] = [],
+        aiDiagnosticAssistant: AIDiagnosticAssistantConfig = AIDiagnosticAssistantConfig()
     ) {
         self.selectedContext = selectedContext
         if let watchlistsByContext {
@@ -35,6 +38,7 @@ public struct AppConfig: Codable, Equatable, Sendable {
         self.refreshIntervalSeconds = RefreshCadence.from(seconds: refreshIntervalSeconds).seconds
         self.healthShiftAlertsEnabled = healthShiftAlertsEnabled
         self.kubeconfigPaths = kubeconfigPaths
+        self.aiDiagnosticAssistant = aiDiagnosticAssistant
     }
 
     public var watchTargets: [WatchTarget] {
@@ -59,7 +63,8 @@ public struct AppConfig: Codable, Equatable, Sendable {
             watchlistsByContext: watchlistsByContext,
             refreshIntervalSeconds: refreshIntervalSeconds,
             healthShiftAlertsEnabled: healthShiftAlertsEnabled,
-            kubeconfigPaths: kubeconfigPaths
+            kubeconfigPaths: kubeconfigPaths,
+            aiDiagnosticAssistant: aiDiagnosticAssistant
         )
     }
 
@@ -72,7 +77,8 @@ public struct AppConfig: Codable, Equatable, Sendable {
             watchlistsByContext: try Self.decodedWatchlists(from: container),
             refreshIntervalSeconds: try container.decodeIfPresent(Int.self, forKey: .refreshIntervalSeconds) ?? RefreshCadence.default.seconds,
             healthShiftAlertsEnabled: try container.decodeIfPresent(Bool.self, forKey: .healthShiftAlertsEnabled) ?? false,
-            kubeconfigPaths: try container.decodeIfPresent([String].self, forKey: .kubeconfigPaths) ?? []
+            kubeconfigPaths: try container.decodeIfPresent([String].self, forKey: .kubeconfigPaths) ?? [],
+            aiDiagnosticAssistant: try container.decodeIfPresent(AIDiagnosticAssistantConfig.self, forKey: .aiDiagnosticAssistant) ?? AIDiagnosticAssistantConfig()
         )
     }
 
@@ -85,6 +91,7 @@ public struct AppConfig: Codable, Equatable, Sendable {
         try container.encode(refreshIntervalSeconds, forKey: .refreshIntervalSeconds)
         try container.encode(healthShiftAlertsEnabled, forKey: .healthShiftAlertsEnabled)
         try container.encode(kubeconfigPaths, forKey: .kubeconfigPaths)
+        try container.encode(aiDiagnosticAssistant, forKey: .aiDiagnosticAssistant)
     }
 
     private static func decodedWatchlists(from container: KeyedDecodingContainer<CodingKeys>) throws -> [String: [WatchTarget]]? {

--- a/KubebarCore/Services/HTTPClient.swift
+++ b/KubebarCore/Services/HTTPClient.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Injectable HTTP client boundary for AI provider requests.
+///
+/// Production access wraps `URLSession`; tests inspect the constructed
+/// `URLRequest` without real network calls.
+public protocol HTTPClient: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}

--- a/KubebarTests/Models/AppConfigTests.swift
+++ b/KubebarTests/Models/AppConfigTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import KubebarCore
 
@@ -54,5 +55,49 @@ struct AppConfigTests {
         #expect(updated.selectedContext == "stage")
         #expect(updated.watchTargets.isEmpty)
         #expect(updated.needsSetup)
+    }
+
+    @Test("ai diagnostic assistant config defaults to unconfigured")
+    func aiDiagnosticAssistantConfigDefaultsToUnconfigured() {
+        let config = AppConfig()
+
+        #expect(config.aiDiagnosticAssistant == AIDiagnosticAssistantConfig())
+        #expect(config.aiDiagnosticAssistant.modelID.isEmpty)
+    }
+
+    @Test("selecting context preserves ai diagnostic assistant config")
+    func selectingContextPreservesAIDiagnosticAssistantConfig() {
+        let config = AppConfig(
+            selectedContext: "prod",
+            watchlistsByContext: ["prod": [.namespace("api")]],
+            aiDiagnosticAssistant: AIDiagnosticAssistantConfig(
+                provider: .anthropic,
+                modelID: "claude-3",
+                baseURL: nil
+            )
+        )
+
+        let updated = config.selectingContext("stage")
+
+        #expect(updated.aiDiagnosticAssistant == config.aiDiagnosticAssistant)
+    }
+
+    @Test("encoded app config never contains an api key")
+    func encodedAppConfigNeverContainsApiKey() throws {
+        let config = AppConfig(
+            selectedContext: "prod",
+            watchTargets: [.namespace("api")],
+            aiDiagnosticAssistant: AIDiagnosticAssistantConfig(
+                provider: .openAICompatible,
+                modelID: "gpt-4o-mini",
+                baseURL: "https://example.test/v1"
+            )
+        )
+
+        let data = try JSONEncoder().encode(config)
+        let json = String(data: data, encoding: .utf8) ?? ""
+
+        #expect(!json.contains("apiKey"))
+        #expect(!json.contains("sk-test-secret"))
     }
 }

--- a/KubebarTests/Models/MenuRuntimeStateTests.swift
+++ b/KubebarTests/Models/MenuRuntimeStateTests.swift
@@ -439,6 +439,63 @@ struct MenuRuntimeStateTests {
         ])
     }
 
+    @Test("prepare settings exposes saved ai diagnostic assistant config")
+    func prepareSettingsExposesSavedAIDiagnosticAssistantConfig() {
+        let savedConfig = AppConfig(
+            selectedContext: "prod",
+            watchTargets: [.namespace("api")],
+            aiDiagnosticAssistant: AIDiagnosticAssistantConfig(
+                provider: .anthropic,
+                modelID: "claude-3",
+                baseURL: nil
+            )
+        )
+        let state = MenuRuntimeState(config: savedConfig)
+
+        #expect(state.setupState.aiDiagnosticAssistant.config == savedConfig.aiDiagnosticAssistant)
+    }
+
+    @Test("completed config preserves ai diagnostic assistant config")
+    func completedConfigPreservesAIDiagnosticAssistantConfig() throws {
+        var state = MenuRuntimeState(
+            config: AppConfig(
+                selectedContext: "prod",
+                watchTargets: [.namespace("api")],
+                aiDiagnosticAssistant: AIDiagnosticAssistantConfig(
+                    provider: .openAICompatible,
+                    modelID: "gpt-4o-mini",
+                    baseURL: "https://example.test/v1"
+                )
+            )
+        )
+        state.setupState.aiDiagnosticAssistant.config.modelID = "gpt-4o"
+
+        let config = try #require(state.completedConfig())
+
+        #expect(config.aiDiagnosticAssistant.provider == .openAICompatible)
+        #expect(config.aiDiagnosticAssistant.modelID == "gpt-4o")
+        #expect(config.aiDiagnosticAssistant.baseURL == "https://example.test/v1")
+    }
+
+    @Test("changed ai diagnostic assistant config marks settings unsaved")
+    func changedAIDiagnosticAssistantConfigMarksSettingsUnsaved() {
+        let savedConfig = AppConfig(
+            selectedContext: "prod",
+            watchTargets: [.namespace("api")],
+            aiDiagnosticAssistant: AIDiagnosticAssistantConfig(
+                provider: .openAI,
+                modelID: "gpt-4o-mini",
+                baseURL: nil
+            )
+        )
+        var state = MenuRuntimeState(config: savedConfig)
+        state.setupState.aiDiagnosticAssistant.config.modelID = "gpt-4o"
+
+        state.prepareSettings(config: savedConfig)
+
+        #expect(state.setupState.aiDiagnosticAssistant.config.modelID == "gpt-4o")
+    }
+
     @Test("replacing available contexts hides missing context tabs without dropping saved watchlists")
     func replacingAvailableContextsHidesMissingContextTabsWithoutDroppingSavedWatchlists() throws {
         var state = MenuRuntimeState(

--- a/KubebarTests/Models/SetupFlowStateTests.swift
+++ b/KubebarTests/Models/SetupFlowStateTests.swift
@@ -3,6 +3,95 @@ import Testing
 
 @Suite("Setup flow state")
 struct SetupFlowStateTests {
+    @Test("app pages are available in stable order")
+    func appPagesAreAvailableInStableOrder() {
+        #expect(SetupFlowState.appPages == [.general, .kubernetes, .notifications, .aiAssistant])
+    }
+
+    @Test("selecting an app page preserves current context watchlist edits")
+    func selectingAnAppPagePreservesCurrentContextWatchlistEdits() {
+        var state = SetupFlowState(
+            selectedContext: "prod",
+            watchlistsByContext: [
+                "prod": WatchlistSelectionState(selectedTargets: [.namespace("api")]),
+                "stage": WatchlistSelectionState(selectedTargets: [.namespace("web")])
+            ]
+        )
+
+        state.selectContext("stage")
+        state.watchlist.toggle(.namespace("ops"))
+        state.selectAppPage(.aiAssistant)
+
+        #expect(state.selectedSettingsTab == .aiAssistant)
+        #expect(state.currentWatchlistsByContext()["stage"]?.isSelected(.namespace("web")) == true)
+        #expect(state.currentWatchlistsByContext()["stage"]?.isSelected(.namespace("ops")) == true)
+    }
+
+    @Test("selecting an app page clears the configuration message")
+    func selectingAnAppPageClearsConfigurationMessage() {
+        var state = SetupFlowState(
+            selectedContext: "prod",
+            watchlistsByContext: [
+                "prod": WatchlistSelectionState(selectedTargets: [.namespace("api")])
+            ],
+            configurationMessage: "Could not save settings. Try again."
+        )
+
+        state.selectAppPage(.kubernetes)
+
+        #expect(state.selectedSettingsTab == .kubernetes)
+        #expect(state.configurationMessage == nil)
+    }
+
+    @Test("selecting a context page loads that context watchlist")
+    func selectingAContextPageLoadsThatContextWatchlist() {
+        var state = SetupFlowState(
+            selectedContext: "prod",
+            watchlistsByContext: [
+                "prod": WatchlistSelectionState(selectedTargets: [.namespace("api")]),
+                "stage": WatchlistSelectionState(selectedTargets: [.namespace("web")])
+            ]
+        )
+
+        state.selectContext("stage")
+
+        #expect(state.selectedSettingsTab == .context("stage"))
+        #expect(state.watchlist.isSelected(.namespace("web")))
+    }
+
+    @Test("completed config is unchanged by app page navigation")
+    func completedConfigIsUnchangedByAppPageNavigation() {
+        var state = SetupFlowState(
+            selectedContext: "prod",
+            watchlistsByContext: [
+                "prod": WatchlistSelectionState(selectedTargets: [.namespace("api")]),
+                "stage": WatchlistSelectionState(selectedTargets: [.namespace("web")])
+            ]
+        )
+
+        state.selectContext("stage")
+        state.selectAppPage(.general)
+
+        #expect(state.selectedContext == "stage")
+        #expect(state.selectedContextForCompletedConfig == "prod")
+        #expect(state.isConfigured)
+    }
+
+    @Test("select app page ignores context pages")
+    func selectAppPageIgnoresContextPages() {
+        var state = SetupFlowState(
+            selectedContext: "prod",
+            watchlistsByContext: [
+                "prod": WatchlistSelectionState(selectedTargets: [.namespace("api")])
+            ]
+        )
+
+        state.selectAppPage(.general)
+        state.selectAppPage(.context("prod"))
+
+        #expect(state.selectedSettingsTab == .general)
+    }
+
     @Test("missing context or watchlist keeps setup active")
     func missingContextOrWatchlistKeepsSetupActive() {
         let state = SetupFlowState(
@@ -51,8 +140,8 @@ struct SetupFlowStateTests {
         #expect(state.watchlist.isSelected(.namespace("api")))
     }
 
-    @Test("settings tabs start with app settings and then contexts")
-    func settingsTabsStartWithAppSettingsAndThenContexts() {
+    @Test("settings tabs start with app pages and then contexts")
+    func settingsTabsStartWithAppPagesAndThenContexts() {
         let state = SetupFlowState(
             selectedContext: "prod",
             availableContexts: ["prod", "stage"],
@@ -61,8 +150,8 @@ struct SetupFlowStateTests {
             ]
         )
 
-        #expect(state.settingsTabs == [.appSettings, .context("prod"), .context("stage")])
-        #expect(state.settingsTabs.first == .appSettings)
+        #expect(state.settingsTabs == [.general, .kubernetes, .notifications, .aiAssistant, .context("prod"), .context("stage")])
+        #expect(state.settingsTabs.first == .general)
     }
 
     @Test("settings tab ids stay stable with two contexts")
@@ -75,9 +164,9 @@ struct SetupFlowStateTests {
             ]
         )
 
-        #expect(state.selectedSettingsTabID == .appSettings)
-        #expect(state.settingsTabs.map(\.id) == [.appSettings, .context("prod"), .context("stage")])
-        #expect(state.settingsTab(for: .appSettings) == .appSettings)
+        #expect(state.selectedSettingsTabID == .general)
+        #expect(state.settingsTabs.map(\.id) == [.general, .kubernetes, .notifications, .aiAssistant, .context("prod"), .context("stage")])
+        #expect(state.settingsTab(for: .general) == .general)
         #expect(state.settingsTab(for: .context("stage")) == .context("stage"))
     }
 
@@ -287,5 +376,79 @@ struct SetupFlowStateTests {
         #expect(state.contextTabs == ["prod"])
         #expect(state.selectedSettingsTab == .appSettings)
         #expect(state.currentWatchlistsByContext()["stage"]?.isSelected(.namespace("web")) == true)
+    }
+
+    @Test("ai diagnostic assistant config defaults unconfigured")
+    func aiDiagnosticAssistantConfigDefaultsUnconfigured() {
+        let state = SetupFlowState()
+
+        #expect(state.aiDiagnosticAssistant.config == AIDiagnosticAssistantConfig())
+        #expect(state.aiDiagnosticAssistant.config.modelID.isEmpty)
+    }
+
+    @Test("ai diagnostic assistant config persists while switching tabs")
+    func aiDiagnosticAssistantConfigPersistsWhileSwitchingTabs() {
+        var state = SetupFlowState(
+            selectedContext: "prod",
+            watchlistsByContext: [
+                "prod": WatchlistSelectionState(selectedTargets: [.namespace("api")]),
+                "stage": WatchlistSelectionState(selectedTargets: [.namespace("web")])
+            ],
+            aiDiagnosticAssistant: AIDiagnosticAssistantState(
+                config: AIDiagnosticAssistantConfig(
+                    provider: .gemini,
+                    modelID: "gemini-1.5-flash",
+                    baseURL: nil
+                )
+            )
+        )
+
+        state.selectContext("stage")
+        state.selectAppSettingsTab()
+
+        #expect(state.aiDiagnosticAssistant.config.provider == .gemini)
+        #expect(state.aiDiagnosticAssistant.config.modelID == "gemini-1.5-flash")
+    }
+
+    @Test("updating ai diagnostic assistant config clears configuration message")
+    func updatingAIDiagnosticAssistantConfigClearsConfigurationMessage() {
+        var state = SetupFlowState(
+            configurationMessage: "Could not save settings. Try again."
+        )
+
+        state.updateAIDiagnosticAssistant(modelID: "gpt-4o-mini")
+
+        #expect(state.aiDiagnosticAssistant.config.modelID == "gpt-4o-mini")
+        #expect(state.configurationMessage == nil)
+    }
+
+    @Test("updating ai provider clears test connection result")
+    func updatingAIProviderClearsTestConnectionResult() {
+        var state = SetupFlowState(
+            aiDiagnosticAssistant: AIDiagnosticAssistantState(
+                config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+                testConnectionResult: .success
+            )
+        )
+
+        state.updateAIDiagnosticAssistant(provider: .anthropic)
+
+        #expect(state.aiDiagnosticAssistant.config.provider == .anthropic)
+        #expect(state.aiDiagnosticAssistant.testConnectionResult == nil)
+    }
+
+    @Test("api key draft is transient and resets when settings reopen")
+    func apiKeyDraftIsTransientAndResetsWhenSettingsReopen() {
+        let savedConfig = AppConfig(
+            selectedContext: "prod",
+            watchTargets: [.namespace("api")],
+            aiDiagnosticAssistant: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini")
+        )
+        var state = MenuRuntimeState(config: savedConfig)
+        state.setupState.aiDiagnosticAssistant.apiKeyDraft = "sk-test-secret"
+        state.prepareSettings(config: savedConfig)
+
+        #expect(state.setupState.aiDiagnosticAssistant.apiKeyDraft.isEmpty)
+        #expect(state.setupState.aiDiagnosticAssistant.config.modelID == "gpt-4o-mini")
     }
 }

--- a/KubebarTests/Services/AIProviderConnectionTesterTests.swift
+++ b/KubebarTests/Services/AIProviderConnectionTesterTests.swift
@@ -1,0 +1,384 @@
+import Foundation
+import Testing
+@testable import KubebarCore
+
+@Suite("AI provider connection tester")
+struct AIProviderConnectionTesterTests {
+    @Test("missing API key returns safe local failure")
+    func missingAPIKeyReturnsSafeLocalFailure() async {
+        let tester = AIProviderConnectionTester(
+            credentialStore: FakeAIProviderCredentialStore(),
+            httpClient: FakeHTTPClient()
+        )
+
+        let result = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        guard case let .failed(message) = result else {
+            Issue.record("Expected failure")
+            return
+        }
+        #expect(message == AIProviderConnectionTester.missingAPIKeyMessage)
+    }
+
+    @Test("missing model ID returns safe local failure")
+    func missingModelIDReturnsSafeLocalFailure() async {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let tester = AIProviderConnectionTester(
+            credentialStore: store,
+            httpClient: FakeHTTPClient()
+        )
+
+        let result = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: ""),
+            provider: .openAI
+        )
+
+        guard case let .failed(message) = result else {
+            Issue.record("Expected failure")
+            return
+        }
+        #expect(message == AIProviderConnectionTester.missingModelIDMessage)
+    }
+
+    @Test("openAI compatible missing base URL returns safe local failure")
+    func openAICompatibleMissingBaseURLReturnsSafeLocalFailure() async {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAICompatible)
+        let tester = AIProviderConnectionTester(
+            credentialStore: store,
+            httpClient: FakeHTTPClient()
+        )
+
+        let result = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAICompatible, modelID: "gpt-4o-mini", baseURL: nil),
+            provider: .openAICompatible
+        )
+
+        guard case let .failed(message) = result else {
+            Issue.record("Expected failure")
+            return
+        }
+        #expect(message == AIProviderConnectionTester.missingBaseURLMessage)
+    }
+
+    @Test("openAI request uses Authorization Bearer and minimal body")
+    func openAIRequestUsesAuthorizationBearerAndMinimalBody() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient()
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        _ = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        let request = try #require(http.lastRequest)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-test-secret")
+        #expect(request.url?.absoluteString == "https://api.openai.com/v1/chat/completions")
+        let body = try #require(request.httpBody)
+        let json = try #require(try? JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["model"] as? String == "gpt-4o-mini")
+        #expect(json["max_tokens"] as? Int == 1)
+    }
+
+    @Test("anthropic request uses provider-specific key and version headers")
+    func anthropicRequestUsesProviderSpecificKeyAndVersionHeaders() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-ant-test", for: .anthropic)
+        let http = FakeHTTPClient()
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        _ = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .anthropic, modelID: "claude-3"),
+            provider: .anthropic
+        )
+
+        let request = try #require(http.lastRequest)
+        #expect(request.value(forHTTPHeaderField: "x-api-key") == "sk-ant-test")
+        #expect(request.value(forHTTPHeaderField: "anthropic-version") == "2023-06-01")
+        #expect(request.url?.absoluteString == "https://api.anthropic.com/v1/messages")
+    }
+
+    @Test("gemini request uses x-goog-api-key header not URL query")
+    func geminiRequestUsesGoogAPIKeyHeaderNotURLQuery() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-gem-test", for: .gemini)
+        let http = FakeHTTPClient()
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        _ = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .gemini, modelID: "gemini-1.5-flash"),
+            provider: .gemini
+        )
+
+        let request = try #require(http.lastRequest)
+        #expect(request.value(forHTTPHeaderField: "x-goog-api-key") == "sk-gem-test")
+        let urlString = request.url?.absoluteString ?? ""
+        #expect(!urlString.contains("key="))
+        #expect(!urlString.contains("sk-gem-test"))
+        #expect(urlString.contains("gemini-1.5-flash:generateContent"))
+    }
+
+    @Test("openAI compatible request uses configured base URL with Bearer and no custom headers")
+    func openAICompatibleRequestUsesConfiguredBaseURLWithBearer() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-custom", for: .openAICompatible)
+        let http = FakeHTTPClient()
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        _ = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAICompatible, modelID: "gpt-4o-mini", baseURL: "https://example.test/v1"),
+            provider: .openAICompatible
+        )
+
+        let request = try #require(http.lastRequest)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-custom")
+        #expect(request.url?.absoluteString == "https://example.test/v1/chat/completions")
+    }
+
+    @Test("HTTP 200 returns success")
+    func http200ReturnsSuccess() async {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(statusCode: 200)
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        let result = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        #expect(result == .success)
+    }
+
+    @Test("HTTP 401 returns authentication failed message")
+    func http401ReturnsAuthenticationFailedMessage() async {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(statusCode: 401, body: Data("sk-test-secret leak".utf8))
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        let result = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        guard case let .failed(message) = result else {
+            Issue.record("Expected failure")
+            return
+        }
+        #expect(message == "Authentication failed. Check your API key.")
+        #expect(!message.contains("sk-test-secret"))
+    }
+
+    @Test("HTTP 500 returns provider error message")
+    func http500ReturnsProviderErrorMessage() async {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(statusCode: 500, body: Data("sk-test-secret leak".utf8))
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        let result = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        guard case let .failed(message) = result else {
+            Issue.record("Expected failure")
+            return
+        }
+        #expect(message == "Provider error (HTTP 500). Try again later.")
+        #expect(!message.contains("sk-test-secret"))
+    }
+
+    @Test("test connection with draft key does not persist to credential store")
+    func testConnectionWithDraftKeyDoesNotPersistToCredentialStore() async {
+        let store = FakeAIProviderCredentialStore()
+        let http = FakeHTTPClient(statusCode: 200)
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        _ = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI,
+            apiKeyOverride: "sk-draft-secret"
+        )
+
+        #expect(store.saveCallCount == 0)
+        #expect(store.loadCallCount == 0)
+    }
+
+    @Test("test connection with draft key uses draft in request")
+    func testConnectionWithDraftKeyUsesDraftInRequest() async throws {
+        let store = FakeAIProviderCredentialStore()
+        let http = FakeHTTPClient(statusCode: 200)
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        _ = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI,
+            apiKeyOverride: "sk-draft-secret"
+        )
+
+        let request = try #require(http.lastRequest)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-draft-secret")
+    }
+
+    @Test("test connection without draft key falls back to stored key")
+    func testConnectionWithoutDraftKeyFallsBackToStoredKey() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-stored-secret", for: .openAI)
+        let http = FakeHTTPClient(statusCode: 200)
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        _ = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI,
+            apiKeyOverride: nil
+        )
+
+        let request = try #require(http.lastRequest)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-stored-secret")
+        #expect(store.loadCallCount == 1)
+    }
+
+    @Test("credential store load failure returns safe error not missing key")
+    func credentialStoreLoadFailureReturnsSafeErrorNotMissingKey() async {
+        let store = FakeAIProviderCredentialStore(shouldFailLoad: true)
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: FakeHTTPClient())
+
+        let result = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI,
+            apiKeyOverride: nil
+        )
+
+        guard case let .failed(message) = result else {
+            Issue.record("Expected failure")
+            return
+        }
+        #expect(message == AIProviderConnectionTester.credentialStoreErrorMessage)
+        #expect(message != AIProviderConnectionTester.missingAPIKeyMessage)
+    }
+
+    @Test("transport error redacts bearer token and key")
+    func transportErrorRedactsBearerTokenAndKey() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(throwError: TestError("Authorization: Bearer sk-test-secret failed"))
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        let result = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        guard case let .failed(message) = result else {
+            Issue.record("Expected failure")
+            return
+        }
+        #expect(message == "Could not reach the provider. Check your network and Base URL.")
+        #expect(!message.contains("sk-test-secret"))
+        #expect(!message.contains("Bearer"))
+    }
+
+    @Test("test connection sends no warning text or kubernetes data")
+    func testConnectionSendsNoWarningTextOrKubernetesData() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(statusCode: 200)
+        let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
+
+        _ = await tester.testConnection(
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        let body = try #require(http.lastRequest?.httpBody)
+        let json = try #require(try? JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let messages = try #require(json["messages"] as? [[String: String]])
+        let content = try #require(messages.first?["content"])
+        #expect(content == "ping")
+        let jsonString = String(data: body, encoding: .utf8) ?? ""
+        #expect(!jsonString.contains("warning"))
+        #expect(!jsonString.contains("kubectl"))
+        #expect(!jsonString.contains("pod"))
+    }
+}
+
+// MARK: - Fakes
+
+final class FakeAIProviderCredentialStore: AIProviderCredentialStoring, @unchecked Sendable {
+    private var keys: [String: String] = [:]
+    private(set) var saveCallCount = 0
+    private(set) var loadCallCount = 0
+    let shouldFailLoad: Bool
+    let shouldFailSave: Bool
+
+    init(shouldFailLoad: Bool = false, shouldFailSave: Bool = false) {
+        self.shouldFailLoad = shouldFailLoad
+        self.shouldFailSave = shouldFailSave
+    }
+
+    func loadAPIKey(for provider: AIProvider) throws -> String? {
+        loadCallCount += 1
+        if shouldFailLoad {
+            throw FakeCredentialError()
+        }
+        return keys[provider.rawValue]
+    }
+
+    func saveAPIKey(_ key: String, for provider: AIProvider) throws {
+        saveCallCount += 1
+        if shouldFailSave {
+            throw FakeCredentialError()
+        }
+        keys[provider.rawValue] = key
+    }
+
+    func deleteAPIKey(for provider: AIProvider) throws {
+        keys.removeValue(forKey: provider.rawValue)
+    }
+}
+
+private struct FakeCredentialError: Error {}
+
+final class FakeHTTPClient: HTTPClient, @unchecked Sendable {
+    private(set) var lastRequest: URLRequest?
+    let statusCode: Int
+    let body: Data
+    let throwError: Error?
+
+    init(statusCode: Int = 200, body: Data = Data(), throwError: Error? = nil) {
+        self.statusCode = statusCode
+        self.body = body
+        self.throwError = throwError
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        lastRequest = request
+        if let throwError {
+            throw throwError
+        }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        return (body, response)
+    }
+}
+
+private struct TestError: Error {
+    let message: String
+    init(_ message: String) { self.message = message }
+}
+
+extension TestError: LocalizedError {
+    var errorDescription: String? { message }
+}

--- a/KubebarTests/Services/AIProviderCredentialStoreTests.swift
+++ b/KubebarTests/Services/AIProviderCredentialStoreTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import KubebarCore
+
+@Suite("AI provider credential store")
+struct AIProviderCredentialStoreTests {
+    @Test("missing key returns nil")
+    func missingKeyReturnsNil() throws {
+        let store = FakeAIProviderCredentialStore()
+
+        #expect(try store.loadAPIKey(for: .openAI) == nil)
+    }
+
+    @Test("saved key loads back")
+    func savedKeyLoadsBack() throws {
+        let store = FakeAIProviderCredentialStore()
+        try store.saveAPIKey("sk-test-secret", for: .openAI)
+
+        #expect(try store.loadAPIKey(for: .openAI) == "sk-test-secret")
+    }
+
+    @Test("replacing key overwrites old value")
+    func replacingKeyOverwritesOldValue() throws {
+        let store = FakeAIProviderCredentialStore()
+        try store.saveAPIKey("old-key", for: .anthropic)
+        try store.saveAPIKey("new-key", for: .anthropic)
+
+        #expect(try store.loadAPIKey(for: .anthropic) == "new-key")
+    }
+
+    @Test("deleting key removes only that provider slot")
+    func deletingKeyRemovesOnlyThatProviderSlot() throws {
+        let store = FakeAIProviderCredentialStore()
+        try store.saveAPIKey("sk-openai", for: .openAI)
+        try store.saveAPIKey("sk-anthropic", for: .anthropic)
+
+        try store.deleteAPIKey(for: .openAI)
+
+        try #expect(store.loadAPIKey(for: .openAI) == nil)
+        try #expect(store.loadAPIKey(for: .anthropic) == "sk-anthropic")
+    }
+
+    @Test("each provider has its own slot")
+    func eachProviderHasItsOwnSlot() throws {
+        let store = FakeAIProviderCredentialStore()
+        try store.saveAPIKey("sk-openai", for: .openAI)
+        try store.saveAPIKey("sk-anthropic", for: .anthropic)
+        try store.saveAPIKey("sk-gemini", for: .gemini)
+        try store.saveAPIKey("sk-custom", for: .openAICompatible)
+
+        try #expect(store.loadAPIKey(for: .openAI) == "sk-openai")
+        try #expect(store.loadAPIKey(for: .anthropic) == "sk-anthropic")
+        try #expect(store.loadAPIKey(for: .gemini) == "sk-gemini")
+        try #expect(store.loadAPIKey(for: .openAICompatible) == "sk-custom")
+    }
+}

--- a/KubebarTests/Services/AppConfigStoreTests.swift
+++ b/KubebarTests/Services/AppConfigStoreTests.swift
@@ -18,6 +18,7 @@ struct AppConfigStoreTests {
         #expect(config.refreshCadence == .oneMinute)
         #expect(!config.healthShiftAlertsEnabled)
         #expect(config.kubeconfigPaths.isEmpty)
+        #expect(config.aiDiagnosticAssistant == AIDiagnosticAssistantConfig())
     }
 
     @Test("unknown refresh interval normalizes to default")
@@ -94,7 +95,12 @@ struct AppConfigStoreTests {
             kubeconfigPaths: [
                 "/Users/derek/.kube/config",
                 "/Users/derek/.kube/team.yaml"
-            ]
+            ],
+            aiDiagnosticAssistant: AIDiagnosticAssistantConfig(
+                provider: .openAI,
+                modelID: "gpt-4o-mini",
+                baseURL: nil
+            )
         )
 
         try store.save(config)
@@ -108,6 +114,8 @@ struct AppConfigStoreTests {
             "/Users/derek/.kube/config",
             "/Users/derek/.kube/team.yaml"
         ])
+        #expect(try store.load().aiDiagnosticAssistant.provider == .openAI)
+        #expect(try store.load().aiDiagnosticAssistant.modelID == "gpt-4o-mini")
     }
 
     @Test("per-context watchlists round trip")
@@ -205,6 +213,28 @@ struct AppConfigStoreTests {
         #expect(throws: AppConfigStoreError.cannotSave) {
             try store.save(AppConfig(selectedContext: "prod", watchTargets: [.namespace("api")]))
         }
+    }
+
+    @Test("config without ai diagnostic assistant setting defaults unconfigured")
+    func configWithoutAIDiagnosticAssistantSettingDefaultsUnconfigured() throws {
+        let directory = makeTemporaryDirectory()
+        let configURL = directory.appendingPathComponent("config.json")
+        let json = """
+        {
+          "selectedContext": "prod",
+          "refreshIntervalSeconds": 60,
+          "watchTargets": [
+            {"namespace": {"_0": "api"}}
+          ]
+        }
+        """
+        try json.write(to: configURL, atomically: true, encoding: .utf8)
+        let store = AppConfigStore(directory: directory)
+
+        let config = try store.load()
+
+        #expect(config.aiDiagnosticAssistant == AIDiagnosticAssistantConfig())
+        #expect(config.aiDiagnosticAssistant.modelID.isEmpty)
     }
 
     private func makeTemporaryDirectory() -> URL {

--- a/changelog.d/ai-diagnostic-assistant.added.md
+++ b/changelog.d/ai-diagnostic-assistant.added.md
@@ -1,0 +1,2 @@
+- Add an AI Diagnostic Assistant page in Settings with provider configuration (OpenAI, Anthropic, Gemini, OpenAI-compatible) and Keychain-backed API key storage.
+- Add a manual Test Connection action that probes the configured provider without sending Kubernetes data.

--- a/changelog.d/settings-sidebar-layout.changed.md
+++ b/changelog.d/settings-sidebar-layout.changed.md
@@ -1,0 +1,2 @@
+- Redesign Settings from a stacked TabView into a macOS-style sidebar/detail layout with General, Kubernetes, Notifications, and AI Assistant pages plus a Contexts section.
+- Add keyboard shortcuts (Cmd+1–Cmd+4) for App Settings pages and warning icons for contexts with no watchlist selected.

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -113,6 +113,16 @@ These are the rules Kubebar must keep true at runtime.
 - A watched target with no matching Pods is a normal OK condition with a clear
   row reason, not a Watch or Bad Pod failure.
 - Kubebar does not query Kubernetes Secrets.
+- AI Diagnostic Assistant is display/help behavior only. It must not affect
+  `HealthEvaluator`, `MenuDisplayModel` health categorization, or the menu bar
+  icon category.
+- AI Provider API keys must be stored in macOS Keychain, never in `AppConfig`,
+  `config.json`, command output, diagnostics, or visible error text.
+- AI Test Connection is manually triggered. It sends a minimal provider probe
+  with no Kubernetes data: no warning text, Pod logs, kubeconfig content, raw
+  `kubectl` output, or cluster JSON.
+- AI diagnostic input, when implemented in a future plan, is limited to
+  user-approved warning summary text and must remain manually triggered.
 - Events warning summaries are capped at 3. Overview `Recent Warnings` is capped
   at 2 visible rows by default so it cannot push the top status row or cards out
   of the first scan.

--- a/docs/plans/2026-07-01-001-feat-ai-diagnostic-assistant-settings-plan.md
+++ b/docs/plans/2026-07-01-001-feat-ai-diagnostic-assistant-settings-plan.md
@@ -1,0 +1,303 @@
+---
+title: "feat: configure AI Diagnostic Assistant provider settings"
+type: feat
+status: planned
+date: 2026-07-01
+origin: .imm/specs/2026-07-01-ai-diagnostic-assistant-settings.md
+---
+
+# feat: configure AI Diagnostic Assistant provider settings
+
+## Summary
+
+- Summary: Users can configure an AI provider, store its API key in Keychain, and manually test the connection without sending Kubernetes data.
+
+Add an app-wide `AI Diagnostic Assistant` section to App Settings. The current executable slice saves non-secret AI Provider configuration, stores provider credentials in macOS Keychain, and exposes a manually triggered Test Connection. It deliberately does not implement automatic diagnosis or warning submission yet; it records that any later diagnostic payload is limited to user-approved warning text.
+
+## Current Slice
+
+- Roadmap source: none
+- Execution scope: App Settings provider metadata, Keychain credential boundary, provider Test Connection service, safe feedback, and docs/tests for those behaviors
+- Deferred phases: manual warning-text explanation, prompt UX, chat history, account/OAuth flows, cloud sync, advanced provider headers, and any deeper troubleshooting surface remain outside this plan
+- This is not the full AI diagnosis roadmap; it is the secure configuration and connection-test slice.
+
+## Task
+
+- Type: feat
+- Scope: AI Diagnostic Assistant settings, app config persistence, Keychain credentials, provider HTTP test boundary, Settings UI, and safety docs
+- Owner: imm-work
+- Verification: focused Swift tests, full Swift quality gate, and visible Settings smoke when practical
+- Brainstorm manifest: BR-REQ-001; BR-REQ-002; BR-REQ-003; BR-REQ-004; BR-REQ-005; BR-REQ-006; BR-REQ-007; BR-REQ-008; BR-REQ-009; BR-REQ-010; BR-REQ-011; BR-REQ-012; BR-OUT-001; BR-OUT-002; BR-OUT-003; BR-OUT-004; BR-OUT-005; BR-DEC-001; BR-DEC-002; BR-DEC-003; BR-Q-001
+
+## Output Language
+
+Spec and Plan prose are English. Schema fields, commands, file paths, provider names, API names, enum cases, and Immune-Brain fields stay literal.
+
+## Origin
+
+The user requested configurable AI Provider support for Kubebar's Settings page and then confirmed the narrowed first version:
+
+- `BR-Q-001`: `OpenAI-compatible` supports only Bearer API Key, Base URL, and Model ID; custom headers are not included.
+- Test Connection is manual.
+- The first executable slice saves configuration and tests the connection.
+- Diagnostic input scope, when later implemented, is warning text only.
+- API keys must be stored in Keychain.
+- `Ollama` is removed and replaced by `OpenAI-compatible`.
+
+## Brainstorm Manifest
+
+- `BR-REQ-001`: Settings' fixed `App Settings tab` adds an `AI Diagnostic Assistant` section.
+- `BR-REQ-002`: Provider choices are `OpenAI`, `Anthropic`, `Google Gemini`, and `OpenAI-compatible`.
+- `BR-REQ-003`: Remove the originally proposed `Ollama` option.
+- `BR-REQ-004`: Users can configure `Model ID`.
+- `BR-REQ-005`: `OpenAI-compatible` supports a configurable `Base URL`.
+- `BR-REQ-006`: API keys must be saved in macOS Keychain, not normal persisted config.
+- `BR-REQ-007`: Saved configuration supports manual `Test Connection`.
+- `BR-REQ-008`: Test Connection must not expose API keys, complete response bodies, raw requests, or token-like text.
+- `BR-REQ-009`: AI actions are manually triggered.
+- `BR-REQ-010`: The first diagnostic input boundary is warning text only.
+- `BR-REQ-011`: AI output must not affect `HealthEvaluator` or menu health categories.
+- `BR-REQ-012`: `OpenAI-compatible` supports only Bearer API Key, Base URL, and Model ID; no custom headers.
+- `BR-OUT-001`: No background automatic diagnosis.
+- `BR-OUT-002`: No Pod log submission.
+- `BR-OUT-003`: No Kubernetes Secret reads or transmission.
+- `BR-OUT-004`: No complete `kubectl` output or raw cluster JSON submission.
+- `BR-OUT-005`: No chat history, account system, OAuth, or cloud sync.
+- `BR-DEC-001`: AI Provider configuration is app-wide, not per-context watchlist state.
+- `BR-DEC-002`: Network calls go through injectable service boundaries; UI does not call provider APIs directly.
+- `BR-DEC-003`: AI results are auxiliary explanations, never health-category inputs.
+- `BR-Q-001`: Whether `OpenAI-compatible` supports custom headers.
+
+## Brainstorm Trace
+
+| Item | Status | Target | Reason |
+| --- | --- | --- | --- |
+| BR-REQ-001 | covered_by_step | U3 | U3 adds the App Settings UI section. |
+| BR-REQ-002 | covered_by_step | U1, U2, U3 | U1 models choices, U2 tests provider requests, and U3 exposes choices. |
+| BR-REQ-003 | covered_by_step | U1, U3 | U1 excludes `Ollama` from the model and U3 excludes it from the picker. |
+| BR-REQ-004 | covered_by_step | U1, U3 | U1 persists `Model ID`; U3 renders editing. |
+| BR-REQ-005 | covered_by_step | U1, U2, U3 | U1 stores the optional base URL, U2 validates request construction, and U3 renders it only when relevant. |
+| BR-REQ-006 | covered_by_step | U2, U3 | U2 creates the Keychain credential boundary; U3 wires Settings save through it. |
+| BR-REQ-007 | covered_by_step | U2, U3 | U2 creates Test Connection service behavior; U3 exposes the manual action. |
+| BR-REQ-008 | covered_by_step | U2, U3 | U2 owns redaction tests and U3 shows only safe result text. |
+| BR-REQ-009 | covered_by_step | U3 | Test Connection is button-triggered; future diagnostics remain documented as manual-only. |
+| BR-REQ-010 | deferred | Deferred Work | This plan does not implement diagnosis; it preserves the accepted warning-text-only boundary for a later diagnostic plan. |
+| BR-REQ-011 | captured_as_decision | Decisions | The plan explicitly keeps AI outside `HealthEvaluator` and health-category ownership. |
+| BR-REQ-012 | covered_by_step | U1, U2, U3 | U1 models the limited contract, U2 tests Bearer request construction, and U3 avoids custom-header UI. |
+| BR-OUT-001 | out_of_scope | Scope Boundaries | No scheduled or background AI work is introduced. |
+| BR-OUT-002 | out_of_scope | Scope Boundaries | Pod logs remain outside AI submission. |
+| BR-OUT-003 | out_of_scope | Scope Boundaries | Kubebar still does not query or send Kubernetes Secrets. |
+| BR-OUT-004 | out_of_scope | Scope Boundaries | Test Connection sends no cluster data; diagnostic data submission is deferred. |
+| BR-OUT-005 | out_of_scope | Scope Boundaries | The slice has no accounts, OAuth, cloud sync, or chat history. |
+| BR-DEC-001 | covered_by_step | U1, U3 | AI config is stored as global app Settings metadata. |
+| BR-DEC-002 | covered_by_step | U2 | Provider calls are behind injectable credential and HTTP/service protocols. |
+| BR-DEC-003 | captured_as_decision | Decisions | AI output is display-only and not part of health evaluation. |
+| BR-Q-001 | resolved_as_assumption | Decisions | User confirmed no custom headers for `OpenAI-compatible` first version. |
+
+## Research
+
+- `CONTEXT.md` now defines `AI Diagnostic Assistant`, `AI Provider configuration`, `AI Provider API key`, `OpenAI-compatible provider`, and `Warning text diagnostic input`.
+- `docs/architecture/runtime-invariants.md` requires external reads through injectable boundaries, safe display text, no raw command transcripts, and no Kubernetes Secret reads.
+- `AGENTS.md` treats secrets, config loading, persistence, and public/network-facing APIs as high-risk changes.
+- `KubebarCore/Services/AppConfigStore.swift` persists selected context, watchlists, refresh cadence, Health State Shift Alerts, and kubeconfig paths with backward-compatible decoding.
+- `KubebarCore/Models/SetupFlowState.swift` owns Settings editing state, including App Settings and per-context tabs.
+- `KubebarCore/Models/MenuRuntimeState.swift` bridges saved `AppConfig`, Settings editing state, completed config, and unsaved-change detection.
+- `Kubebar/Views/SetupView.swift` renders App Settings sections and context tab content.
+- `Kubebar/Views/SettingsRootView.swift` wraps `SetupView` and routes Settings callbacks to `MenuBarViewModel`.
+- `Kubebar/MenuBarViewModel.swift` owns Settings preparation, save, and app-target service injection.
+- `KubebarCore/Services/CommandRunner.swift`, `KubebarCore/Services/KubectlClusterReader.swift`, and `KubebarCore/Services/WatchTargetCatalog.swift` show the preferred injectable boundary pattern.
+- `docs/solutions/app-settings/start-at-login-boundary-2026-05-19.md` shows how native macOS side effects stay behind an app-target boundary and fake-friendly Core abstractions.
+- `docs/solutions/architecture/per-context-watchlists-active-context-2026-06-03.md` shows the App Settings/global-state pattern and the need to preserve per-context watchlists.
+- Search found no existing Keychain, `SecItem`, or AI provider client code.
+- Current provider docs indicate direct Anthropic requests use `x-api-key` plus `anthropic-version`, Gemini supports OpenAI-compatible endpoints and direct Gemini APIs, and OpenAI-compatible endpoints commonly use `Authorization: Bearer`; implementation should isolate these details behind provider-specific request builders and tests.
+- Planner research dispatch used two read-only agents because the task spans Settings/config and secrets/network domains. Their outputs identified state-sync risks, Keychain redaction risks, and focused verification implications.
+
+## Decisions
+
+- Model AI Provider configuration as a small app-wide value type in `KubebarCore`, separate from any secret-bearing value.
+- Persist provider kind, model ID, and `OpenAI-compatible` base URL through `AppConfig`; do not encode API keys.
+- Default older configs to an unconfigured AI Provider state so existing users are not forced into AI setup.
+- Store provider API keys through an injectable credential-store protocol with a production Keychain adapter and in-memory fakes for tests.
+- Build Test Connection through an injectable service boundary that owns credential lookup, URLRequest construction, provider-specific headers, HTTP execution, and redaction.
+- Keep SwiftUI views thin: views render fields/buttons and callbacks, but do not read Keychain, construct requests, or inspect raw provider responses.
+- Make Test Connection manual and send only a minimal provider-specific probe; no Kubernetes data is included.
+- Keep `OpenAI-compatible` limited to Bearer API Key, Base URL, and Model ID. Do not add custom headers.
+- Preserve AI as display/help behavior only; `HealthEvaluator`, `MenuDisplayModel` health categories, and menu bar icon states remain unchanged.
+
+## Assumptions
+
+- One API key slot per provider kind is sufficient for this slice; `OpenAI-compatible` uses its own credential slot.
+- Empty model ID, missing API key, or missing `OpenAI-compatible` base URL should produce safe local validation feedback instead of attempting a network request.
+- Provider-specific advanced settings such as organization IDs, project IDs, temperature, custom headers, or alternate auth flows are not required for Test Connection.
+- Production Keychain access can be implemented in the app target while Core owns protocols and pure testable behavior.
+- Visible app smoke is useful but not the primary verification signal because automated UI tests are not configured.
+
+## Planning Quality Gate Notes
+
+- Contract surface: `CONTEXT.md`, `.imm/specs/2026-07-01-ai-diagnostic-assistant-settings.md`, `docs/architecture/runtime-invariants.md`, `AppConfig`, `SetupFlowState`, `MenuRuntimeState`, `SetupView`, `SettingsRootView`, `MenuBarViewModel`, new AI provider/credential/test service types, app-target Keychain adapter, provider tests, Settings state tests, and quality-gate scripts.
+- Compatibility: older `config.json` files must decode with a default AI Provider configuration and no credential requirement. No migration prompt is allowed.
+- Interruption recovery: after U1, config metadata can exist but no provider call is exposed. After U2, service tests can pass without UI exposure. After U3, users can configure and test connections; failure feedback remains safe.
+- Rollback path: revert the files touched by the failed step plus related tests/docs. Deleting the AI config field from a partially written local config must fall back to defaults; Keychain entries should be namespaced so they can be deleted by the credential-store boundary if a later cleanup is needed.
+- Verification strength: use Codable tests, Settings state tests, fake credential-store tests, fake HTTP request-construction tests, redaction tests, full Swift quality gate, and visible Settings smoke instead of label-only checks.
+- Brainstorm traceability: every `BR-*` item is mapped above, including the resolved `BR-Q-001`.
+- Acceptance scope discipline: current acceptance proves configuration and Test Connection only; warning-text diagnosis is deferred and non-executable in this plan.
+
+## Devil's Advocate Audit
+
+### Rollback resilience
+
+The plan separates metadata persistence, credential/provider service boundaries, and UI exposure. If U1 fails, revert the config/model tests without touching Keychain or network code. If U2 fails, the unexposed service boundary can be reverted independently. If U3 fails, UI wiring can be reverted while leaving tested Core service behavior intact. No step mutates Kubernetes resources or reads Kubernetes Secrets.
+
+### Verification vanity
+
+A Settings label existing is not enough. U1 must fail if API keys can be encoded into `AppConfig` or if old configs no longer decode. U2 must fail if a request leaks credentials, skips the provider-specific auth contract, includes Kubernetes data, or surfaces raw secret-bearing error text. U3 must fail if the UI triggers provider calls without explicit user action or if the Settings save path drops provider metadata or credentials.
+
+### Spec dilution detection
+
+The plan covers all confirmed provider choices, removes `Ollama`, stores secrets in Keychain, supports Test Connection, and preserves the manual/warning-only diagnostic boundary. It intentionally defers actual warning explanation because the user confirmed the first executable work as configuration plus Test Connection; that deferral is mapped in Brainstorm Trace rather than silently omitted.
+
+## Scope Boundaries
+
+- In scope: app-wide AI Provider metadata, Keychain credential storage boundary, provider-specific Test Connection, safe result text, Settings UI controls, docs updates, and focused tests.
+- Out of scope: Ollama, automatic diagnosis, Pod logs, Kubernetes Secrets, complete `kubectl` output, raw cluster JSON, warning explanation execution, chat history, account system, OAuth, cloud sync, custom headers, and health-category changes.
+
+## Deferred Work
+
+- Manual AI explanation for user-approved warning summary text.
+- A dedicated diagnostics result surface, if warning explanation needs more than a Settings/Test Connection message.
+- Provider-specific advanced settings beyond model/base URL/API key.
+- Credential rotation or reset UX beyond replacing/deleting the currently selected provider key.
+- Optional docs for enterprise privacy posture after the diagnostic submission slice exists.
+
+## Implementation Units
+
+### Step 1
+
+- Step ID: U1
+- Result: AI Provider configuration metadata persists through Settings state without storing API keys.
+- Verification: swift test --filter AppConfigTests && swift test --filter AppConfigStoreTests && swift test --filter SetupFlowStateTests && swift test --filter MenuRuntimeStateTests && rtk git diff --check
+- Depends on: None
+- Test scenarios: older configs decode with default AI Provider configuration; provider kind/model/base URL round-trip through AppConfig; AppConfig encoding does not contain sentinel API keys; selecting context preserves app-wide AI Provider configuration; preparing Settings exposes saved AI Provider configuration; completed config preserves AI Provider configuration and existing per-context watchlists
+- Discovery cache: KubebarCore/Services/AppConfigStore.swift (persisted config shape); KubebarCore/Models/SetupFlowState.swift (Settings editing state); KubebarCore/Models/MenuRuntimeState.swift (completed config and unsaved-change detection); KubebarTests/Models/AppConfigTests.swift (global config behavior); KubebarTests/Services/AppConfigStoreTests.swift (Codable compatibility); KubebarTests/Models/SetupFlowStateTests.swift (Settings state behavior); KubebarTests/Models/MenuRuntimeStateTests.swift (completed config behavior)
+
+**Goal:** Add durable non-secret AI Provider configuration while preserving existing config compatibility and Settings behavior.
+
+**Verification type:** automated
+
+**Execution note:** test-first
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R13
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `KubebarCore/Services/AppConfigStore.swift`
+- Modify or add: `KubebarCore/Models/AIDiagnosticAssistantConfig.swift`
+- Modify: `KubebarCore/Models/SetupFlowState.swift`
+- Modify: `KubebarCore/Models/MenuRuntimeState.swift`
+- Modify: `KubebarTests/Models/AppConfigTests.swift`
+- Modify: `KubebarTests/Services/AppConfigStoreTests.swift`
+- Modify: `KubebarTests/Models/SetupFlowStateTests.swift`
+- Modify: `KubebarTests/Models/MenuRuntimeStateTests.swift`
+
+**Approach:**
+- Add a small Codable/Equatable/Sendable model for provider kind, model ID, and optional OpenAI-compatible base URL.
+- Add backward-compatible `AppConfig` decoding with a safe default AI Provider configuration.
+- Keep API key values out of the model entirely; tests should encode a sentinel key elsewhere and assert it never appears in config JSON.
+- Thread the value through `SetupFlowState`, `MenuRuntimeState.setupState(from:)`, `completedConfig()`, and unsaved-change detection.
+- Keep AI Provider configuration app-wide and independent of per-context watchlists.
+
+**failure_behavior:** If compatibility tests fail, stop before adding credential or network behavior. Existing user configs must remain loadable before later steps can proceed.
+
+**security_considerations:** This step must prove the persisted model has no API-key field and no encoded sentinel secret.
+
+### Step 2
+
+- Step ID: U2
+- Result: AI Provider Test Connection uses injectable redacted credential boundaries.
+- Verification: swift test --filter AIDiagnosticAssistant && swift test --filter AIProviderCredential && swift test --filter AIProviderConnection && swift build && rtk git diff --check
+- Depends on: 1
+- Test scenarios: missing API key returns safe local failure; replacing a key updates only the credential store; AppConfigStore never receives a secret-bearing model; OpenAI request uses Authorization Bearer and minimal body; Anthropic request uses provider-specific key/version headers; Gemini request avoids putting the key in visible result text; OpenAI-compatible request uses configured Base URL with Bearer auth and no custom headers; network/provider errors containing a sentinel key or Bearer token are redacted; Test Connection sends no warning text, Pod logs, kubeconfig, raw kubectl output, or cluster JSON
+- Discovery cache: KubebarCore/Services/CommandRunner.swift (injectable boundary pattern); KubebarCore/Services/KubectlClusterReader.swift (safe failure mapping pattern); KubebarCore/Services/StartAtLoginSettingsCoordinator.swift (native side-effect abstraction pattern); Kubebar/Services/LoginItemController.swift (app-target macOS API wrapper pattern); KubebarTests/Services/StartAtLoginSettingsCoordinatorTests.swift (fake-controller tests); KubebarTests/Services/KubectlClusterReaderTests.swift (request/failure tests)
+
+**Goal:** Make credential handling and provider probing testable without leaking secrets or performing real network calls in tests.
+
+**Verification type:** automated
+
+**Execution note:** test-first
+
+**Requirements:** R2, R5, R6, R7, R8, R9, R10, R11, R13
+
+**Dependencies:** U1
+
+**Files:**
+- Add: `KubebarCore/Services/AIProviderCredentialStore.swift`
+- Add: `KubebarCore/Services/AIProviderConnectionTester.swift`
+- Add: `KubebarCore/Services/HTTPClient.swift`
+- Add or modify: app-target Keychain adapter under `Kubebar/Services/`
+- Add or modify: `KubebarTests/Services/AIProviderCredentialStoreTests.swift`
+- Add or modify: `KubebarTests/Services/AIProviderConnectionTesterTests.swift`
+
+**Approach:**
+- Define credential-store and HTTP-client protocols in Core with fake implementations in tests.
+- Put production Keychain access behind an app-target adapter using macOS Security APIs.
+- Build provider-specific request builders inside the service layer, not in SwiftUI views.
+- Keep Test Connection payload minimal and unrelated to Kubernetes data.
+- Centralize redaction so thrown errors, HTTP bodies, and transport descriptions cannot surface API keys or Bearer tokens.
+
+**parallel_probes:**
+- scope: `KubebarCore/Services/CommandRunner.swift`, `KubebarCore/Services/KubectlClusterReader.swift`; output: boundary and safe-failure conventions to preserve; readonly: true
+- scope: `Kubebar/Services/LoginItemController.swift`, `KubebarCore/Services/StartAtLoginSettingsCoordinator.swift`; output: native macOS adapter and fake-test conventions; readonly: true
+- scope: provider API docs and tests; output: minimal request contract per provider without adding custom headers; readonly: true
+
+**failure_behavior:** If Keychain or redaction tests fail, do not wire UI actions. The feature must remain unreachable until credentials and safe errors are proven.
+
+**security_considerations:** This is the highest-risk step. It touches secrets and network-facing behavior, so all user-visible result strings must be sanitized and tests must include sentinel secrets.
+
+### Step 3
+
+- Step ID: U3
+- Result: App Settings exposes AI Diagnostic Assistant configuration with manual Test Connection feedback.
+- Verification: swift test --filter SetupFlowStateTests && swift test --filter MenuRuntimeStateTests && swift test --filter AIDiagnosticAssistant && /usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local && rtk git diff --check
+- Depends on: 2
+- Test scenarios: App Settings shows AI Diagnostic Assistant controls; provider picker excludes Ollama; OpenAI-compatible reveals Base URL and does not reveal custom-header fields; saving Settings persists provider metadata and saves API key through credential store only; Test Connection is button-triggered and not automatic on open/save; success and failure messages are safe; missing key/model/base URL shows local validation feedback; existing Start at Login, Health State Shift Alerts, kubeconfig paths, and per-context watchlists still save correctly; runtime docs state AI does not affect Health category and diagnostic input is manually approved warning text only
+- Discovery cache: Kubebar/Views/SetupView.swift (App Settings UI); Kubebar/Views/SettingsRootView.swift (Settings wrapper callbacks); Kubebar/MenuBarViewModel.swift (Settings save/test action boundary); KubebarCore/Models/MenuRuntimeState.swift (runtime state publication); docs/architecture/runtime-invariants.md (runtime safety rules); scripts/swift-quality-gate.sh (full verification)
+
+**Goal:** Give users a visible, safe Settings workflow for provider configuration and Test Connection.
+
+**Verification type:** automated
+
+**Execution note:** test-first
+
+**Requirements:** R1, R2, R3, R4, R5, R7, R8, R9, R10, R11, R13
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `Kubebar/Views/SetupView.swift`
+- Modify: `Kubebar/Views/SettingsRootView.swift`
+- Modify: `Kubebar/MenuBarViewModel.swift`
+- Modify: `KubebarCore/Models/SetupFlowState.swift`
+- Modify: `KubebarCore/Models/MenuRuntimeState.swift`
+- Modify: `docs/architecture/runtime-invariants.md`
+- Modify or add: relevant Settings/ViewModel tests where feasible
+
+**Approach:**
+- Add a dedicated `AI Diagnostic Assistant` section to App Settings using existing Settings section patterns.
+- Render provider picker, model text field, OpenAI-compatible base URL field, secure API key entry, credential delete/replace affordance if needed, and a `Test Connection` button.
+- Route field updates and Test Connection through `MenuBarViewModel`; publish safe state changes back through `MenuRuntimeState`.
+- Ensure opening Settings and saving Settings do not automatically call providers.
+- Update runtime invariants to preserve no-health-category-input and warning-text-only diagnostic boundaries.
+- Run the full quality gate and, when practical, launch the app to smoke-check the Settings section and manual Test Connection affordance.
+
+**failure_behavior:** If UI wiring fails, leave provider settings inaccessible rather than exposing a button that can leak secrets or make unintended network calls.
+
+**security_considerations:** The UI must not display raw API keys after save, raw HTTP bodies, full requests, or token-like provider errors. It must clearly separate Test Connection from any Kubernetes diagnostic submission.
+
+## Verification Approach
+
+- Run `/Users/derek/workspaces/agent-skills/plugins/immune-brain/bin/imm-plan docs/plans/2026-07-01-001-feat-ai-diagnostic-assistant-settings-plan.md --json` before execution handoff.
+- U1 uses Codable and state tests to prove compatibility and non-secret persistence.
+- U2 uses fake credential and HTTP clients to prove provider request construction, manual Test Connection behavior, and redaction without real network calls.
+- U3 uses focused state/UI wiring tests plus the full `./scripts/swift-quality-gate.sh local` gate.
+- A visible app smoke with `./scripts/compile-and-run.sh` is recommended when practical to confirm App Settings shows the section and Test Connection remains manual.

--- a/docs/plans/2026-07-01-002-refactor-settings-sidebar-layout-plan.md
+++ b/docs/plans/2026-07-01-002-refactor-settings-sidebar-layout-plan.md
@@ -1,0 +1,166 @@
+---
+title: "refactor: Settings sidebar detail layout"
+type: refactor
+status: planned
+date: 2026-07-01
+origin: .imm/specs/2026-07-01-settings-sidebar-layout.md
+---
+
+# refactor: Settings sidebar detail layout
+
+## Summary
+
+- Summary: Redesign Kubebar Settings from a stacked tab/form surface into a native sidebar/detail layout with a dedicated `AI Assistant` page.
+
+This plan is a UI structure refactor. It does not change AI provider behavior, Keychain behavior, Kubernetes reads, saved AppConfig semantics, Health category evaluation, or menu health display. It reorganizes Settings so App-level pages and Context watchlist pages have clearer hierarchy and local actions.
+
+## Task
+
+- Type: refactor
+- Scope: Settings navigation state, Settings window layout, `SetupView`, `SettingsRootView`, Settings tests, and canonical Settings vocabulary docs
+- Owner: imm-work
+- Verification: focused Settings state tests, Swift build/tests, full Swift quality gate, and visible Settings smoke
+- Brainstorm manifest: BR-REQ-001; BR-REQ-002; BR-REQ-003; BR-REQ-004; BR-REQ-005; BR-REQ-006; BR-REQ-007; BR-REQ-008; BR-REQ-009; BR-REQ-010; BR-OUT-001; BR-OUT-002; BR-OUT-003; BR-OUT-004; BR-DEC-001; BR-DEC-002; BR-DEC-003
+
+## Output Language
+
+Spec and Plan prose are English. Schema fields, commands, file paths, Swift identifiers, canonical terms, and Immune-Brain fields stay literal.
+
+## Origin
+
+The user confirmed the design direction after noting that the current Settings layout feels like a simple stack of controls. The confirmed direction is:
+
+- Keep a standard macOS Settings feel.
+- Move from one long App Settings page to sidebar/detail navigation.
+- Keep App pages separate from Context watchlist pages.
+- Give `AI Diagnostic Assistant` a dedicated `AI Assistant` page instead of appending it under unrelated sections.
+- Prioritize grouping, spacing, scroll behavior, and local action placement over decorative styling.
+
+## Brainstorm Manifest
+
+- `BR-REQ-001`: Settings uses a sidebar/detail layout instead of a stacked `TabView` page.
+- `BR-REQ-002`: Sidebar groups App-level pages separately from Context pages.
+- `BR-REQ-003`: App pages are `General`, `Kubernetes`, `Notifications`, and `AI Assistant`.
+- `BR-REQ-004`: Context pages continue to edit exactly one per-context watchlist.
+- `BR-REQ-005`: `AI Assistant` is a dedicated App page, not a bottom section on a long App Settings page.
+- `BR-REQ-006`: `AI Assistant` groups Provider, Endpoint, Credentials, and Connection.
+- `BR-REQ-007`: `AI Assistant` explains manual Test Connection, Keychain-backed API keys, and no Kubernetes data in Test Connection.
+- `BR-REQ-008`: Detail content scrolls when needed while the footer remains reachable.
+- `BR-REQ-009`: Form fields keep readable width limits instead of stretching across the whole detail pane.
+- `BR-REQ-010`: Existing Settings save and state behavior is preserved.
+- `BR-OUT-001`: No new AI diagnostic execution or automatic/background AI action.
+- `BR-OUT-002`: No new provider choices, custom headers, OAuth, cloud sync, or chat surface.
+- `BR-OUT-003`: No Kubernetes read/write behavior changes.
+- `BR-OUT-004`: No custom visual theme, rich animation, or decorative redesign.
+- `BR-DEC-001`: `AI Assistant` should be an App-level Settings page because it is app-wide helper configuration.
+- `BR-DEC-002`: `Test Connection` remains a local action in the `AI Assistant` detail pane, not a footer action.
+- `BR-DEC-003`: The window may become wider if needed to fit sidebar plus detail forms comfortably.
+
+## Brainstorm Trace
+
+| Item | Status | Target | Reason |
+| --- | --- | --- | --- |
+| BR-REQ-001 | covered_by_step | U1, U2 | U1 creates page-oriented selection; U2 renders sidebar/detail layout. |
+| BR-REQ-002 | covered_by_step | U1, U2 | U1 models App and Context pages; U2 renders the grouped sidebar. |
+| BR-REQ-003 | covered_by_step | U1, U2 | U1 defines the App page choices; U2 renders each detail page. |
+| BR-REQ-004 | covered_by_step | U1, U2 | U1 preserves context selection behavior; U2 keeps the watchlist detail page. |
+| BR-REQ-005 | covered_by_step | U2 | U2 moves AI controls to the dedicated page. |
+| BR-REQ-006 | covered_by_step | U2 | U2 structures the AI detail page groups. |
+| BR-REQ-007 | covered_by_step | U2 | U2 adds AI page explanatory text without changing behavior. |
+| BR-REQ-008 | covered_by_step | U2 | U2 owns ScrollView/detail/footer layout behavior. |
+| BR-REQ-009 | covered_by_step | U2 | U2 owns form row width and detail layout bounds. |
+| BR-REQ-010 | covered_by_step | U1, U2 | U1 state tests and U2 focused tests/quality gate guard behavior. |
+| BR-OUT-001 | out_of_scope | Scope Boundaries | This refactor only reorganizes Settings UI. |
+| BR-OUT-002 | out_of_scope | Scope Boundaries | Provider/API feature scope remains unchanged. |
+| BR-OUT-003 | out_of_scope | Scope Boundaries | Settings layout must not alter Kubernetes reads or writes. |
+| BR-OUT-004 | out_of_scope | Scope Boundaries | The design tier is Standard and uses inherited native styling. |
+| BR-DEC-001 | covered_by_step | U1, U2 | App-level page modeling and UI placement enforce this decision. |
+| BR-DEC-002 | covered_by_step | U2 | The `Test Connection` action remains inside the AI detail page. |
+| BR-DEC-003 | captured_as_decision | Decisions | U2 may adjust `SettingsWindowLayout.width` if the current width is cramped. |
+
+## Research
+
+- `CONTEXT.md` currently defines `App Settings tab` and `Context Settings tab`, which reflects the existing tab-based implementation and must be updated when the layout becomes page/sidebar-based.
+- `SetupFlowState` owns Settings selection and currently exposes one `.appSettings` tab plus one tab per context.
+- `MenuRuntimeState` owns Settings preparation, completed config generation, unsaved-change detection, and selection callbacks.
+- `SetupView` currently renders a `TabView` and one long `appSettingsContent` stack with General, Kubeconfig, Launch, Alerts, and AI sections.
+- `SettingsRootView` owns the fixed Settings window frame and passes callbacks into `SetupView`.
+- `SettingsWindowLayout` is currently `640 x 560`; a sidebar/detail layout may need a wider width to avoid cramped controls.
+- There is no root `DESIGN.md`; visual decisions should stay source-neutral and native-system inherited.
+- The previous AI settings work already added provider config, Keychain credential storage, and manual Test Connection behavior. This plan must preserve that behavior rather than reopen the AI feature scope.
+- Planner research dispatch was not needed because this is a single-domain Settings layout refactor with known files and verification paths.
+
+## Decisions
+
+- Use page-oriented Settings selection rather than continuing the `SettingsTabSelection` mental model.
+- Keep App-level pages in a stable order: `General`, `Kubernetes`, `Notifications`, `AI Assistant`.
+- Keep Context pages generated from local context names and preserve the existing selected-context/watchlist behavior.
+- Keep the Settings footer as the global save area.
+- Keep local actions inside their page: `Add Files` in `Kubernetes`, `Test Connection` in `AI Assistant`.
+- Use native SwiftUI styling, inherited system colors, and the existing form-row pattern with better grouping.
+- Allow a wider Settings window if 640pt cannot fit sidebar plus detail content cleanly.
+- Prefer a mechanical state/UI refactor over introducing a custom design system.
+
+## Assumptions
+
+- macOS 14 support allows use of modern SwiftUI layout primitives, but a simple custom `HStack` sidebar/detail layout is acceptable if it better preserves existing callbacks.
+- There are no automated SwiftUI snapshot tests, so visible Settings smoke remains HITL evidence for layout quality.
+- Existing unit tests can be adapted to page-oriented Settings selection without changing AppConfig persistence semantics.
+- The existing save button title and enabled/disabled rules remain based on configuration completeness.
+
+## Devil's Advocate Audit
+
+### Rollback resilience
+
+The plan separates state navigation modeling from the visual sidebar/detail implementation. If U1 fails, revert Core selection model/test changes before touching UI layout. If U2 fails, revert `SetupView`/`SettingsRootView` layout changes while retaining any valid page-selection model only if tests prove it remains useful. No step changes Kubernetes access, Keychain access, provider HTTP behavior, or persisted config schema.
+
+### Verification vanity
+
+A sidebar label existing is not enough. U1 tests must fail if context watchlist selection or completed config behavior changes. U2 verification must include focused Settings tests, full build/quality gate, and HITL smoke that confirms actual layout hierarchy, conditional Base URL behavior, local Test Connection placement, and footer stability.
+
+### Spec dilution detection
+
+The plan covers the user's core complaint: Settings should stop feeling like a simple stack. It does not silently narrow the task to AI-only polish; it restructures the whole Settings surface enough to separate App pages and Context pages while keeping AI as one clear App-level page. It intentionally excludes rich visual theming and new AI behavior because the request is layout hierarchy, not feature expansion.
+
+## Scope Boundaries
+
+- In scope: Settings navigation model, sidebar/detail layout, App page grouping, AI page grouping/copy, field width/scroll/footer layout, Settings vocabulary docs, and focused tests.
+- Out of scope: provider behavior changes, Keychain behavior changes, Kubernetes behavior changes, health-category behavior, menu dropdown redesign, new AI diagnostic execution, custom visual theme, and snapshot-test infrastructure.
+
+## Implementation Units
+
+### Step 1
+
+- Step ID: U1
+- Result: Settings state exposes page-oriented navigation while preserving completed configuration behavior.
+- Verification: swift test --filter SetupFlowStateTests && swift test --filter MenuRuntimeStateTests && rtk git diff --check
+- Depends on: None
+- Test scenarios: App pages are available in stable order; context pages are generated from available contexts; selecting an App page preserves current watchlist edits; selecting a Context page loads that context's watchlist; completed config is unchanged by page navigation; `CONTEXT.md` Settings vocabulary matches page/sidebar navigation
+- Discovery cache: KubebarCore/Models/SetupFlowState.swift (Settings selection model); KubebarCore/Models/MenuRuntimeState.swift (prepare/save/selection state); KubebarTests/Models/SetupFlowStateTests.swift (Settings state tests); KubebarTests/Models/MenuRuntimeStateTests.swift (runtime state tests); CONTEXT.md (canonical Settings vocabulary)
+
+**Goal:** Replace tab-centric Settings state vocabulary with page-oriented App/Context selection while preserving existing save semantics.
+
+**Verification type:** automated
+
+**Execution note:** characterization-first
+
+**failure_behavior:** If state tests show completed config, context selection, or watchlist preservation regresses, stop before changing UI layout.
+
+### Step 2
+
+- Step ID: U2
+- Result: Settings renders a sidebar/detail layout with `AI Assistant` as a focused App page.
+- Verification: swift test --filter SetupFlowStateTests && swift test --filter MenuRuntimeStateTests && swift test --filter AIDiagnosticAssistant && swift build && /usr/bin/env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/swift-quality-gate.sh local && rtk git diff --check
+- Depends on: 1
+- Test scenarios: sidebar shows App group and Context pages; `General` renders refresh cadence and Start at Login; `Kubernetes` renders kubeconfig source/files and Add Files action; `Notifications` renders Health State Shift Alerts; `AI Assistant` renders Provider/Endpoint/Credentials/Connection groups; Base URL appears only for `OpenAI-compatible`; Test Connection stays manual and local to AI page; footer save action remains visible; visible Settings smoke confirms hierarchy and spacing
+- Discovery cache: Kubebar/Views/SetupView.swift (Settings layout); Kubebar/Views/SettingsRootView.swift (window frame and callbacks); Kubebar/MenuBarViewModel.swift (Settings callbacks and save/test behavior); KubebarCore/Models/AIDiagnosticAssistantState.swift (AI UI state); KubebarCore/Services/AIProviderConnectionTester.swift (manual Test Connection behavior); docs/architecture/runtime-invariants.md (AI and Settings runtime constraints)
+
+**Goal:** Implement the confirmed layout contract in SwiftUI without changing Settings behavior.
+
+**Verification type:** automated + hitl
+
+**Execution note:** characterization-first
+
+**failure_behavior:** If the layout builds but smoke shows cramped or unclear hierarchy, adjust layout bounds/spacing inside U2 rather than adding new behavior.
+
+**security_considerations:** The AI page must keep Keychain/no-Kubernetes-data messaging and must not add raw key display, raw provider error display, automatic diagnosis, or any Kubernetes data submission path.

--- a/docs/solutions/app-settings/settings-sidebar-layout-2026-07-01.md
+++ b/docs/solutions/app-settings/settings-sidebar-layout-2026-07-01.md
@@ -1,0 +1,104 @@
+---
+module: app-settings
+tags:
+  - macos
+  - settings
+  - sidebar
+  - navigation
+  - page-oriented
+  - refactor
+problem_type: settings-layout
+reusability: medium
+key_files:
+  - KubebarCore/Models/SetupFlowState.swift
+  - KubebarCore/Models/MenuRuntimeState.swift
+  - Kubebar/Views/SetupView.swift
+  - Kubebar/Views/SettingsRootView.swift
+  - KubebarTests/Models/SetupFlowStateTests.swift
+next_reuse_scenarios:
+  - Adding a new App-level Settings page to the sidebar.
+  - Refactoring a single-page settings form into grouped navigation.
+  - Expanding an enum-based selection model without breaking callers.
+---
+
+# Settings Sidebar Layout Refactor
+
+## Problem
+
+App Settings was a single long `TabView` page with General, Kubeconfig, Launch,
+Alerts, and AI Diagnostic Assistant sections stacked vertically. Unrelated
+concerns had equal visual weight, and AI configuration was appended at the
+bottom without its own information hierarchy. This created a "simple stack of
+controls" feel.
+
+## Solution
+
+Split the Settings surface into a **sidebar/detail layout**:
+
+- Left sidebar: `List(selection:)` with `.sidebar` style, grouped into `App`
+  and `Contexts` sections.
+- Right detail: `ScrollView` rendering the selected page's content.
+- Footer: global Save action, always visible at the bottom.
+
+App pages are stable in order: `General`, `Kubernetes`, `Notifications`,
+`AI Assistant`. Context pages are generated from local context names.
+
+### Enum expansion without breaking callers
+
+The core insight: `SettingsTabSelection` was expanded from
+`.appSettings | .context(String)` to four App pages plus `.context(String)`,
+while keeping a backward-compatible `static var appSettings` that returns
+`.general`. This let existing call sites (`selectAppSettingsTab()`, test
+assertions, `SettingsTabID.appSettings`) continue compiling without a
+sweeping rename, while the new page model was available immediately.
+
+### Navigation reset bug
+
+When wiring the new `onSelectAppPage` callback, the initial implementation
+called `onSelectAppSettings()` (which maps to `viewModel.selectAppSettingsTab()`
+→ `runtimeState.selectAppSettingsTab()` → `selectAppPage(.general)`). This
+silently reset any App page selection back to `.general`, making it impossible
+to navigate to Kubernetes/Notifications/AI Assistant.
+
+Fix: add a dedicated `selectAppPage(_:)` callback chain
+(`SetupView` → `SettingsRootView` → `MenuBarViewModel.selectAppPage(_:)` →
+`MenuRuntimeState.selectAppPage(_:)`) that preserves the selected page instead
+of forcing `.general`.
+
+## Evidence
+
+- 318 tests pass across 31 suites including 6 new tests for App page
+  navigation behavior.
+- `swift build` and `swift-quality-gate.sh local` both pass.
+- `rtk git diff --check` clean.
+- App launches cleanly via `compile-and-run.sh`.
+
+## UI Polish Applied After Initial Implementation
+
+- Replaced invalid `k.stack` SF Symbol with `square.3.layers.3d`.
+- Added keyboard shortcuts (`Cmd+1`..`Cmd+4`) for App pages.
+- Merged AI Assistant sections into "Provider configuration" and
+  "Connection"; Base URL is hidden unless the provider is
+  `OpenAI-compatible`.
+- App pages now show their own descriptive subtitles instead of the active
+  Kubernetes context.
+- Removed unnecessary `maxHeight: .infinity` from the detail content pane
+  now that it scrolls.
+- Widened `SettingsRow` content area from 280pt to 360pt for long paths and
+  keys.
+- Raised Settings window height from 560pt to 620pt.
+- Added a warning icon next to contexts that have no watchlist selected.
+- Unified App page and Context sidebar rows to a single `HStack` helper
+  with a fixed 20pt icon width, identical spacing, and a trailing warning
+  icon, so icons and text align consistently regardless of section.
+
+## Reusability Critique
+
+- **Falsifiability**: This pattern works for macOS SwiftUI Settings windows
+  with a small number of grouped pages. It would not apply to iOS settings
+  where `NavigationSplitView` or `Form` sections are idiomatic.
+- **Evidence trail**: SetupFlowStateTests, MenuRuntimeStateTests, and the
+  compile-and-run smoke test confirm the model and build are correct. Layout
+  quality is HITL-verified (no automated SwiftUI snapshot tests exist).
+- **Architecture entropy**: This appends to the `app-settings` hub without
+  duplicating the per-context-watchlists pattern in `architecture/`.


### PR DESCRIPTION
## Summary

Add a configurable **AI Diagnostic Assistant** to Kubebar Settings with Keychain-backed API keys and manual Test Connection. Redesign the Settings window from a stacked TabView into a sidebar/detail layout.

### AI Diagnostic Assistant
- Provider picker: OpenAI, Anthropic, Google Gemini, OpenAI-compatible (no Ollama)
- Keychain-backed API key storage (never in AppConfig)
- Manual Test Connection using minimal provider probe (no K8s data sent)
- Injectably tested credential store, HTTP client, and connection tester
- Safe failure messages that never leak keys or raw errors

### Settings Sidebar Layout
- macOS-style sidebar with App pages (General, Kubernetes, Notifications, AI Assistant) and Contexts
- Detail pane with ScrollView, global footer save action
- Enum-based page selection model with backward-compatible `.appSettings` alias
- Keyboard shortcuts `Cmd+1`–`Cmd+4` for App pages
- Config‑state warning icons for unconfigured contexts

### UI Polish
- Merged AI sections into Provider configuration + Connection
- Widened form fields (280pt → 360pt)
- Raised window height (560pt → 620pt)
- Unified sidebar row alignment via custom HStack helper
- Fixed invalid `k.stack` SF Symbol

## Verification
- 318 tests, 31 suites pass
- `swift build` + `swift-quality-gate.sh local` pass
- `rtk git diff --check` clean
- App launches via `compile-and-run.sh`

## Notes
- AI output does not affect HealthEvaluator or menu health categories
- API keys stored exclusively in macOS Keychain, not in AppConfig
- Test Connection is manual and sends no Kubernetes data
- Future AI diagnostic input limited to user‑approved warning text only
- Layout quality is HITL (no automated snapshot tests)