### PR TITLE
feat: add manual AI diagnosis for pod logs and warning events

### DIFF
--- a/.imm/memory/MEMORY.md
+++ b/.imm/memory/MEMORY.md
@@ -1,9 +1,9 @@
 # Immune-Brain Summary
 
 ## 当前状态
-- **最新摘要**: Closed: captured reusable architecture guidance for focusable Pod log windows and native read-only log text surfaces.
-- **待办事项**: Next: work is closed; optional next step is to review docs/solutions/architecture/pod-log-focus-window-2026-06-22.md or start a new scoped task.
-- **最后同步**: 2026-06-22 15:58:45
+- **最新摘要**: Closed: implemented Overview Recent Warnings AI Event diagnostics and captured reusable explicit-warning-target/fresh-event-read architecture guidance.
+- **待办事项**: Next: work is closed; optional next step is code owner review or manual app smoke of the Overview warning AI action.
+- **最后同步**: 2026-07-02 07:40:00
 
 ## Knowledge Index
 
@@ -19,6 +19,10 @@
   reusable pattern for menu-launched troubleshooting surfaces that need a
   focusable app-owned macOS window, ViewModel-owned side effects, and native
   read-only text behavior for live logs.
+- `docs/solutions/architecture/ai-event-diagnostics-overview-entry-2026-07-02.md`:
+  reusable pattern for AI diagnostic actions that need explicit display-model
+  targets, fresh app-owned `kubectl` reads, event-only provider payloads, and
+  transient menu UI state.
 - `docs/solutions/app-settings/start-at-login-boundary-2026-05-19.md`:
   reusable pattern for macOS-only settings that mutate system state through an
   app-target boundary while keeping state transitions testable in KubebarCore.

--- a/.imm/memory/current_iteration.json
+++ b/.imm/memory/current_iteration.json
@@ -4,54 +4,75 @@
     "1": {
       "number": 1,
       "step_id": "U1",
-      "result": "`Overview` `Recent Warnings` manually renders a safe AI diagnosis from the latest 5 fresh matching Warning Events.",
-      "verification": "swift test --filter AIProviderConnectionTesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter WarningEventDiagnosticReaderTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
+      "result": "`AI Assistant` Settings supports safe prompt customization/reset for Pod/Event diagnosis.",
+      "verification": "swift test --filter AIPodDiagnosticRequesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter AppConfigTests && swift test --filter SetupFlowStateTests && swift test --filter MenuRuntimeStateTests && swift test --filter AIProviderConnectionTesterTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
       "test_scenarios": [
-        "Overview Recent Warnings exposes the AI action while Events tab rows do not",
-        "the diagnostic reader builds a fresh `kubectl --context <context> get events --all-namespaces --field-selector type=Warning -o json` style read with effective kubeconfig overrides",
-        "exact matching uses `namespace`, `objectKind`, `objectName`, and `reason` without substring fallback",
-        "provider input is sorted newest first and capped at 5 matching Warning Events",
-        "no matching fresh events produces a safe retryable failure",
-        "event messages are redacted before provider submission",
-        "missing provider model/key/base URL returns safe local failure",
-        "provider/network errors never expose API keys/Bearer tokens/raw response bodies",
-        "request body includes structured event context and required Markdown instructions but no Pod logs, kubeconfig content, raw cluster JSON, or raw kubectl transcript",
-        "diagnosis state supports loading, success, retryable failure, unavailable configuration, and stale-display disclosure",
-        "AI suggested commands remain text only and no mutation command is executed by Kubebar",
+        "existing configs without prompt fields decode and use defaults",
+        "saving config round-trips custom Pod and Event prompt overrides without API keys",
+        "blank custom prompt falls back to built-in default",
+        "reset clears a surface override rather than saving default text",
+        "Settings change detection includes prompt overrides",
+        "Pod diagnostic request body includes custom Pod prompt instructions plus fixed safety prompt, bounded redacted last-50 logs, and no-auto-execute disclosure",
+        "Event diagnostic request body includes custom Event prompt instructions plus fixed safety prompt, latest-5 matching events, and no Pod logs",
+        "Test Connection sends no custom prompt or Kubernetes data",
         "docs preserve Health category independence"
       ],
       "discovery_cache": [
         {
-          "path": "Kubebar/Views/OverviewTabView.swift",
-          "reason": "Overview Recent Warnings UI"
+          "path": "KubebarCore/Models/AIDiagnosticAssistantConfig.swift",
+          "reason": "prompt override config and defaults"
         },
         {
-          "path": "Kubebar/Views/WarningEventsView.swift",
-          "reason": "shared warning row view and Events-tab separation risk"
+          "path": "KubebarCore/Models/AIDiagnosticAssistantState.swift",
+          "reason": "Settings editing state helper surface"
         },
         {
-          "path": "KubebarCore/Models/MenuDisplayModel.swift",
-          "reason": "display-ready warnings and diagnostic target value"
+          "path": "KubebarCore/Models/SetupFlowState.swift",
+          "reason": "Settings mutation methods"
         },
         {
-          "path": "KubebarCore/Services/HealthEvaluator.swift",
-          "reason": "warning grouping key"
+          "path": "KubebarCore/Models/MenuRuntimeState.swift",
+          "reason": "config change detection"
         },
         {
-          "path": "KubebarCore/Services/KubectlClusterReader.swift",
-          "reason": "Warning Event kubectl decode/command pattern"
-        },
-        {
-          "path": "KubebarCore/Services/AIProviderConnectionTester.swift",
-          "reason": "provider validation pattern"
+          "path": "KubebarCore/Services/AppConfigStore.swift",
+          "reason": "config encode/decode compatibility"
         },
         {
           "path": "KubebarCore/Services/AIPodDiagnosticRequester.swift",
-          "reason": "diagnostic requester/redaction pattern"
+          "reason": "Pod prompt request composition"
         },
         {
-          "path": "Kubebar/MenuBarViewModel.swift",
-          "reason": "transient AI state and app-owned config"
+          "path": "KubebarCore/Services/AIEventDiagnosticRequester.swift",
+          "reason": "Event prompt request composition"
+        },
+        {
+          "path": "KubebarCore/Services/AIProviderConnectionTester.swift",
+          "reason": "unchanged Test Connection boundary"
+        },
+        {
+          "path": "Kubebar/Views/SetupView.swift",
+          "reason": "`AI Assistant` Settings UI"
+        },
+        {
+          "path": "KubebarTests/Models/AppConfigTests.swift",
+          "reason": "config compatibility tests"
+        },
+        {
+          "path": "KubebarTests/Models/SetupFlowStateTests.swift",
+          "reason": "Settings mutation tests"
+        },
+        {
+          "path": "KubebarTests/Models/MenuRuntimeStateTests.swift",
+          "reason": "change detection tests"
+        },
+        {
+          "path": "KubebarTests/Services/AIPodDiagnosticRequesterTests.swift",
+          "reason": "Pod request-body tests"
+        },
+        {
+          "path": "KubebarTests/Services/AIEventDiagnosticRequesterTests.swift",
+          "reason": "Event request-body tests"
         },
         {
           "path": "docs/architecture/runtime-invariants.md",
@@ -66,86 +87,112 @@
       "depends_on": [],
       "agent_hint": null,
       "state": "closed",
-      "activated_at": "2026-07-02T07:07:13Z",
+      "activated_at": "2026-07-03T06:52:23Z",
       "execution_evidence": {
         "changed_files": [
           "CONTEXT.md",
           "docs/architecture/runtime-invariants.md",
-          ".imm/specs/2026-07-02-ai-event-diagnostics.md",
-          "docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md",
-          "changelog.d/ai-event-diagnostics.added.md",
-          "Kubebar.xcodeproj/project.pbxproj",
-          "KubebarCore/Models/AIEventDiagnosis.swift",
-          "KubebarCore/Models/MenuDisplayModel.swift",
-          "KubebarCore/Services/HealthEvaluator.swift",
-          "KubebarCore/Services/WarningEventDiagnosticReader.swift",
+          ".imm/specs/2026-07-03-ai-diagnostic-prompt-customization.md",
+          "docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md",
+          "changelog.d/ai-diagnostic-prompt-customization.added.md",
+          "KubebarCore/Models/AIDiagnosticAssistantConfig.swift",
+          "KubebarCore/Models/AIDiagnosticAssistantState.swift",
+          "KubebarCore/Models/SetupFlowState.swift",
+          "KubebarCore/Services/AIPodDiagnosticRequester.swift",
           "KubebarCore/Services/AIEventDiagnosticRequester.swift",
           "Kubebar/MenuBarViewModel.swift",
-          "Kubebar/Views/MenuBarRootView.swift",
-          "Kubebar/Views/OverviewTabView.swift",
+          "Kubebar/Views/SetupView.swift",
+          "Kubebar/Views/SettingsRootView.swift",
           "Kubebar/KubebarApp.swift",
-          "KubebarTests/Services/WarningEventDiagnosticReaderTests.swift",
+          "KubebarTests/Models/AppConfigTests.swift",
+          "KubebarTests/Models/SetupFlowStateTests.swift",
+          "KubebarTests/Models/MenuRuntimeStateTests.swift",
+          "KubebarTests/Services/AIPodDiagnosticRequesterTests.swift",
           "KubebarTests/Services/AIEventDiagnosticRequesterTests.swift",
-          "KubebarTests/Models/MenuDisplayModelTests.swift"
+          "KubebarTests/Services/AIProviderConnectionTesterTests.swift"
         ],
-        "verification_result": "passed: focused Swift tests, swift build, full ./scripts/swift-quality-gate.sh local, and rtk git diff --check after UI review follow-up",
-        "verification_command": "swift test --filter AIProviderConnectionTesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter WarningEventDiagnosticReaderTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
-        "notes": "Implemented Overview-only Recent Warnings AI event diagnosis. Addressed UI review follow-up by making each sparkles button accessible/help text include warning reason and location, and by adding a dismiss action to the transient diagnosis panel. Focused tests, swift build, quality gate, and diff check passed after follow-up.",
-        "recorded_at": "2026-07-02T07:44:12Z"
+        "verification_result": "passed: focused Swift tests for prompt requester/config/state/Test Connection, swift build, full ./scripts/swift-quality-gate.sh local, and rtk git diff --check",
+        "verification_command": "swift test --filter AIPodDiagnosticRequesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter AppConfigTests && swift test --filter SetupFlowStateTests && swift test --filter MenuRuntimeStateTests && swift test --filter AIProviderConnectionTesterTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
+        "notes": "Implemented per-surface Pod/Event AI diagnostic prompt overrides with default fallback and reset semantics. Requesters keep fixed system prompts and code-owned bounded context blocks; Test Connection remains prompt-free.",
+        "recorded_at": "2026-07-03T07:18:45Z"
       },
-      "closed_at": "2026-07-02T07:44:55Z"
+      "closed_at": "2026-07-03T07:20:41Z"
     }
   },
   "pending_follow_up": null,
   "last_review": {
     "decision": "pass",
-    "evidence": "Focused tests, swift build, full ./scripts/swift-quality-gate.sh local, and rtk git diff --check passed after implementation and UI follow-up. UI review findings fixed: distinctive warning-specific accessibility labels/help and dismiss control for inline diagnosis panel. Code review child returned no findings/output; main-thread verification checked fresh event read, exact matching, latest-5 cap, redaction, no Pod logs, and Events tab remains action-free.",
-    "artifacts": "CONTEXT.md; docs/architecture/runtime-invariants.md; .imm/specs/2026-07-02-ai-event-diagnostics.md; docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md; changelog.d/ai-event-diagnostics.added.md; KubebarCore/Models/AIEventDiagnosis.swift; KubebarCore/Services/WarningEventDiagnosticReader.swift; KubebarCore/Services/AIEventDiagnosticRequester.swift; Kubebar/MenuBarViewModel.swift; Kubebar/Views/OverviewTabView.swift; tests",
-    "notes": "Review closure after bounded same-boundary UI follow-up.",
-    "recorded_at": "2026-07-02T07:44:55Z"
+    "evidence": "Focused tests for Pod/Event requesters, AppConfig, SetupFlowState, MenuRuntimeState, and AIProviderConnectionTester passed; swift build passed; full ./scripts/swift-quality-gate.sh local passed; rtk git diff --check passed. RED phase captured missing prompt config/requester APIs before implementation.",
+    "artifacts": "CONTEXT.md; docs/architecture/runtime-invariants.md; .imm/specs/2026-07-03-ai-diagnostic-prompt-customization.md; docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md; changelog.d/ai-diagnostic-prompt-customization.added.md; KubebarCore/Models/AIDiagnosticAssistantConfig.swift; KubebarCore/Models/AIDiagnosticAssistantState.swift; KubebarCore/Models/SetupFlowState.swift; KubebarCore/Services/AIPodDiagnosticRequester.swift; KubebarCore/Services/AIEventDiagnosticRequester.swift; Kubebar/MenuBarViewModel.swift; Kubebar/Views/SetupView.swift; Kubebar/Views/SettingsRootView.swift; Kubebar/KubebarApp.swift; focused tests",
+    "notes": "YAGNI check passed: changes are limited to per-surface prompt override config, Settings UI, request prompt composition, docs, and verification tests.",
+    "recorded_at": "2026-07-03T07:20:41Z"
   },
   "validated_plan_snapshot": {
-    "plan_path": "docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md",
-    "plan_signature": "c1ec9e5dd5a6c872a34bef00ab6873313a8518edd3fcc217d9f100d849c1a7db",
+    "plan_path": "docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md",
+    "plan_signature": "197958c7f012186428e47125f495f783e7bb44ee5390c6251658a219762c3dd2",
     "steps": [
       {
         "number": 1,
         "step_id": "U1",
-        "result": "`Overview` `Recent Warnings` manually renders a safe AI diagnosis from the latest 5 fresh matching Warning Events.",
-        "verification": "swift test --filter AIProviderConnectionTesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter WarningEventDiagnosticReaderTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
+        "result": "`AI Assistant` Settings supports safe prompt customization/reset for Pod/Event diagnosis.",
+        "verification": "swift test --filter AIPodDiagnosticRequesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter AppConfigTests && swift test --filter SetupFlowStateTests && swift test --filter MenuRuntimeStateTests && swift test --filter AIProviderConnectionTesterTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
         "depends_on": [],
         "discovery_cache": [
           {
-            "path": "Kubebar/Views/OverviewTabView.swift",
-            "reason": "Overview Recent Warnings UI"
+            "path": "KubebarCore/Models/AIDiagnosticAssistantConfig.swift",
+            "reason": "prompt override config and defaults"
           },
           {
-            "path": "Kubebar/Views/WarningEventsView.swift",
-            "reason": "shared warning row view and Events-tab separation risk"
+            "path": "KubebarCore/Models/AIDiagnosticAssistantState.swift",
+            "reason": "Settings editing state helper surface"
           },
           {
-            "path": "KubebarCore/Models/MenuDisplayModel.swift",
-            "reason": "display-ready warnings and diagnostic target value"
+            "path": "KubebarCore/Models/SetupFlowState.swift",
+            "reason": "Settings mutation methods"
           },
           {
-            "path": "KubebarCore/Services/HealthEvaluator.swift",
-            "reason": "warning grouping key"
+            "path": "KubebarCore/Models/MenuRuntimeState.swift",
+            "reason": "config change detection"
           },
           {
-            "path": "KubebarCore/Services/KubectlClusterReader.swift",
-            "reason": "Warning Event kubectl decode/command pattern"
-          },
-          {
-            "path": "KubebarCore/Services/AIProviderConnectionTester.swift",
-            "reason": "provider validation pattern"
+            "path": "KubebarCore/Services/AppConfigStore.swift",
+            "reason": "config encode/decode compatibility"
           },
           {
             "path": "KubebarCore/Services/AIPodDiagnosticRequester.swift",
-            "reason": "diagnostic requester/redaction pattern"
+            "reason": "Pod prompt request composition"
           },
           {
-            "path": "Kubebar/MenuBarViewModel.swift",
-            "reason": "transient AI state and app-owned config"
+            "path": "KubebarCore/Services/AIEventDiagnosticRequester.swift",
+            "reason": "Event prompt request composition"
+          },
+          {
+            "path": "KubebarCore/Services/AIProviderConnectionTester.swift",
+            "reason": "unchanged Test Connection boundary"
+          },
+          {
+            "path": "Kubebar/Views/SetupView.swift",
+            "reason": "`AI Assistant` Settings UI"
+          },
+          {
+            "path": "KubebarTests/Models/AppConfigTests.swift",
+            "reason": "config compatibility tests"
+          },
+          {
+            "path": "KubebarTests/Models/SetupFlowStateTests.swift",
+            "reason": "Settings mutation tests"
+          },
+          {
+            "path": "KubebarTests/Models/MenuRuntimeStateTests.swift",
+            "reason": "change detection tests"
+          },
+          {
+            "path": "KubebarTests/Services/AIPodDiagnosticRequesterTests.swift",
+            "reason": "Pod request-body tests"
+          },
+          {
+            "path": "KubebarTests/Services/AIEventDiagnosticRequesterTests.swift",
+            "reason": "Event request-body tests"
           },
           {
             "path": "docs/architecture/runtime-invariants.md",
@@ -159,17 +206,14 @@
         "parallel_probes": [],
         "agent_hint": null,
         "test_scenarios": [
-          "Overview Recent Warnings exposes the AI action while Events tab rows do not",
-          "the diagnostic reader builds a fresh `kubectl --context <context> get events --all-namespaces --field-selector type=Warning -o json` style read with effective kubeconfig overrides",
-          "exact matching uses `namespace`, `objectKind`, `objectName`, and `reason` without substring fallback",
-          "provider input is sorted newest first and capped at 5 matching Warning Events",
-          "no matching fresh events produces a safe retryable failure",
-          "event messages are redacted before provider submission",
-          "missing provider model/key/base URL returns safe local failure",
-          "provider/network errors never expose API keys/Bearer tokens/raw response bodies",
-          "request body includes structured event context and required Markdown instructions but no Pod logs, kubeconfig content, raw cluster JSON, or raw kubectl transcript",
-          "diagnosis state supports loading, success, retryable failure, unavailable configuration, and stale-display disclosure",
-          "AI suggested commands remain text only and no mutation command is executed by Kubebar",
+          "existing configs without prompt fields decode and use defaults",
+          "saving config round-trips custom Pod and Event prompt overrides without API keys",
+          "blank custom prompt falls back to built-in default",
+          "reset clears a surface override rather than saving default text",
+          "Settings change detection includes prompt overrides",
+          "Pod diagnostic request body includes custom Pod prompt instructions plus fixed safety prompt, bounded redacted last-50 logs, and no-auto-execute disclosure",
+          "Event diagnostic request body includes custom Event prompt instructions plus fixed safety prompt, latest-5 matching events, and no Pod logs",
+          "Test Connection sends no custom prompt or Kubernetes data",
           "docs preserve Health category independence"
         ]
       }
@@ -246,18 +290,225 @@
       "details": {
         "plan_path": "docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md"
       }
+    },
+    {
+      "at": "2026-07-03T06:50:50Z",
+      "action": "sync_plan_from_imm_plan",
+      "details": {
+        "plan_path": "docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md",
+        "plan_signature": "e82ce4ee6b70bd66a4133b3c86a4e4a9581d77d0d87545a58d6a0cefd1f4d5df",
+        "same_plan": false
+      }
+    },
+    {
+      "at": "2026-07-03T06:51:42Z",
+      "action": "sync_plan_from_imm_plan",
+      "details": {
+        "plan_path": "docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md",
+        "plan_signature": "197958c7f012186428e47125f495f783e7bb44ee5390c6251658a219762c3dd2",
+        "same_plan": true
+      }
+    },
+    {
+      "at": "2026-07-03T07:20:41Z",
+      "action": "review_step",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "decision": "pass",
+        "target_kind": "plan_step"
+      }
+    },
+    {
+      "at": "2026-07-03T07:21:49Z",
+      "action": "finish_reset",
+      "details": {
+        "plan_path": "docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md"
+      }
+    },
+    {
+      "at": "2026-07-03T07:38:07Z",
+      "action": "review_gate_pass",
+      "details": {
+        "gate": "imm-code-review",
+        "reviewed_changed_files": [
+          "CONTEXT.md",
+          "Kubebar/KubebarApp.swift",
+          "Kubebar/MenuBarViewModel.swift",
+          "Kubebar/Views/SettingsRootView.swift",
+          "Kubebar/Views/SetupView.swift",
+          "KubebarCore/Models/AIDiagnosticAssistantConfig.swift",
+          "KubebarCore/Models/AIDiagnosticAssistantState.swift",
+          "KubebarCore/Models/SetupFlowState.swift",
+          "KubebarCore/Services/AIEventDiagnosticRequester.swift",
+          "KubebarCore/Services/AIPodDiagnosticRequester.swift",
+          "KubebarTests/Models/AppConfigTests.swift",
+          "KubebarTests/Models/MenuRuntimeStateTests.swift",
+          "KubebarTests/Models/SetupFlowStateTests.swift",
+          "KubebarTests/Services/AIEventDiagnosticRequesterTests.swift",
+          "KubebarTests/Services/AIPodDiagnosticRequesterTests.swift",
+          "KubebarTests/Services/AIProviderConnectionTesterTests.swift",
+          "docs/architecture/runtime-invariants.md"
+        ],
+        "evidence_ref": "Solo code review: fixed safety/system prompt remains code-owned; prompt overrides are non-secret AppConfig fields with nil/blank default fallback; reset clears overrides; Test Connection stays prompt-free and sends no Kubernetes data; requester request bodies still include bounded/redacted Pod logs (last 50) and latest-5 Warning Events; API keys remain Keychain-only. Existing configs decode without prompt fields. Focused tests + swift build + full quality gate + rtk git diff --check passed."
+      }
+    },
+    {
+      "at": "2026-07-03T07:43:09Z",
+      "action": "review_gate_pass",
+      "details": {
+        "gate": "imm-code-review",
+        "reviewed_changed_files": [
+          ".imm/specs/2026-07-03-ai-diagnostic-prompt-customization.md",
+          "CONTEXT.md",
+          "Kubebar/KubebarApp.swift",
+          "Kubebar/MenuBarViewModel.swift",
+          "Kubebar/Views/SettingsRootView.swift",
+          "Kubebar/Views/SetupView.swift",
+          "KubebarCore/Models/AIDiagnosticAssistantConfig.swift",
+          "KubebarCore/Models/AIDiagnosticAssistantState.swift",
+          "KubebarCore/Models/SetupFlowState.swift",
+          "KubebarCore/Services/AIEventDiagnosticRequester.swift",
+          "KubebarCore/Services/AIPodDiagnosticRequester.swift",
+          "KubebarTests/Models/AppConfigTests.swift",
+          "KubebarTests/Models/MenuRuntimeStateTests.swift",
+          "KubebarTests/Models/SetupFlowStateTests.swift",
+          "KubebarTests/Services/AIEventDiagnosticRequesterTests.swift",
+          "KubebarTests/Services/AIPodDiagnosticRequesterTests.swift",
+          "KubebarTests/Services/AIProviderConnectionTesterTests.swift",
+          "changelog.d/ai-diagnostic-prompt-customization.added.md",
+          "docs/architecture/runtime-invariants.md",
+          "docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md"
+        ],
+        "evidence_ref": "Solo code review: fixed safety/system prompt remains code-owned; prompt overrides are non-secret AppConfig fields with nil/blank default fallback; reset clears overrides; Test Connection stays prompt-free and sends no Kubernetes data; requester request bodies still include bounded/redacted Pod logs (last 50) and latest-5 Warning Events; API keys remain Keychain-only. Existing configs decode without prompt fields. Focused tests + swift build + full quality gate + rtk git diff --check passed."
+      }
+    },
+    {
+      "at": "2026-07-03T07:44:44Z",
+      "action": "review_gate_pass",
+      "details": {
+        "gate": "imm-ui-review",
+        "reviewed_changed_files": [
+          "Kubebar/KubebarApp.swift",
+          "Kubebar/MenuBarViewModel.swift",
+          "Kubebar/Views/SettingsRootView.swift",
+          "Kubebar/Views/SetupView.swift"
+        ],
+        "evidence_ref": "Solo UI review: AI Assistant Settings adds a Diagnostic prompts section with two TextEditors (Pod/Event) initialized from effective defaults and Reset to default buttons. TextEditor and reset buttons carry accessibilityLabel; Settings detail is scrollable so two editors fit within fixed 620px window; effective-default binding returns default text when no override is saved, so reset clears the override and the editor returns to default; monospaced caption font keeps prompts readable. No color-only state, no menu-bar icon change, no health impact. Quality gate build passed."
+      }
+    },
+    {
+      "at": "2026-07-03T07:45:49Z",
+      "action": "review_gate_pass",
+      "details": {
+        "gate": "imm-ui-review",
+        "reviewed_changed_files": [
+          ".imm/specs/2026-07-03-ai-diagnostic-prompt-customization.md",
+          "CONTEXT.md",
+          "Kubebar/KubebarApp.swift",
+          "Kubebar/MenuBarViewModel.swift",
+          "Kubebar/Views/SettingsRootView.swift",
+          "Kubebar/Views/SetupView.swift",
+          "KubebarCore/Models/AIDiagnosticAssistantConfig.swift",
+          "KubebarCore/Models/AIDiagnosticAssistantState.swift",
+          "KubebarCore/Models/SetupFlowState.swift",
+          "KubebarCore/Services/AIEventDiagnosticRequester.swift",
+          "KubebarCore/Services/AIPodDiagnosticRequester.swift",
+          "KubebarTests/Models/AppConfigTests.swift",
+          "KubebarTests/Models/MenuRuntimeStateTests.swift",
+          "KubebarTests/Models/SetupFlowStateTests.swift",
+          "KubebarTests/Services/AIEventDiagnosticRequesterTests.swift",
+          "KubebarTests/Services/AIPodDiagnosticRequesterTests.swift",
+          "KubebarTests/Services/AIProviderConnectionTesterTests.swift",
+          "changelog.d/ai-diagnostic-prompt-customization.added.md",
+          "docs/architecture/runtime-invariants.md",
+          "docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md"
+        ],
+        "evidence_ref": "Solo UI review: AI Assistant Settings adds a Diagnostic prompts section with two TextEditors (Pod/Event) initialized from effective defaults and Reset to default buttons. TextEditor and reset buttons carry accessibilityLabel; Settings detail is scrollable so two editors fit within fixed 620px window; effective-default binding returns default text when no override is saved, so reset clears the override and the editor returns to default; monospaced caption font keeps prompts readable. No color-only state, no menu-bar icon change, no health impact. Quality gate build passed."
+      }
+    },
+    {
+      "at": "2026-07-03T07:50:09Z",
+      "action": "finish_reset",
+      "details": {
+        "plan_path": "docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md"
+      }
     }
   ],
   "requires_replan": false,
   "runtime_status": "idle",
-  "plan_path": "docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md",
-  "plan_summary": "Add a manual AI diagnosis action only to `Overview` `Recent Warnings` rows that rereads fresh Warning Events through `kubectl`, filters by exact `namespace`, `objectKind`, `objectName`, and `reason`, sends the latest 5 matching events to the configured AI Provider, and renders a transient Markdown diagnosis.",
-  "plan_signature": "c1ec9e5dd5a6c872a34bef00ab6873313a8518edd3fcc217d9f100d849c1a7db",
-  "plan_last_validated_at": "2026-07-02T07:00:23Z",
+  "plan_path": "docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md",
+  "plan_summary": "Add per-surface AI diagnostic prompt customization in `AI Assistant` Settings so users can edit Pod and Warning Event diagnosis instructions from built-in defaults, reset either surface to default, and keep immutable safety/data boundaries in code.",
+  "plan_signature": "197958c7f012186428e47125f495f783e7bb44ee5390c6251658a219762c3dd2",
+  "plan_last_validated_at": "2026-07-03T06:51:42Z",
   "completed_steps": [
     1
   ],
   "active_step": null,
   "next_action": null,
-  "reset_reason": "intentional_reset"
+  "reset_reason": "intentional_reset",
+  "review_state": {
+    "gates": {
+      "imm-code-review": {
+        "gate": "imm-code-review",
+        "decision": "pass",
+        "reviewed_changed_files": [
+          ".imm/specs/2026-07-03-ai-diagnostic-prompt-customization.md",
+          "CONTEXT.md",
+          "Kubebar/KubebarApp.swift",
+          "Kubebar/MenuBarViewModel.swift",
+          "Kubebar/Views/SettingsRootView.swift",
+          "Kubebar/Views/SetupView.swift",
+          "KubebarCore/Models/AIDiagnosticAssistantConfig.swift",
+          "KubebarCore/Models/AIDiagnosticAssistantState.swift",
+          "KubebarCore/Models/SetupFlowState.swift",
+          "KubebarCore/Services/AIEventDiagnosticRequester.swift",
+          "KubebarCore/Services/AIPodDiagnosticRequester.swift",
+          "KubebarTests/Models/AppConfigTests.swift",
+          "KubebarTests/Models/MenuRuntimeStateTests.swift",
+          "KubebarTests/Models/SetupFlowStateTests.swift",
+          "KubebarTests/Services/AIEventDiagnosticRequesterTests.swift",
+          "KubebarTests/Services/AIPodDiagnosticRequesterTests.swift",
+          "KubebarTests/Services/AIProviderConnectionTesterTests.swift",
+          "changelog.d/ai-diagnostic-prompt-customization.added.md",
+          "docs/architecture/runtime-invariants.md",
+          "docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md"
+        ],
+        "changed_files_signature": "562f3e73c65f8d84034d0d59398ccc15993beda90f66105536cdc78e9c059d61",
+        "evidence_ref": "Solo code review: fixed safety/system prompt remains code-owned; prompt overrides are non-secret AppConfig fields with nil/blank default fallback; reset clears overrides; Test Connection stays prompt-free and sends no Kubernetes data; requester request bodies still include bounded/redacted Pod logs (last 50) and latest-5 Warning Events; API keys remain Keychain-only. Existing configs decode without prompt fields. Focused tests + swift build + full quality gate + rtk git diff --check passed.",
+        "reviewer_skill": "imm-code-review",
+        "reviewed_at": "2026-07-03T07:43:09Z"
+      },
+      "imm-ui-review": {
+        "gate": "imm-ui-review",
+        "decision": "pass",
+        "reviewed_changed_files": [
+          ".imm/specs/2026-07-03-ai-diagnostic-prompt-customization.md",
+          "CONTEXT.md",
+          "Kubebar/KubebarApp.swift",
+          "Kubebar/MenuBarViewModel.swift",
+          "Kubebar/Views/SettingsRootView.swift",
+          "Kubebar/Views/SetupView.swift",
+          "KubebarCore/Models/AIDiagnosticAssistantConfig.swift",
+          "KubebarCore/Models/AIDiagnosticAssistantState.swift",
+          "KubebarCore/Models/SetupFlowState.swift",
+          "KubebarCore/Services/AIEventDiagnosticRequester.swift",
+          "KubebarCore/Services/AIPodDiagnosticRequester.swift",
+          "KubebarTests/Models/AppConfigTests.swift",
+          "KubebarTests/Models/MenuRuntimeStateTests.swift",
+          "KubebarTests/Models/SetupFlowStateTests.swift",
+          "KubebarTests/Services/AIEventDiagnosticRequesterTests.swift",
+          "KubebarTests/Services/AIPodDiagnosticRequesterTests.swift",
+          "KubebarTests/Services/AIProviderConnectionTesterTests.swift",
+          "changelog.d/ai-diagnostic-prompt-customization.added.md",
+          "docs/architecture/runtime-invariants.md",
+          "docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md"
+        ],
+        "changed_files_signature": "562f3e73c65f8d84034d0d59398ccc15993beda90f66105536cdc78e9c059d61",
+        "evidence_ref": "Solo UI review: AI Assistant Settings adds a Diagnostic prompts section with two TextEditors (Pod/Event) initialized from effective defaults and Reset to default buttons. TextEditor and reset buttons carry accessibilityLabel; Settings detail is scrollable so two editors fit within fixed 620px window; effective-default binding returns default text when no override is saved, so reset clears the override and the editor returns to default; monospaced caption font keeps prompts readable. No color-only state, no menu-bar icon change, no health impact. Quality gate build passed.",
+        "reviewer_skill": "imm-ui-review",
+        "reviewed_at": "2026-07-03T07:45:49Z"
+      }
+    }
+  }
 }

--- a/.imm/memory/current_iteration.json
+++ b/.imm/memory/current_iteration.json
@@ -4,52 +4,54 @@
     "1": {
       "number": 1,
       "step_id": "U1",
-      "result": "The Pod Micro-Logs Drawer manually renders a safe AI diagnosis for its selected Pod.",
-      "verification": "swift test --filter AIProviderConnectionTesterTests && swift test --filter PodLogStreamerTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
+      "result": "`Overview` `Recent Warnings` manually renders a safe AI diagnosis from the latest 5 fresh matching Warning Events.",
+      "verification": "swift test --filter AIProviderConnectionTesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter WarningEventDiagnosticReaderTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
       "test_scenarios": [
-        "Pod AI action is only in the Pod log drawer",
-        "finite log request uses `--context`, `logs`, `--tail=50`, namespace, and pod name without `-f`",
-        "explicit kubeconfig paths flow into the finite log environment",
+        "Overview Recent Warnings exposes the AI action while Events tab rows do not",
+        "the diagnostic reader builds a fresh `kubectl --context <context> get events --all-namespaces --field-selector type=Warning -o json` style read with effective kubeconfig overrides",
+        "exact matching uses `namespace`, `objectKind`, `objectName`, and `reason` without substring fallback",
+        "provider input is sorted newest first and capped at 5 matching Warning Events",
+        "no matching fresh events produces a safe retryable failure",
+        "event messages are redacted before provider submission",
         "missing provider model/key/base URL returns safe local failure",
-        "diagnostic request body includes Pod status, 3 warning summaries, redacted last 50 log lines, and required Markdown headings",
-        "obvious secrets in logs are redacted before submission",
-        "provider/network errors never expose API keys/Bearer tokens/raw response body",
-        "report state supports loading, success, retryable failure, unavailable logs, and empty logs",
+        "provider/network errors never expose API keys/Bearer tokens/raw response bodies",
+        "request body includes structured event context and required Markdown instructions but no Pod logs, kubeconfig content, raw cluster JSON, or raw kubectl transcript",
+        "diagnosis state supports loading, success, retryable failure, unavailable configuration, and stale-display disclosure",
         "AI suggested commands remain text only and no mutation command is executed by Kubebar",
         "docs preserve Health category independence"
       ],
       "discovery_cache": [
         {
-          "path": "KubebarCore/Services/AIProviderConnectionTester.swift",
-          "reason": "provider request/redaction pattern"
+          "path": "Kubebar/Views/OverviewTabView.swift",
+          "reason": "Overview Recent Warnings UI"
         },
         {
-          "path": "KubebarCore/Services/AIProviderCredentialStore.swift",
-          "reason": "Keychain protocol"
-        },
-        {
-          "path": "KubebarCore/Services/HTTPClient.swift",
-          "reason": "provider HTTP boundary"
-        },
-        {
-          "path": "KubebarCore/Services/PodLogStreamer.swift",
-          "reason": "kubectl logs context/kubeconfig pattern"
-        },
-        {
-          "path": "Kubebar/MenuBarViewModel.swift",
-          "reason": "Pod drawer lifecycle and AI settings callbacks"
-        },
-        {
-          "path": "Kubebar/Views/MenuBarRootView.swift",
-          "reason": "PodLogDrawerView"
-        },
-        {
-          "path": "Kubebar/Views/PodLogWindowPresenter.swift",
-          "reason": "log window host"
+          "path": "Kubebar/Views/WarningEventsView.swift",
+          "reason": "shared warning row view and Events-tab separation risk"
         },
         {
           "path": "KubebarCore/Models/MenuDisplayModel.swift",
-          "reason": "display-ready warnings and Pod rows"
+          "reason": "display-ready warnings and diagnostic target value"
+        },
+        {
+          "path": "KubebarCore/Services/HealthEvaluator.swift",
+          "reason": "warning grouping key"
+        },
+        {
+          "path": "KubebarCore/Services/KubectlClusterReader.swift",
+          "reason": "Warning Event kubectl decode/command pattern"
+        },
+        {
+          "path": "KubebarCore/Services/AIProviderConnectionTester.swift",
+          "reason": "provider validation pattern"
+        },
+        {
+          "path": "KubebarCore/Services/AIPodDiagnosticRequester.swift",
+          "reason": "diagnostic requester/redaction pattern"
+        },
+        {
+          "path": "Kubebar/MenuBarViewModel.swift",
+          "reason": "transient AI state and app-owned config"
         },
         {
           "path": "docs/architecture/runtime-invariants.md",
@@ -64,83 +66,86 @@
       "depends_on": [],
       "agent_hint": null,
       "state": "closed",
-      "activated_at": "2026-07-02T03:58:07Z",
+      "activated_at": "2026-07-02T07:07:13Z",
       "execution_evidence": {
         "changed_files": [
           "CONTEXT.md",
           "docs/architecture/runtime-invariants.md",
-          ".imm/specs/2026-07-02-ai-pod-diagnostics.md",
-          "docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md",
-          "changelog.d/ai-pod-diagnostics.added.md",
+          ".imm/specs/2026-07-02-ai-event-diagnostics.md",
+          "docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md",
+          "changelog.d/ai-event-diagnostics.added.md",
           "Kubebar.xcodeproj/project.pbxproj",
-          "KubebarCore/Models/AIPodDiagnosis.swift",
-          "KubebarCore/Services/AIPodDiagnosticRequester.swift",
-          "KubebarCore/Services/PodDiagnosticLogReader.swift",
-          "KubebarCore/Services/PodLogStreamer.swift",
+          "KubebarCore/Models/AIEventDiagnosis.swift",
+          "KubebarCore/Models/MenuDisplayModel.swift",
+          "KubebarCore/Services/HealthEvaluator.swift",
+          "KubebarCore/Services/WarningEventDiagnosticReader.swift",
+          "KubebarCore/Services/AIEventDiagnosticRequester.swift",
           "Kubebar/MenuBarViewModel.swift",
           "Kubebar/Views/MenuBarRootView.swift",
-          "Kubebar/Views/PodLogWindowPresenter.swift",
-          "KubebarTests/Services/AIPodDiagnosticRequesterTests.swift",
-          "KubebarTests/Services/PodLogStreamerTests.swift"
+          "Kubebar/Views/OverviewTabView.swift",
+          "Kubebar/KubebarApp.swift",
+          "KubebarTests/Services/WarningEventDiagnosticReaderTests.swift",
+          "KubebarTests/Services/AIEventDiagnosticRequesterTests.swift",
+          "KubebarTests/Models/MenuDisplayModelTests.swift"
         ],
-        "verification_result": "passed: focused Swift tests, swift build, full ./scripts/swift-quality-gate.sh local, and rtk git diff --check",
-        "verification_command": "swift test --filter AIProviderConnectionTesterTests && swift test --filter AIPodDiagnosticRequesterTests && swift test --filter PodLogStreamerTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
-        "notes": "TDD evidence: RED captured before implementation with missing AIPodDiagnosticContext/AIPodWarningContext/PodDiagnosticLogReadRequest types and inaccessible local TestError; GREEN implemented contextual Pod Micro-Logs Drawer AI diagnosis with finite --tail=50 log reread, redacted provider request, transient Markdown report UI, docs/spec/plan/changelog updates, and Xcode project source references. One quality-gate run exposed flaky stderr drain in ProcessPodLogStreamer; fixed by draining remaining pipes on termination and reran quality gate successfully.",
-        "recorded_at": "2026-07-02T04:05:05Z"
+        "verification_result": "passed: focused Swift tests, swift build, full ./scripts/swift-quality-gate.sh local, and rtk git diff --check after UI review follow-up",
+        "verification_command": "swift test --filter AIProviderConnectionTesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter WarningEventDiagnosticReaderTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
+        "notes": "Implemented Overview-only Recent Warnings AI event diagnosis. Addressed UI review follow-up by making each sparkles button accessible/help text include warning reason and location, and by adding a dismiss action to the transient diagnosis panel. Focused tests, swift build, quality gate, and diff check passed after follow-up.",
+        "recorded_at": "2026-07-02T07:44:12Z"
       },
-      "closed_at": "2026-07-02T04:05:31Z"
+      "closed_at": "2026-07-02T07:44:55Z"
     }
   },
   "pending_follow_up": null,
   "last_review": {
     "decision": "pass",
-    "evidence": "",
-    "artifacts": "",
-    "notes": "",
-    "recorded_at": "2026-07-02T04:05:31Z"
+    "evidence": "Focused tests, swift build, full ./scripts/swift-quality-gate.sh local, and rtk git diff --check passed after implementation and UI follow-up. UI review findings fixed: distinctive warning-specific accessibility labels/help and dismiss control for inline diagnosis panel. Code review child returned no findings/output; main-thread verification checked fresh event read, exact matching, latest-5 cap, redaction, no Pod logs, and Events tab remains action-free.",
+    "artifacts": "CONTEXT.md; docs/architecture/runtime-invariants.md; .imm/specs/2026-07-02-ai-event-diagnostics.md; docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md; changelog.d/ai-event-diagnostics.added.md; KubebarCore/Models/AIEventDiagnosis.swift; KubebarCore/Services/WarningEventDiagnosticReader.swift; KubebarCore/Services/AIEventDiagnosticRequester.swift; Kubebar/MenuBarViewModel.swift; Kubebar/Views/OverviewTabView.swift; tests",
+    "notes": "Review closure after bounded same-boundary UI follow-up.",
+    "recorded_at": "2026-07-02T07:44:55Z"
   },
   "validated_plan_snapshot": {
-    "plan_path": "docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md",
-    "plan_signature": "71517baf643953a27144615f2663ae37a67c7ec6671d959955966de9b1db2cf1",
+    "plan_path": "docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md",
+    "plan_signature": "c1ec9e5dd5a6c872a34bef00ab6873313a8518edd3fcc217d9f100d849c1a7db",
     "steps": [
       {
         "number": 1,
         "step_id": "U1",
-        "result": "The Pod Micro-Logs Drawer manually renders a safe AI diagnosis for its selected Pod.",
-        "verification": "swift test --filter AIProviderConnectionTesterTests && swift test --filter PodLogStreamerTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
+        "result": "`Overview` `Recent Warnings` manually renders a safe AI diagnosis from the latest 5 fresh matching Warning Events.",
+        "verification": "swift test --filter AIProviderConnectionTesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter WarningEventDiagnosticReaderTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
         "depends_on": [],
         "discovery_cache": [
           {
-            "path": "KubebarCore/Services/AIProviderConnectionTester.swift",
-            "reason": "provider request/redaction pattern"
+            "path": "Kubebar/Views/OverviewTabView.swift",
+            "reason": "Overview Recent Warnings UI"
           },
           {
-            "path": "KubebarCore/Services/AIProviderCredentialStore.swift",
-            "reason": "Keychain protocol"
-          },
-          {
-            "path": "KubebarCore/Services/HTTPClient.swift",
-            "reason": "provider HTTP boundary"
-          },
-          {
-            "path": "KubebarCore/Services/PodLogStreamer.swift",
-            "reason": "kubectl logs context/kubeconfig pattern"
-          },
-          {
-            "path": "Kubebar/MenuBarViewModel.swift",
-            "reason": "Pod drawer lifecycle and AI settings callbacks"
-          },
-          {
-            "path": "Kubebar/Views/MenuBarRootView.swift",
-            "reason": "PodLogDrawerView"
-          },
-          {
-            "path": "Kubebar/Views/PodLogWindowPresenter.swift",
-            "reason": "log window host"
+            "path": "Kubebar/Views/WarningEventsView.swift",
+            "reason": "shared warning row view and Events-tab separation risk"
           },
           {
             "path": "KubebarCore/Models/MenuDisplayModel.swift",
-            "reason": "display-ready warnings and Pod rows"
+            "reason": "display-ready warnings and diagnostic target value"
+          },
+          {
+            "path": "KubebarCore/Services/HealthEvaluator.swift",
+            "reason": "warning grouping key"
+          },
+          {
+            "path": "KubebarCore/Services/KubectlClusterReader.swift",
+            "reason": "Warning Event kubectl decode/command pattern"
+          },
+          {
+            "path": "KubebarCore/Services/AIProviderConnectionTester.swift",
+            "reason": "provider validation pattern"
+          },
+          {
+            "path": "KubebarCore/Services/AIPodDiagnosticRequester.swift",
+            "reason": "diagnostic requester/redaction pattern"
+          },
+          {
+            "path": "Kubebar/MenuBarViewModel.swift",
+            "reason": "transient AI state and app-owned config"
           },
           {
             "path": "docs/architecture/runtime-invariants.md",
@@ -154,14 +159,16 @@
         "parallel_probes": [],
         "agent_hint": null,
         "test_scenarios": [
-          "Pod AI action is only in the Pod log drawer",
-          "finite log request uses `--context`, `logs`, `--tail=50`, namespace, and pod name without `-f`",
-          "explicit kubeconfig paths flow into the finite log environment",
+          "Overview Recent Warnings exposes the AI action while Events tab rows do not",
+          "the diagnostic reader builds a fresh `kubectl --context <context> get events --all-namespaces --field-selector type=Warning -o json` style read with effective kubeconfig overrides",
+          "exact matching uses `namespace`, `objectKind`, `objectName`, and `reason` without substring fallback",
+          "provider input is sorted newest first and capped at 5 matching Warning Events",
+          "no matching fresh events produces a safe retryable failure",
+          "event messages are redacted before provider submission",
           "missing provider model/key/base URL returns safe local failure",
-          "diagnostic request body includes Pod status, 3 warning summaries, redacted last 50 log lines, and required Markdown headings",
-          "obvious secrets in logs are redacted before submission",
-          "provider/network errors never expose API keys/Bearer tokens/raw response body",
-          "report state supports loading, success, retryable failure, unavailable logs, and empty logs",
+          "provider/network errors never expose API keys/Bearer tokens/raw response bodies",
+          "request body includes structured event context and required Markdown instructions but no Pod logs, kubeconfig content, raw cluster JSON, or raw kubectl transcript",
+          "diagnosis state supports loading, success, retryable failure, unavailable configuration, and stale-display disclosure",
           "AI suggested commands remain text only and no mutation command is executed by Kubebar",
           "docs preserve Health category independence"
         ]
@@ -206,17 +213,51 @@
         "decision": "pass",
         "target_kind": "plan_step"
       }
+    },
+    {
+      "at": "2026-07-02T07:00:23Z",
+      "action": "sync_plan_from_imm_plan",
+      "details": {
+        "plan_path": "docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md",
+        "plan_signature": "c1ec9e5dd5a6c872a34bef00ab6873313a8518edd3fcc217d9f100d849c1a7db",
+        "same_plan": false
+      }
+    },
+    {
+      "at": "2026-07-02T07:44:55Z",
+      "action": "review_step",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "decision": "pass",
+        "target_kind": "plan_step"
+      }
+    },
+    {
+      "at": "2026-07-02T07:46:30Z",
+      "action": "finish_reset",
+      "details": {
+        "plan_path": "docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md"
+      }
+    },
+    {
+      "at": "2026-07-02T07:46:58Z",
+      "action": "finish_reset",
+      "details": {
+        "plan_path": "docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md"
+      }
     }
   ],
   "requires_replan": false,
   "runtime_status": "idle",
-  "plan_path": "docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md",
-  "plan_summary": "Add a contextual, manually triggered `AI Diagnose this Pod` action to the Pod Micro-Logs Drawer that rereads the last 50 Pod log lines, sends bounded redacted context to the configured AI Provider, and renders a transient Markdown diagnosis.",
-  "plan_signature": "71517baf643953a27144615f2663ae37a67c7ec6671d959955966de9b1db2cf1",
-  "plan_last_validated_at": "2026-07-02T03:58:07Z",
+  "plan_path": "docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md",
+  "plan_summary": "Add a manual AI diagnosis action only to `Overview` `Recent Warnings` rows that rereads fresh Warning Events through `kubectl`, filters by exact `namespace`, `objectKind`, `objectName`, and `reason`, sends the latest 5 matching events to the configured AI Provider, and renders a transient Markdown diagnosis.",
+  "plan_signature": "c1ec9e5dd5a6c872a34bef00ab6873313a8518edd3fcc217d9f100d849c1a7db",
+  "plan_last_validated_at": "2026-07-02T07:00:23Z",
   "completed_steps": [
     1
   ],
   "active_step": null,
-  "next_action": null
+  "next_action": null,
+  "reset_reason": "intentional_reset"
 }

--- a/.imm/memory/current_iteration.json
+++ b/.imm/memory/current_iteration.json
@@ -2,65 +2,168 @@
   "schema_version": 2,
   "steps": {
     "1": {
+      "number": 1,
       "step_id": "U1",
-      "state": "pending",
-      "result": "Publish dry-runs cannot be mistaken for public release success.",
-      "verification": "ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/release.yml\")' && ./scripts/test-changelog-tools.sh && ./scripts/test-release-build-version.sh",
+      "result": "The Pod Micro-Logs Drawer manually renders a safe AI diagnosis for its selected Pod.",
+      "verification": "swift test --filter AIProviderConnectionTesterTests && swift test --filter PodLogStreamerTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
       "test_scenarios": [
-        "default checklist no longer requires candidate generation or publish dry-run",
-        "publish dry-run logs an explicit no-tag/no-release summary",
-        "real publish path remains conditioned on dry_run != true"
+        "Pod AI action is only in the Pod log drawer",
+        "finite log request uses `--context`, `logs`, `--tail=50`, namespace, and pod name without `-f`",
+        "explicit kubeconfig paths flow into the finite log environment",
+        "missing provider model/key/base URL returns safe local failure",
+        "diagnostic request body includes Pod status, 3 warning summaries, redacted last 50 log lines, and required Markdown headings",
+        "obvious secrets in logs are redacted before submission",
+        "provider/network errors never expose API keys/Bearer tokens/raw response body",
+        "report state supports loading, success, retryable failure, unavailable logs, and empty logs",
+        "AI suggested commands remain text only and no mutation command is executed by Kubebar",
+        "docs preserve Health category independence"
       ],
       "discovery_cache": [
         {
-          "path": "docs/RELEASING.md",
-          "reason": "release-owner checklist"
+          "path": "KubebarCore/Services/AIProviderConnectionTester.swift",
+          "reason": "provider request/redaction pattern"
         },
         {
-          "path": ".github/workflows/release.yml",
-          "reason": "publish dry-run and real publish conditions"
+          "path": "KubebarCore/Services/AIProviderCredentialStore.swift",
+          "reason": "Keychain protocol"
         },
         {
-          "path": "scripts/test-changelog-tools.sh",
-          "reason": "release-note tooling regression check"
+          "path": "KubebarCore/Services/HTTPClient.swift",
+          "reason": "provider HTTP boundary"
         },
         {
-          "path": "scripts/test-release-build-version.sh",
-          "reason": "release packaging metadata check"
+          "path": "KubebarCore/Services/PodLogStreamer.swift",
+          "reason": "kubectl logs context/kubeconfig pattern"
+        },
+        {
+          "path": "Kubebar/MenuBarViewModel.swift",
+          "reason": "Pod drawer lifecycle and AI settings callbacks"
+        },
+        {
+          "path": "Kubebar/Views/MenuBarRootView.swift",
+          "reason": "PodLogDrawerView"
+        },
+        {
+          "path": "Kubebar/Views/PodLogWindowPresenter.swift",
+          "reason": "log window host"
+        },
+        {
+          "path": "KubebarCore/Models/MenuDisplayModel.swift",
+          "reason": "display-ready warnings and Pod rows"
+        },
+        {
+          "path": "docs/architecture/runtime-invariants.md",
+          "reason": "runtime safety contract"
+        },
+        {
+          "path": "CONTEXT.md",
+          "reason": "canonical AI diagnostic vocabulary"
         }
       ],
+      "parallel_probes": [],
       "depends_on": [],
-      "agent_hint": null
+      "agent_hint": null,
+      "state": "closed",
+      "activated_at": "2026-07-02T03:58:07Z",
+      "execution_evidence": {
+        "changed_files": [
+          "CONTEXT.md",
+          "docs/architecture/runtime-invariants.md",
+          ".imm/specs/2026-07-02-ai-pod-diagnostics.md",
+          "docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md",
+          "changelog.d/ai-pod-diagnostics.added.md",
+          "Kubebar.xcodeproj/project.pbxproj",
+          "KubebarCore/Models/AIPodDiagnosis.swift",
+          "KubebarCore/Services/AIPodDiagnosticRequester.swift",
+          "KubebarCore/Services/PodDiagnosticLogReader.swift",
+          "KubebarCore/Services/PodLogStreamer.swift",
+          "Kubebar/MenuBarViewModel.swift",
+          "Kubebar/Views/MenuBarRootView.swift",
+          "Kubebar/Views/PodLogWindowPresenter.swift",
+          "KubebarTests/Services/AIPodDiagnosticRequesterTests.swift",
+          "KubebarTests/Services/PodLogStreamerTests.swift"
+        ],
+        "verification_result": "passed: focused Swift tests, swift build, full ./scripts/swift-quality-gate.sh local, and rtk git diff --check",
+        "verification_command": "swift test --filter AIProviderConnectionTesterTests && swift test --filter AIPodDiagnosticRequesterTests && swift test --filter PodLogStreamerTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
+        "notes": "TDD evidence: RED captured before implementation with missing AIPodDiagnosticContext/AIPodWarningContext/PodDiagnosticLogReadRequest types and inaccessible local TestError; GREEN implemented contextual Pod Micro-Logs Drawer AI diagnosis with finite --tail=50 log reread, redacted provider request, transient Markdown report UI, docs/spec/plan/changelog updates, and Xcode project source references. One quality-gate run exposed flaky stderr drain in ProcessPodLogStreamer; fixed by draining remaining pipes on termination and reran quality gate successfully.",
+        "recorded_at": "2026-07-02T04:05:05Z"
+      },
+      "closed_at": "2026-07-02T04:05:31Z"
     }
   },
-  "last_review": null,
+  "pending_follow_up": null,
+  "last_review": {
+    "decision": "pass",
+    "evidence": "",
+    "artifacts": "",
+    "notes": "",
+    "recorded_at": "2026-07-02T04:05:31Z"
+  },
   "validated_plan_snapshot": {
-    "plan_path": "docs/plans/2026-06-22-002-ci-release-flow-simplification-plan.md",
-    "plan_signature": "fb1d0367839f1113eff25ccc1464545a231e3c6e9c03c1c9e21ac3d5d6071aa9",
+    "plan_path": "docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md",
+    "plan_signature": "71517baf643953a27144615f2663ae37a67c7ec6671d959955966de9b1db2cf1",
     "steps": [
       {
         "number": 1,
         "step_id": "U1",
-        "result": "Publish dry-runs cannot be mistaken for public release success.",
-        "verification": "ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/release.yml\")' && ./scripts/test-changelog-tools.sh && ./scripts/test-release-build-version.sh",
+        "result": "The Pod Micro-Logs Drawer manually renders a safe AI diagnosis for its selected Pod.",
+        "verification": "swift test --filter AIProviderConnectionTesterTests && swift test --filter PodLogStreamerTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check",
         "depends_on": [],
         "discovery_cache": [
           {
-            "path": "docs/RELEASING.md",
-            "reason": "release-owner checklist"
+            "path": "KubebarCore/Services/AIProviderConnectionTester.swift",
+            "reason": "provider request/redaction pattern"
           },
           {
-            "path": ".github/workflows/release.yml",
-            "reason": "publish dry-run and real publish conditions"
+            "path": "KubebarCore/Services/AIProviderCredentialStore.swift",
+            "reason": "Keychain protocol"
           },
           {
-            "path": "scripts/test-changelog-tools.sh",
-            "reason": "release-note tooling regression check"
+            "path": "KubebarCore/Services/HTTPClient.swift",
+            "reason": "provider HTTP boundary"
           },
           {
-            "path": "scripts/test-release-build-version.sh",
-            "reason": "release packaging metadata check"
+            "path": "KubebarCore/Services/PodLogStreamer.swift",
+            "reason": "kubectl logs context/kubeconfig pattern"
+          },
+          {
+            "path": "Kubebar/MenuBarViewModel.swift",
+            "reason": "Pod drawer lifecycle and AI settings callbacks"
+          },
+          {
+            "path": "Kubebar/Views/MenuBarRootView.swift",
+            "reason": "PodLogDrawerView"
+          },
+          {
+            "path": "Kubebar/Views/PodLogWindowPresenter.swift",
+            "reason": "log window host"
+          },
+          {
+            "path": "KubebarCore/Models/MenuDisplayModel.swift",
+            "reason": "display-ready warnings and Pod rows"
+          },
+          {
+            "path": "docs/architecture/runtime-invariants.md",
+            "reason": "runtime safety contract"
+          },
+          {
+            "path": "CONTEXT.md",
+            "reason": "canonical AI diagnostic vocabulary"
           }
+        ],
+        "parallel_probes": [],
+        "agent_hint": null,
+        "test_scenarios": [
+          "Pod AI action is only in the Pod log drawer",
+          "finite log request uses `--context`, `logs`, `--tail=50`, namespace, and pod name without `-f`",
+          "explicit kubeconfig paths flow into the finite log environment",
+          "missing provider model/key/base URL returns safe local failure",
+          "diagnostic request body includes Pod status, 3 warning summaries, redacted last 50 log lines, and required Markdown headings",
+          "obvious secrets in logs are redacted before submission",
+          "provider/network errors never expose API keys/Bearer tokens/raw response body",
+          "report state supports loading, success, retryable failure, unavailable logs, and empty logs",
+          "AI suggested commands remain text only and no mutation command is executed by Kubebar",
+          "docs preserve Health category independence"
         ]
       }
     ]
@@ -75,11 +178,45 @@
         "plan_summary": "Release owners can follow a clearer prepare-then-publish path.",
         "same_plan": false
       }
+    },
+    {
+      "at": "2026-07-02T03:30:16Z",
+      "action": "sync_plan_from_imm_plan",
+      "details": {
+        "plan_path": "docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md",
+        "plan_signature": "71517baf643953a27144615f2663ae37a67c7ec6671d959955966de9b1db2cf1",
+        "same_plan": false
+      }
+    },
+    {
+      "at": "2026-07-02T03:58:07Z",
+      "action": "sync_plan_from_imm_plan",
+      "details": {
+        "plan_path": "docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md",
+        "plan_signature": "71517baf643953a27144615f2663ae37a67c7ec6671d959955966de9b1db2cf1",
+        "same_plan": true
+      }
+    },
+    {
+      "at": "2026-07-02T04:05:31Z",
+      "action": "review_step",
+      "details": {
+        "step_number": 1,
+        "step_id": "U1",
+        "decision": "pass",
+        "target_kind": "plan_step"
+      }
     }
   ],
   "requires_replan": false,
-  "plan_path": "docs/plans/2026-06-22-002-ci-release-flow-simplification-plan.md",
-  "plan_summary": "Release owners can follow a clearer prepare-then-publish path.",
-  "plan_signature": "fb1d0367839f1113eff25ccc1464545a231e3c6e9c03c1c9e21ac3d5d6071aa9",
-  "plan_last_validated_at": "2026-06-22T08:39:02Z"
+  "runtime_status": "idle",
+  "plan_path": "docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md",
+  "plan_summary": "Add a contextual, manually triggered `AI Diagnose this Pod` action to the Pod Micro-Logs Drawer that rereads the last 50 Pod log lines, sends bounded redacted context to the configured AI Provider, and renders a transient Markdown diagnosis.",
+  "plan_signature": "71517baf643953a27144615f2663ae37a67c7ec6671d959955966de9b1db2cf1",
+  "plan_last_validated_at": "2026-07-02T03:58:07Z",
+  "completed_steps": [
+    1
+  ],
+  "active_step": null,
+  "next_action": null
 }

--- a/.imm/specs/2026-07-02-ai-event-diagnostics.md
+++ b/.imm/specs/2026-07-02-ai-event-diagnostics.md
@@ -1,0 +1,55 @@
+# AI Event Diagnostics
+
+## Summary
+
+Kubebar will add a manually triggered AI diagnosis action to `Overview` `Recent Warnings`. When the user clicks a warning row action, Kubebar rereads Warning Events through `kubectl`, filters the fresh result by the selected warning group's `namespace`, `objectKind`, `objectName`, and `reason`, sends the latest 5 matching Warning Events to the configured AI Provider, and renders a transient diagnosis.
+
+This is an event-only diagnostic path. It does not read Pod logs, does not diagnose from the Events tab, and does not execute any AI-suggested commands. AI output remains display/help behavior only and never affects `HealthEvaluator`, `MenuDisplayModel` health categorization, Health State Shift Alerts, watchlist ordering, or the menu bar icon category.
+
+## Output Language
+
+Spec and Plan prose are English. Code identifiers, schema fields, CLI commands, file paths, provider names, API names, enum cases, Markdown headings, and Immune-Brain fields remain literal.
+
+## Requirements
+
+- R1: Add a manual AI diagnosis entry only to `Overview` `Recent Warnings` rows.
+- R2: Do not add the diagnosis entry to the Events tab in this slice.
+- R3: Match the selected warning group by exact `namespace`, `objectKind`, `objectName`, and `reason`; do not use substring matching.
+- R4: Reread Warning Events with `kubectl` at diagnosis time instead of reusing the current snapshot rows.
+- R5: The fresh `kubectl` read must use Kubebar's app-owned selected context and effective kubeconfig rules.
+- R6: Send only the latest 5 matching Warning Events to the configured AI Provider.
+- R7: The event diagnostic payload may include structured event fields such as context, namespace, object kind, object name, reason, message/note, observed timestamp, and count. It must not include Pod logs, kubeconfig content, Secrets, full raw cluster JSON, or raw command transcripts.
+- R8: Event message text sent to the provider must pass through basic secret redaction for obvious tokens, authorization headers, passwords, and API-key-like fields.
+- R9: AI Provider API keys remain Keychain-only and must never appear in AppConfig, command output, visible errors, or diagnostic reports.
+- R10: AI calls and `kubectl` reads go through injectable service boundaries; SwiftUI views do not construct provider requests, read credentials, or invoke `kubectl` directly.
+- R11: AI results render as human-readable Markdown with concise possible causes and actionable fixes.
+- R12: Suggested `kubectl` commands are copyable text only; Kubebar must not automatically execute AI-suggested commands or mutate Kubernetes resources.
+- R13: Failure states are safe and actionable for unconfigured provider, missing API key/model/base URL, event read failure, no matching fresh events, provider timeout/network failure, provider HTTP failure, and stale display data.
+- R14: AI event diagnosis must not affect `HealthEvaluator`, `MenuDisplayModel` health categorization, watchlist ordering, alerts, or menu bar icon state.
+
+## Non-goals
+
+- No Events tab diagnosis entry in this slice.
+- No Pod log reads for event diagnosis.
+- No global cluster AI diagnosis from the footer.
+- No automatic/background AI diagnosis on refresh or alert creation.
+- No auto-executed remediation commands.
+- No Secret reads, kubeconfig transmission, raw cluster JSON, full kubectl transcript submission, or provider response raw-body display.
+- No persisted diagnosis history, chat UX, report archive, cloud sync, prompt template editor, provider advanced tuning, or custom headers.
+
+## Data and Security Boundaries
+
+The AI event diagnostic payload is manually triggered and warning-group-scoped. It is limited to the latest 5 fresh Warning Events matching the selected `Overview` `Recent Warnings` row's exact target key. The request uses the app-owned context and effective kubeconfig rules used by other `kubectl` reads.
+
+Visible failures must be sanitized: no API key, Bearer token, Authorization header, raw HTTP body, raw request, raw stderr transcript, kubeconfig content, or token-like values. The report is transient UI state; it is not persisted and is not an input to health evaluation.
+
+## Success Criteria
+
+- `Overview` `Recent Warnings` rows expose a manual AI diagnosis entry, while Events tab rows do not.
+- Clicking the action performs a fresh `kubectl --context <context> get events ... -o json` style read through an injectable boundary with the configured kubeconfig environment.
+- Matching uses exact `namespace`, `objectKind`, `objectName`, and `reason`, sorts by observed timestamp, and caps provider input at the latest 5 matching Warning Events.
+- Provider request tests prove the body contains structured event context and does not contain Pod logs, kubeconfig content, raw cluster JSON, or raw command transcripts.
+- Redaction tests prove obvious secrets in event messages and visible provider/transport errors are not surfaced or sent unredacted.
+- UI/model behavior supports loading, success, retryable failure, no-match, and unavailable-configuration states without expanding the Events tab scope.
+- Documentation updates preserve display-only health behavior.
+- The Swift quality gate passes.

--- a/.imm/specs/2026-07-02-ai-pod-diagnostics.md
+++ b/.imm/specs/2026-07-02-ai-pod-diagnostics.md
@@ -1,0 +1,53 @@
+# AI Pod Diagnostics
+
+## Summary
+
+Kubebar will add a manually triggered `AI Diagnose this Pod` action to the Pod Micro-Logs Drawer. When the user clicks the action, Kubebar rereads the selected Pod's last 50 log lines, combines them with the current display-model Pod status and the latest 3 related warning summaries, sends that minimal troubleshooting context to the configured AI Provider, and renders a structured Markdown report below the logs.
+
+This changes the earlier diagnostic input boundary from warning-summary-only to user-approved Pod diagnostic context that may include redacted log text. It remains display/help behavior only and never affects `HealthEvaluator`, `MenuDisplayModel` health categorization, or the menu bar icon category.
+
+## Output Language
+
+Spec and Plan prose are English. Code identifiers, schema fields, CLI commands, file paths, provider names, API names, enum cases, Markdown headings, and Immune-Brain fields remain literal.
+
+## Requirements
+
+- R1: Add a contextual `sparkles` / `AI Diagnose this Pod` action to the Pod Micro-Logs Drawer toolbar, near search/copy controls.
+- R2: Do not add the primary AI diagnosis action to the menu footer because footer actions are app-level utilities and the diagnosis target must be explicit.
+- R3: Diagnosis is always manually triggered by the user; no automatic, scheduled, background, or refresh-triggered AI diagnosis.
+- R4: The diagnostic request rereads Pod logs with `kubectl logs --tail=50` for the selected Pod, instead of reusing the live drawer buffer.
+- R5: The diagnostic context includes the selected Pod's current display-ready status/reason, the latest 3 related warning summaries when available, and the last 50 log lines.
+- R6: Before or while triggering diagnosis, the UI clearly communicates that Pod status, warning summaries, and last 50 log lines will be sent to the configured AI Provider.
+- R7: Log text sent to the provider must be bounded and pass through basic secret redaction for obvious tokens, authorization headers, passwords, and API-key-like fields.
+- R8: AI Provider API keys remain Keychain-only and must never appear in AppConfig, command output, visible errors, or diagnostic reports.
+- R9: AI calls go through injectable service boundaries; SwiftUI views do not construct provider requests, read credentials, or invoke `kubectl` directly.
+- R10: AI results render as human-readable Markdown with `🔍 Possible causes` and `🛠️ Actionable fixes` sections.
+- R11: Suggested `kubectl` commands are copyable text only; Kubebar must not automatically execute AI-suggested commands or mutate Kubernetes resources.
+- R12: Failure states are safe and actionable for unconfigured provider, missing API key/model/base URL, log read failure, event unavailability, provider timeout/network failure, provider HTTP failure, empty logs, and stale data.
+- R13: AI diagnosis must not query Kubernetes Secrets, send kubeconfig content, send full raw `kubectl` transcripts, send raw cluster JSON, persist history, or cloud-sync reports.
+- R14: AI diagnosis must not affect `HealthEvaluator`, `MenuDisplayModel` health categorization, watchlist ordering, alerts, or menu bar icon state.
+
+## Non-goals
+
+- No global cluster AI diagnosis from the footer.
+- No primary Warning Events AI diagnosis in the MVP.
+- No auto-executed remediation commands.
+- No Secret reads, kubeconfig transmission, raw cluster JSON, full kubectl transcript submission, or provider response raw-body display.
+- No chat history, conversation memory, cloud sync, prompt template editor, provider advanced tuning, or custom headers.
+- No previous-container logs or multi-container selection in this slice.
+
+## Data and Security Boundaries
+
+The Pod AI diagnostic payload is manually triggered and target-scoped. It may include redacted last-50-line Pod logs only after the user acts from the Pod Micro-Logs Drawer, where the exact Pod target is visible. The request uses the app-owned context and effective kubeconfig rules used by other `kubectl` reads. The app reads logs through an injectable command boundary and sends provider requests through the existing AI credential/HTTP boundary pattern.
+
+Visible failures must be sanitized: no API key, Bearer token, Authorization header, raw HTTP body, raw request, raw stderr transcript, kubeconfig path content beyond existing safe display strings, or token-like values. The report is transient UI state; it is not persisted and is not an input to health evaluation.
+
+## Success Criteria
+
+- A Bad Pod row can open the existing Pod Micro-Logs Drawer and run `AI Diagnose this Pod` from the drawer toolbar.
+- The finite diagnostic log read uses `kubectl --context <context> logs --tail=50 -n <namespace> <pod>` with the app-owned context and configured kubeconfig environment.
+- Provider request tests prove the body contains the structured diagnostic context, asks for `🔍 Possible causes` and `🛠️ Actionable fixes`, and avoids raw kubeconfig, Secrets, raw cluster JSON, and full command transcripts.
+- Redaction tests prove obvious secrets in log text and provider/transport errors are not surfaced or sent unredacted.
+- UI state tests or focused model tests prove diagnosis has loading, success, retryable failure, and unavailable-configuration states.
+- Documentation updates reflect the new user-approved Pod log submission boundary while preserving display-only health behavior.
+- The Swift quality gate passes.

--- a/.imm/specs/2026-07-03-ai-diagnostic-prompt-customization.md
+++ b/.imm/specs/2026-07-03-ai-diagnostic-prompt-customization.md
@@ -1,0 +1,52 @@
+# AI Diagnostic Prompt Customization
+
+## Summary
+
+Kubebar will let users customize the prompt instructions used by manual AI Pod diagnosis and manual AI Warning Event diagnosis. Users can start from Kubebar's default prompt text, edit per diagnostic surface, save the custom instructions in local non-secret app config, and reset either surface back to the built-in default. Kubebar keeps immutable safety instructions and structured diagnostic context generation in code so prompt customization cannot expand the submitted Kubernetes data boundary or enable automatic remediation.
+
+## Output Language
+
+Spec and Plan prose are written in English. Code identifiers, schema fields, CLI commands, file paths, provider names, API names, enum cases, Markdown headings, and Immune-Brain fields remain literal.
+
+## Requirements
+
+- R1: Add per-surface prompt customization for manual `AI Pod diagnosis` and manual `AI Event diagnosis`.
+- R2: The `AI Assistant` Settings page must show editable text initialized from the effective default prompt instructions so users can modify the default rather than starting from a blank field.
+- R3: The Settings page must provide `Reset to default` behavior for each prompt surface.
+- R4: Reset must remove the custom override and return to the built-in default rather than persisting a copied default string.
+- R5: Existing `AppConfig` files without prompt fields must decode successfully and use the built-in default prompts.
+- R6: Prompt overrides are non-secret local settings and may be persisted in `AppConfig`; API keys remain Keychain-only.
+- R7: Manual Pod diagnosis must use the configured Pod prompt instructions while preserving fixed safety instructions, bounded/redacted last-50 log context, warning cap, app-owned context, and no automatic command execution.
+- R8: Manual Event diagnosis must use the configured Event prompt instructions while preserving fixed safety instructions, latest-5 matching Warning Event context, event-only payload, app-owned context, and no automatic command execution.
+- R9: Users must not be able to override the immutable safety/system prompt that tells the provider to use only supplied context and not claim command execution.
+- R10: Blank or whitespace-only custom prompt text must fall back safely to the built-in default.
+- R11: Test Connection remains a provider ping only and must not send custom prompts or Kubernetes data.
+- R12: AI prompt customization and AI results must not affect `HealthEvaluator`, `MenuDisplayModel` health categorization, Health State Shift Alerts, watchlist ordering, or the menu bar icon category.
+
+## Non-goals
+
+- No global cluster diagnosis prompt.
+- No Events tab diagnosis entry.
+- No chat history, diagnosis history, cloud sync, or remote prompt sharing.
+- No custom provider headers, model parameter tuning, prompt variables UI, or full template language.
+- No user-editable safety/system prompt.
+- No automatic/background diagnosis and no automatic execution of suggested `kubectl` commands.
+- No expansion of submitted diagnostic data beyond the existing Pod and Event diagnosis boundaries.
+
+## Data and Security Boundaries
+
+Prompt customization changes only the natural-language instructions used in manual AI diagnosis requests. The diagnostic data included in requests remains code-owned and bounded by existing runtime invariants: Pod diagnosis may include the selected Pod's display-ready status, up to 3 warning summaries, and freshly read/redacted `kubectl logs --tail=50`; Event diagnosis may include only the latest 5 fresh exact-key matching Warning Events. Secrets, kubeconfig content, raw command transcripts, raw cluster JSON, and provider raw response bodies remain excluded.
+
+Prompt overrides are not credentials. They may be serialized inside `AppConfig` with other non-secret AI Provider configuration. API keys remain in macOS Keychain only.
+
+## Success Criteria
+
+- Existing configs decode with no prompt customization and produce the same effective default prompt behavior.
+- Saving Settings round-trips prompt overrides without writing API keys to `AppConfig`.
+- Each prompt surface has a visible editor and a `Reset to default` action in `AI Assistant` Settings.
+- Reset produces default effective prompt text and removes the custom override from persisted config.
+- Pod requester tests prove custom Pod prompt instructions appear in the provider request while the fixed safety prompt and bounded/redacted context remain present.
+- Event requester tests prove custom Event prompt instructions appear in the provider request while the fixed safety prompt and latest-5 event context remain present.
+- Blank custom prompt text falls back to built-in defaults.
+- Test Connection request behavior remains unchanged and sends no custom prompts or Kubernetes data.
+- Full Swift quality gate passes.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,9 +20,9 @@
   local app behavior, consume `MenuDisplayModel`, and must not add new health
   rules.
 - **AI Diagnostic Assistant**: an optional app-wide feature for manually testing
-  a configured AI provider and, from a Pod troubleshooting surface, explaining
-  user-approved Pod diagnostic context. It is display/help behavior only and
-  must not change `Health category`.
+  a configured AI provider and, from explicit troubleshooting surfaces,
+  explaining user-approved Kubernetes diagnostic context. It is display/help
+  behavior only and must not change `Health category`.
 - **AI Provider configuration**: non-secret app-wide provider metadata such as
   provider kind, `Model ID`, and an `OpenAI-compatible` `Base URL`. It belongs
   in App Settings and may be persisted in local app config.
@@ -38,6 +38,13 @@
   redacted `kubectl logs --tail=50` sample. It does not include Kubernetes
   Secrets, kubeconfig content, raw cluster JSON, full command transcripts, or
   automatically executed remediation.
+- **AI Event diagnostic input**: a manually submitted AI diagnostic payload from
+  `Overview` `Recent Warnings`. It is limited to a fresh `kubectl get events`
+  read through Kubebar's app-owned context, exact matching by `namespace`,
+  `objectKind`, `objectName`, and `reason`, and the latest 5 matching redacted
+  Warning Events. It does not include Pod logs, Kubernetes Secrets, kubeconfig
+  content, raw cluster JSON, full command transcripts, or automatically
+  executed remediation.
 - **Pod Micro-Logs Drawer**: a user-opened focusable log window for a single
   `Bad` Pod row that streams a bounded `kubectl logs --tail=100 -f` view
   through Kubebar's app-owned context and kubeconfig. It is temporary
@@ -116,3 +123,13 @@ explicitly changes that scope.
   plus `Kubebar/Views/MenuBarRootView.swift` own the row entry point and
   focusable log window UI. The log body should be hosted by a Read-only log
   text view rather than a hand-built text scroller.
+- AI Event diagnostics: `KubebarCore/Models/MenuDisplayModel.swift` carries an
+  explicit `WarningEventDiagnosticTarget` for structured warning groups,
+  `KubebarCore/Services/HealthEvaluator.swift` derives that target from Warning
+  Event records, `KubebarCore/Services/WarningEventDiagnosticReader.swift` owns
+  fresh latest-5 event reads, `KubebarCore/Services/AIEventDiagnosticRequester.swift`
+  owns provider diagnostic requests, `Kubebar/MenuBarViewModel.swift` owns
+  transient diagnosis lifecycle, and `Kubebar/Views/OverviewTabView.swift` owns
+  the `Overview` `Recent Warnings` entry point. `Kubebar/Views/WarningEventsView.swift`
+  remains a shared row renderer and must not infer diagnostic targets in the
+  Events tab.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,8 +24,13 @@
   explaining user-approved Kubernetes diagnostic context. It is display/help
   behavior only and must not change `Health category`.
 - **AI Provider configuration**: non-secret app-wide provider metadata such as
-  provider kind, `Model ID`, and an `OpenAI-compatible` `Base URL`. It belongs
-  in App Settings and may be persisted in local app config.
+  provider kind, `Model ID`, an `OpenAI-compatible` `Base URL`, and custom AI
+  diagnostic prompt instructions. It belongs in App Settings and may be
+  persisted in local app config.
+- **AI diagnostic prompt instructions**: optional user-authored Pod/Event
+  diagnosis instructions edited in `AI Assistant` Settings. They start from
+  built-in defaults, reset by clearing the custom override, and cannot replace
+  Kubebar's fixed safety prompt or code-owned diagnostic context payload.
 - **AI Provider API key**: the secret credential for an AI provider. It must be
   stored in macOS Keychain, never in `AppConfig`, command output, diagnostics,
   or visible raw error text.
@@ -133,3 +138,9 @@ explicitly changes that scope.
   the `Overview` `Recent Warnings` entry point. `Kubebar/Views/WarningEventsView.swift`
   remains a shared row renderer and must not infer diagnostic targets in the
   Events tab.
+- AI diagnostic prompt customization: `KubebarCore/Models/AIDiagnosticAssistantConfig.swift`
+  owns non-secret Pod/Event prompt overrides plus built-in defaults,
+  `KubebarCore/Models/SetupFlowState.swift` owns Settings mutations/reset,
+  `Kubebar/Views/SetupView.swift` owns the editors, and the Pod/Event
+  diagnostic requesters combine effective prompt instructions with code-owned
+  safety prompts and bounded diagnostic context.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,9 +19,9 @@
   directionally worse Health category or watchlist attention changes. They are
   local app behavior, consume `MenuDisplayModel`, and must not add new health
   rules.
-- **AI Diagnostic Assistant**: an optional app-wide Settings feature for
-  manually testing a configured AI provider and, in a later diagnostic slice,
-  explaining user-approved warning text. It is display/help behavior only and
+- **AI Diagnostic Assistant**: an optional app-wide feature for manually testing
+  a configured AI provider and, from a Pod troubleshooting surface, explaining
+  user-approved Pod diagnostic context. It is display/help behavior only and
   must not change `Health category`.
 - **AI Provider configuration**: non-secret app-wide provider metadata such as
   provider kind, `Model ID`, and an `OpenAI-compatible` `Base URL`. It belongs
@@ -32,9 +32,12 @@
 - **OpenAI-compatible provider**: a custom endpoint that uses only `Bearer` API
   key authentication, `Base URL`, and `Model ID` in the first version. Custom
   headers are out of scope.
-- **Warning text diagnostic input**: a future manually submitted AI diagnostic
-  payload limited to warning summary text. It does not include Pod logs,
-  Kubernetes Secrets, raw `kubectl` output, kubeconfig content, or cluster JSON.
+- **AI Pod diagnostic input**: a manually submitted AI diagnostic payload from
+  the Pod Micro-Logs Drawer. It is limited to the selected Pod's display-ready
+  status, up to 3 related warning summaries, and a freshly read, bounded,
+  redacted `kubectl logs --tail=50` sample. It does not include Kubernetes
+  Secrets, kubeconfig content, raw cluster JSON, full command transcripts, or
+  automatically executed remediation.
 - **Pod Micro-Logs Drawer**: a user-opened focusable log window for a single
   `Bad` Pod row that streams a bounded `kubectl logs --tail=100 -f` view
   through Kubebar's app-owned context and kubeconfig. It is temporary
@@ -106,8 +109,10 @@ explicitly changes that scope.
 - Pod Micro-Logs Drawer: `KubebarCore/Models/MenuDisplayModel.swift` carries
   display-ready Pod row identity, `KubebarCore/Services/HealthEvaluator.swift`
   maps `PodDetail` into `PodItemDisplay`, `KubebarCore/Services/CommandRunner.swift`
-  owns process-launch environment behavior, `Kubebar/MenuBarViewModel.swift`
-  owns app-owned context and lifecycle cancellation, and
-  `Kubebar/Views/PodsTabView.swift` plus `Kubebar/Views/MenuBarRootView.swift`
-  own the row entry point and focusable log window UI. The log body should be
-  hosted by a Read-only log text view rather than a hand-built text scroller.
+  owns process-launch environment behavior, `KubebarCore/Services/PodDiagnosticLogReader.swift`
+  owns finite AI diagnostic log reads, `KubebarCore/Services/AIPodDiagnosticRequester.swift`
+  owns provider diagnostic requests, `Kubebar/MenuBarViewModel.swift` owns
+  app-owned context and lifecycle cancellation, and `Kubebar/Views/PodsTabView.swift`
+  plus `Kubebar/Views/MenuBarRootView.swift` own the row entry point and
+  focusable log window UI. The log body should be hosted by a Read-only log
+  text view rather than a hand-built text scroller.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,44 +1,41 @@
 # Kubebar Handoff
 
-**Last updated**: 2026-07-02T04:05:00Z
+**Last updated**: 2026-07-03T15:15:00Z
 
 ## Current State
 
-- Plan: `docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md`
-- Summary: Pod Micro-Logs Drawer now has a manual `AI Diagnose this Pod` action that rereads `kubectl logs --tail=50`, sends bounded/redacted Pod context to the configured AI Provider, and renders a transient Markdown diagnosis.
+- Plan: `docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md`
+- Summary: `AI Assistant` Settings now supports separate custom prompt instructions for Pod diagnosis and Warning Event diagnosis. Each editor starts from the built-in default and can reset by clearing the custom override. Requesters keep fixed safety/system prompts and code-owned bounded diagnostic context.
 - Status: complete; Step U1 passed QA.
 - Completed steps:
-  - U1 (closed): The Pod Micro-Logs Drawer manually renders a safe AI diagnosis for its selected Pod.
+  - U1 (closed): `AI Assistant` Settings supports safe prompt customization/reset for Pod/Event diagnosis.
 - Active step: none.
 - Known blockers: none.
 
 ## Verification
 
-- `swift test --filter AIProviderConnectionTesterTests` passed.
-- `swift test --filter AIPodDiagnosticRequesterTests` passed.
-- `swift test --filter PodLogStreamerTests` passed.
-- `swift test --filter MenuDisplayModelTests` passed.
+- `swift test --filter AIPodDiagnosticRequesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter AppConfigTests && swift test --filter SetupFlowStateTests && swift test --filter MenuRuntimeStateTests && swift test --filter AIProviderConnectionTesterTests` passed.
 - `swift build` passed.
 - `./scripts/swift-quality-gate.sh local` passed.
 - `rtk git diff --check` clean.
 
 ## Notes
 
-- AI Provider API keys remain Keychain-only.
-- AI Pod diagnosis is manual, target-scoped, transient, and does not affect Health category, alerts, watchlist ordering, or menu bar icon state.
-- Suggested `kubectl` commands in the AI report are text only; Kubebar does not execute them.
-- The first quality-gate run exposed a `ProcessPodLogStreamer` stderr drain race; fixed by draining remaining pipe data on termination.
+- Prompt overrides are non-secret local `AppConfig` fields; API keys remain Keychain-only.
+- Reset to default clears the override instead of persisting a copied default prompt.
+- Custom instructions do not replace the fixed safety prompt and do not expand submitted Pod/Event diagnostic data.
+- Test Connection remains a provider ping and sends no custom prompts or Kubernetes data.
 
 ## Compaction Handoff
 
-- Active plan: `docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md`
-- Active Step ID plus Result: none active; U1 passed — The Pod Micro-Logs Drawer manually renders a safe AI diagnosis for its selected Pod.
+- Active plan: `docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md`
+- Active Step ID plus Result: none active; U1 passed — `AI Assistant` Settings supports safe prompt customization/reset for Pod/Event diagnosis.
 - Priority files for reload:
-  - `Kubebar/MenuBarViewModel.swift`
-  - `Kubebar/Views/MenuBarRootView.swift`
+  - `KubebarCore/Models/AIDiagnosticAssistantConfig.swift`
+  - `Kubebar/Views/SetupView.swift`
   - `KubebarCore/Services/AIPodDiagnosticRequester.swift`
-  - `KubebarCore/Services/PodDiagnosticLogReader.swift`
+  - `KubebarCore/Services/AIEventDiagnosticRequester.swift`
   - `docs/architecture/runtime-invariants.md`
-- Uncommitted work summary: AI Pod diagnosis implementation, docs/spec/plan/changelog, Xcode project references, and focused tests are uncommitted.
-- Session decisions: primary entry lives in Pod Micro-Logs Drawer, not footer; diagnosis sends display-ready Pod status, up to 3 related warning summaries, and freshly read redacted last 50 log lines; reports are transient and no command is auto-executed.
+- Uncommitted work summary: AI diagnostic prompt customization implementation, docs/spec/plan/changelog, runtime state, handoff update, and focused tests are uncommitted.
+- Session decisions: Pod and Warning Event prompts are separate; reset clears overrides; fixed safety/system prompt and bounded diagnostic context remain code-owned.
 - Next boundary skill: none required unless user asks for follow-up; otherwise ready for review/commit.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,39 +1,44 @@
 # Kubebar Handoff
 
-**Last updated**: 2026-07-01T11:00:00Z
+**Last updated**: 2026-07-02T04:05:00Z
 
 ## Current State
 
-- Plan: `docs/plans/2026-07-01-002-refactor-settings-sidebar-layout-plan.md`
-- Summary: Settings redesigned from a stacked TabView into a sidebar/detail layout with a dedicated AI Assistant page; UI polish applied.
-- Status: complete with post-review polish.
+- Plan: `docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md`
+- Summary: Pod Micro-Logs Drawer now has a manual `AI Diagnose this Pod` action that rereads `kubectl logs --tail=50`, sends bounded/redacted Pod context to the configured AI Provider, and renders a transient Markdown diagnosis.
+- Status: complete; Step U1 passed QA.
 - Completed steps:
-  - U1 (closed): Settings state exposes page-oriented navigation while preserving completed configuration behavior.
-  - U2 (closed): Settings renders a sidebar/detail layout with AI Assistant as a focused App page.
+  - U1 (closed): The Pod Micro-Logs Drawer manually renders a safe AI diagnosis for its selected Pod.
 - Active step: none.
+- Known blockers: none.
 
 ## Verification
 
-- `swift test --filter SetupFlowStateTests && swift test --filter MenuRuntimeStateTests` passed.
+- `swift test --filter AIProviderConnectionTesterTests` passed.
+- `swift test --filter AIPodDiagnosticRequesterTests` passed.
+- `swift test --filter PodLogStreamerTests` passed.
+- `swift test --filter MenuDisplayModelTests` passed.
 - `swift build` passed.
-- `./scripts/swift-quality-gate.sh local` passed (318 tests, 31 suites, BUILD SUCCEEDED, TEST SUCCEEDED).
+- `./scripts/swift-quality-gate.sh local` passed.
 - `rtk git diff --check` clean.
-- App launches cleanly via `./scripts/compile-and-run.sh`.
-
-## UI Polish Applied
-
-- Replaced invalid `k.stack` SF Symbol with `square.3.layers.3d`.
-- Added keyboard shortcuts `Cmd+1`..`Cmd+4` for App pages.
-- Merged AI Assistant sections into "Provider configuration" and "Connection".
-- Base URL hidden unless provider is `OpenAI-compatible`.
-- App pages show descriptive subtitles instead of active context.
-- Removed unnecessary `maxHeight: .infinity` from detail pane.
-- Widened `SettingsRow` content area to 360pt.
-- Raised window height to 620pt.
-- Added warning icon for contexts with no watchlist selected.
-- Unified sidebar row style: both App pages and Contexts use the same `HStack` helper with a fixed 20pt icon width, identical spacing, and optional trailing warning icon, so icons and text align consistently across the App and Contexts sections.
 
 ## Notes
 
-- No automated SwiftUI snapshot tests exist; layout quality is HITL.
-- Native macOS app screenshots require Accessibility consent (not available in this environment).
+- AI Provider API keys remain Keychain-only.
+- AI Pod diagnosis is manual, target-scoped, transient, and does not affect Health category, alerts, watchlist ordering, or menu bar icon state.
+- Suggested `kubectl` commands in the AI report are text only; Kubebar does not execute them.
+- The first quality-gate run exposed a `ProcessPodLogStreamer` stderr drain race; fixed by draining remaining pipe data on termination.
+
+## Compaction Handoff
+
+- Active plan: `docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md`
+- Active Step ID plus Result: none active; U1 passed — The Pod Micro-Logs Drawer manually renders a safe AI diagnosis for its selected Pod.
+- Priority files for reload:
+  - `Kubebar/MenuBarViewModel.swift`
+  - `Kubebar/Views/MenuBarRootView.swift`
+  - `KubebarCore/Services/AIPodDiagnosticRequester.swift`
+  - `KubebarCore/Services/PodDiagnosticLogReader.swift`
+  - `docs/architecture/runtime-invariants.md`
+- Uncommitted work summary: AI Pod diagnosis implementation, docs/spec/plan/changelog, Xcode project references, and focused tests are uncommitted.
+- Session decisions: primary entry lives in Pod Micro-Logs Drawer, not footer; diagnosis sends display-ready Pod status, up to 3 related warning summaries, and freshly read redacted last 50 log lines; reports are transient and no command is auto-executed.
+- Next boundary skill: none required unless user asks for follow-up; otherwise ready for review/commit.

--- a/Kubebar.xcodeproj/project.pbxproj
+++ b/Kubebar.xcodeproj/project.pbxproj
@@ -20,6 +20,14 @@
 		A30000000000000000000003 /* AIPodDiagnosticRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000004 /* AIPodDiagnosticRequester.swift */; };
 		A30000000000000000000005 /* PodDiagnosticLogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000006 /* PodDiagnosticLogReader.swift */; };
 		A30000000000000000000007 /* AIPodDiagnosticRequesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000008 /* AIPodDiagnosticRequesterTests.swift */; };
+		A40000000000000000000001 /* AIEventDiagnosis.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000002 /* AIEventDiagnosis.swift */; };
+		A40000000000000000000003 /* AIEventDiagnosticRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000004 /* AIEventDiagnosticRequester.swift */; };
+		A5FF000000000000000B0001 /* AIDiagnosticResponseFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FF000000000000000B0002 /* AIDiagnosticResponseFormatter.swift */; };
+		A5FF000000000000000B0003 /* AIDiagnosisContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FF000000000000000B0004 /* AIDiagnosisContentView.swift */; };
+		A5FF000000000000000B0005 /* AIDiagnosticResponseFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FF000000000000000B0006 /* AIDiagnosticResponseFormatterTests.swift */; };
+		A40000000000000000000005 /* WarningEventDiagnosticReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000006 /* WarningEventDiagnosticReader.swift */; };
+		A40000000000000000000007 /* AIEventDiagnosticRequesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40000000000000000000008 /* AIEventDiagnosticRequesterTests.swift */; };
+		A40000000000000000000009 /* WarningEventDiagnosticReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4000000000000000000000A /* WarningEventDiagnosticReaderTests.swift */; };
 		0ABC7D9044D83EA481BBB112 /* WatchTargetCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD651CCDAAD62B4E7C090D6F /* WatchTargetCatalog.swift */; };
 		0C5D3D56CEDAB47E9528A4F6 /* WatchlistCandidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CF64AA3581163BEA218DFB /* WatchlistCandidate.swift */; };
 		0D127D20E9DEDC847D33AE77 /* MenuDisplayModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27036F7AEDEFA527AF44A619 /* MenuDisplayModelTests.swift */; };
@@ -160,6 +168,14 @@
 		A30000000000000000000004 /* AIPodDiagnosticRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIPodDiagnosticRequester.swift; sourceTree = "<group>"; };
 		A30000000000000000000006 /* PodDiagnosticLogReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodDiagnosticLogReader.swift; sourceTree = "<group>"; };
 		A30000000000000000000008 /* AIPodDiagnosticRequesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIPodDiagnosticRequesterTests.swift; sourceTree = "<group>"; };
+		A40000000000000000000002 /* AIEventDiagnosis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIEventDiagnosis.swift; sourceTree = "<group>"; };
+		A40000000000000000000004 /* AIEventDiagnosticRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIEventDiagnosticRequester.swift; sourceTree = "<group>"; };
+		A5FF000000000000000B0002 /* AIDiagnosticResponseFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIDiagnosticResponseFormatter.swift; sourceTree = "<group>"; };
+		A5FF000000000000000B0004 /* AIDiagnosisContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIDiagnosisContentView.swift; sourceTree = "<group>"; };
+		A5FF000000000000000B0006 /* AIDiagnosticResponseFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIDiagnosticResponseFormatterTests.swift; sourceTree = "<group>"; };
+		A40000000000000000000006 /* WarningEventDiagnosticReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningEventDiagnosticReader.swift; sourceTree = "<group>"; };
+		A40000000000000000000008 /* AIEventDiagnosticRequesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIEventDiagnosticRequesterTests.swift; sourceTree = "<group>"; };
+		A4000000000000000000000A /* WarningEventDiagnosticReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningEventDiagnosticReaderTests.swift; sourceTree = "<group>"; };
 		039D4A0BD680E236E953D7EF /* StatusSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusSummaryView.swift; sourceTree = "<group>"; };
 		03C2110AF1395713CD29D1E3 /* MenuBarStatusPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentationTests.swift; sourceTree = "<group>"; };
 		044436EFC75907A7253A3A7A /* SettingsRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRootView.swift; sourceTree = "<group>"; };
@@ -294,6 +310,7 @@
 				F0A043426B709BACA5F1E0AD /* NodeDetailsView.swift */,
 				4602F3AD3687ABB356E1C266 /* NodesTabView.swift */,
 				66841095D9A2044E6C8AF517 /* OverviewTabView.swift */,
+				A5FF000000000000000B0004 /* AIDiagnosisContentView.swift */,
 				8E2F5A64A72F45C7A7E95A46 /* PodLogWindowPresenter.swift */,
 				BE870F98B15D0AD4D10E4031 /* PodsTabView.swift */,
 				8E2F5A66A72F45C7A7E95A46 /* ReadOnlyLogTextView.swift */,
@@ -339,6 +356,8 @@
 				A2000000000000000000000C /* AIProviderCredentialStoreTests.swift */,
 				A2000000000000000000000E /* AIProviderConnectionTesterTests.swift */,
 				A30000000000000000000008 /* AIPodDiagnosticRequesterTests.swift */,
+				A40000000000000000000008 /* AIEventDiagnosticRequesterTests.swift */,
+				A5FF000000000000000B0006 /* AIDiagnosticResponseFormatterTests.swift */,
 				B29566B59D491F95C0EE5504 /* CommandRunnerTests.swift */,
 				8727736B73E1A28F6DC70C66 /* ContextCatalogTests.swift */,
 				BEC71932B945E1D6592AA77E /* FreshnessDisplayScheduleTests.swift */,
@@ -352,6 +371,7 @@
 				A10000000000000000000008 /* StartAtLoginSettingsCoordinatorTests.swift */,
 				A1000000000000000000000F /* NetworkReachabilityTests.swift */,
 				68E80FACFC916D53A5004BFF /* WatchTargetCatalogTests.swift */,
+				A4000000000000000000000A /* WarningEventDiagnosticReaderTests.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -362,6 +382,7 @@
 				A20000000000000000000002 /* AIDiagnosticAssistantConfig.swift */,
 				A20000000000000000000004 /* AIDiagnosticAssistantState.swift */,
 				A30000000000000000000002 /* AIPodDiagnosis.swift */,
+				A40000000000000000000002 /* AIEventDiagnosis.swift */,
 				256B0E761A99ACDD9110BC8E /* ClusterHealthState.swift */,
 				7BF8969BAFC7CADA85C406E9 /* ClusterSnapshot.swift */,
 				E4EFC03EAA7FF0C71200678B /* MenuBarStatusPresentation.swift */,
@@ -385,6 +406,8 @@
 				A20000000000000000000006 /* AIProviderCredentialStore.swift */,
 				A20000000000000000000008 /* AIProviderConnectionTester.swift */,
 				A30000000000000000000004 /* AIPodDiagnosticRequester.swift */,
+				A40000000000000000000004 /* AIEventDiagnosticRequester.swift */,
+				A5FF000000000000000B0002 /* AIDiagnosticResponseFormatter.swift */,
 				A2000000000000000000000A /* HTTPClient.swift */,
 				A59D91E3E139CA91BC232D40 /* CommandRunner.swift */,
 				16B80AFB0373C83CDF78D0BE /* ContextCatalog.swift */,
@@ -396,6 +419,7 @@
 				689EC8218395797C0788B282 /* MenuLayoutSizing.swift */,
 				79D6D8313F4347E9ABFE8701 /* PodLogStreamer.swift */,
 				A30000000000000000000006 /* PodDiagnosticLogReader.swift */,
+				A40000000000000000000006 /* WarningEventDiagnosticReader.swift */,
 				B1ABF4BE1D5A8A8B7E474CBD /* RefreshCoordinator.swift */,
 				A1F687524DAA74E9F5F64CFC /* RefreshGate.swift */,
 				A10000000000000000000006 /* StartAtLoginSettingsCoordinator.swift */,
@@ -589,6 +613,8 @@
 				A2000000000000000000000B /* AIProviderCredentialStoreTests.swift in Sources */,
 				A2000000000000000000000D /* AIProviderConnectionTesterTests.swift in Sources */,
 				A30000000000000000000007 /* AIPodDiagnosticRequesterTests.swift in Sources */,
+				A40000000000000000000007 /* AIEventDiagnosticRequesterTests.swift in Sources */,
+				A5FF000000000000000B0005 /* AIDiagnosticResponseFormatterTests.swift in Sources */,
 				495D556A6DF84C8C22BB9D63 /* ClusterHealthStateTests.swift in Sources */,
 				2673AA6352855DBB0B87599A /* CommandRunnerTests.swift in Sources */,
 				1956982E5C1832CD17224A14 /* ContextCatalogTests.swift in Sources */,
@@ -609,6 +635,7 @@
 				A10000000000000000000004 /* StartAtLoginSettingsCoordinatorTests.swift in Sources */,
 				A1000000000000000000000C /* NetworkReachabilityTests.swift in Sources */,
 				4C818D44CA17CB017E0A5379 /* WatchTargetCatalogTests.swift in Sources */,
+				A40000000000000000000009 /* WarningEventDiagnosticReaderTests.swift in Sources */,
 				EA3A58433537560B8EFFE763 /* WatchTargetTests.swift in Sources */,
 				9B671EDA20D6DF7D94CF39C5 /* WatchlistSelectionStateTests.swift in Sources */,
 			);
@@ -622,9 +649,12 @@
 				A20000000000000000000001 /* AIDiagnosticAssistantConfig.swift in Sources */,
 				A20000000000000000000003 /* AIDiagnosticAssistantState.swift in Sources */,
 				A30000000000000000000001 /* AIPodDiagnosis.swift in Sources */,
+				A40000000000000000000001 /* AIEventDiagnosis.swift in Sources */,
 				A20000000000000000000005 /* AIProviderCredentialStore.swift in Sources */,
 				A20000000000000000000007 /* AIProviderConnectionTester.swift in Sources */,
 				A30000000000000000000003 /* AIPodDiagnosticRequester.swift in Sources */,
+				A40000000000000000000003 /* AIEventDiagnosticRequester.swift in Sources */,
+				A5FF000000000000000B0001 /* AIDiagnosticResponseFormatter.swift in Sources */,
 				A20000000000000000000009 /* HTTPClient.swift in Sources */,
 				43A2E812863B312A3F47C289 /* ClusterHealthState.swift in Sources */,
 				DC3D760FA2EF2E5789C6CD21 /* ClusterSnapshot.swift in Sources */,
@@ -642,6 +672,7 @@
 				EA0C0E575B5F1256F7E02BA5 /* MenuStateFixtureCatalog.swift in Sources */,
 				79D6D8323F4347E9ABFE8701 /* PodLogStreamer.swift in Sources */,
 				A30000000000000000000005 /* PodDiagnosticLogReader.swift in Sources */,
+				A40000000000000000000005 /* WarningEventDiagnosticReader.swift in Sources */,
 				A6FCE353AEC1C8483F645A4C /* RefreshCadence.swift in Sources */,
 				F11947BC8E49AFFF882FE036 /* RefreshCoordinator.swift in Sources */,
 				C37388D088AFEA095E3E172E /* RefreshGate.swift in Sources */,
@@ -677,6 +708,7 @@
 				0DF4C90F99F2163FADFDD4B4 /* NodeDetailsView.swift in Sources */,
 				9D2AA2BB55D09D9AFDDE7202 /* NodesTabView.swift in Sources */,
 				55F321A04D2EA4B27B1BFD9D /* OverviewTabView.swift in Sources */,
+				A5FF000000000000000B0003 /* AIDiagnosisContentView.swift in Sources */,
 				8E2F5A65A72F45C7A7E95A46 /* PodLogWindowPresenter.swift in Sources */,
 				D343AF9AAD2DB31A718A3396 /* PodsTabView.swift in Sources */,
 				8E2F5A67A72F45C7A7E95A46 /* ReadOnlyLogTextView.swift in Sources */,

--- a/Kubebar.xcodeproj/project.pbxproj
+++ b/Kubebar.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		A2000000000000000000000D /* AIProviderConnectionTesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000000000000000000000E /* AIProviderConnectionTesterTests.swift */; };
 		A2000000000000000000000F /* KeychainAIProviderCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000010 /* KeychainAIProviderCredentialStore.swift */; };
 		A20000000000000000000011 /* URLSessionHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000000000000000000012 /* URLSessionHTTPClient.swift */; };
+		A30000000000000000000001 /* AIPodDiagnosis.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000002 /* AIPodDiagnosis.swift */; };
+		A30000000000000000000003 /* AIPodDiagnosticRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000004 /* AIPodDiagnosticRequester.swift */; };
+		A30000000000000000000005 /* PodDiagnosticLogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000006 /* PodDiagnosticLogReader.swift */; };
+		A30000000000000000000007 /* AIPodDiagnosticRequesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30000000000000000000008 /* AIPodDiagnosticRequesterTests.swift */; };
 		0ABC7D9044D83EA481BBB112 /* WatchTargetCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD651CCDAAD62B4E7C090D6F /* WatchTargetCatalog.swift */; };
 		0C5D3D56CEDAB47E9528A4F6 /* WatchlistCandidate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CF64AA3581163BEA218DFB /* WatchlistCandidate.swift */; };
 		0D127D20E9DEDC847D33AE77 /* MenuDisplayModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27036F7AEDEFA527AF44A619 /* MenuDisplayModelTests.swift */; };
@@ -152,6 +156,10 @@
 		A2000000000000000000000E /* AIProviderConnectionTesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderConnectionTesterTests.swift; sourceTree = "<group>"; };
 		A20000000000000000000010 /* KeychainAIProviderCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAIProviderCredentialStore.swift; sourceTree = "<group>"; };
 		A20000000000000000000012 /* URLSessionHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHTTPClient.swift; sourceTree = "<group>"; };
+		A30000000000000000000002 /* AIPodDiagnosis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIPodDiagnosis.swift; sourceTree = "<group>"; };
+		A30000000000000000000004 /* AIPodDiagnosticRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIPodDiagnosticRequester.swift; sourceTree = "<group>"; };
+		A30000000000000000000006 /* PodDiagnosticLogReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodDiagnosticLogReader.swift; sourceTree = "<group>"; };
+		A30000000000000000000008 /* AIPodDiagnosticRequesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIPodDiagnosticRequesterTests.swift; sourceTree = "<group>"; };
 		039D4A0BD680E236E953D7EF /* StatusSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusSummaryView.swift; sourceTree = "<group>"; };
 		03C2110AF1395713CD29D1E3 /* MenuBarStatusPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentationTests.swift; sourceTree = "<group>"; };
 		044436EFC75907A7253A3A7A /* SettingsRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRootView.swift; sourceTree = "<group>"; };
@@ -330,6 +338,7 @@
 				684455D1430321334848EB7F /* AppConfigStoreTests.swift */,
 				A2000000000000000000000C /* AIProviderCredentialStoreTests.swift */,
 				A2000000000000000000000E /* AIProviderConnectionTesterTests.swift */,
+				A30000000000000000000008 /* AIPodDiagnosticRequesterTests.swift */,
 				B29566B59D491F95C0EE5504 /* CommandRunnerTests.swift */,
 				8727736B73E1A28F6DC70C66 /* ContextCatalogTests.swift */,
 				BEC71932B945E1D6592AA77E /* FreshnessDisplayScheduleTests.swift */,
@@ -352,6 +361,7 @@
 			children = (
 				A20000000000000000000002 /* AIDiagnosticAssistantConfig.swift */,
 				A20000000000000000000004 /* AIDiagnosticAssistantState.swift */,
+				A30000000000000000000002 /* AIPodDiagnosis.swift */,
 				256B0E761A99ACDD9110BC8E /* ClusterHealthState.swift */,
 				7BF8969BAFC7CADA85C406E9 /* ClusterSnapshot.swift */,
 				E4EFC03EAA7FF0C71200678B /* MenuBarStatusPresentation.swift */,
@@ -374,6 +384,7 @@
 				E3CFEB46C82EDA2D094BDDF0 /* AppConfigStore.swift */,
 				A20000000000000000000006 /* AIProviderCredentialStore.swift */,
 				A20000000000000000000008 /* AIProviderConnectionTester.swift */,
+				A30000000000000000000004 /* AIPodDiagnosticRequester.swift */,
 				A2000000000000000000000A /* HTTPClient.swift */,
 				A59D91E3E139CA91BC232D40 /* CommandRunner.swift */,
 				16B80AFB0373C83CDF78D0BE /* ContextCatalog.swift */,
@@ -384,6 +395,7 @@
 				09E8C7051DD3BC07BF86A950 /* KubectlClusterReader.swift */,
 				689EC8218395797C0788B282 /* MenuLayoutSizing.swift */,
 				79D6D8313F4347E9ABFE8701 /* PodLogStreamer.swift */,
+				A30000000000000000000006 /* PodDiagnosticLogReader.swift */,
 				B1ABF4BE1D5A8A8B7E474CBD /* RefreshCoordinator.swift */,
 				A1F687524DAA74E9F5F64CFC /* RefreshGate.swift */,
 				A10000000000000000000006 /* StartAtLoginSettingsCoordinator.swift */,
@@ -576,6 +588,7 @@
 				3A2ABB50330CBD164F187074 /* AppConfigStoreTests.swift in Sources */,
 				A2000000000000000000000B /* AIProviderCredentialStoreTests.swift in Sources */,
 				A2000000000000000000000D /* AIProviderConnectionTesterTests.swift in Sources */,
+				A30000000000000000000007 /* AIPodDiagnosticRequesterTests.swift in Sources */,
 				495D556A6DF84C8C22BB9D63 /* ClusterHealthStateTests.swift in Sources */,
 				2673AA6352855DBB0B87599A /* CommandRunnerTests.swift in Sources */,
 				1956982E5C1832CD17224A14 /* ContextCatalogTests.swift in Sources */,
@@ -608,8 +621,10 @@
 				279114E96D410FFB2622B97E /* AppConfigStore.swift in Sources */,
 				A20000000000000000000001 /* AIDiagnosticAssistantConfig.swift in Sources */,
 				A20000000000000000000003 /* AIDiagnosticAssistantState.swift in Sources */,
+				A30000000000000000000001 /* AIPodDiagnosis.swift in Sources */,
 				A20000000000000000000005 /* AIProviderCredentialStore.swift in Sources */,
 				A20000000000000000000007 /* AIProviderConnectionTester.swift in Sources */,
+				A30000000000000000000003 /* AIPodDiagnosticRequester.swift in Sources */,
 				A20000000000000000000009 /* HTTPClient.swift in Sources */,
 				43A2E812863B312A3F47C289 /* ClusterHealthState.swift in Sources */,
 				DC3D760FA2EF2E5789C6CD21 /* ClusterSnapshot.swift in Sources */,
@@ -626,6 +641,7 @@
 				43A6EE04D05E8CCF4CAD47D1 /* MenuRuntimeState.swift in Sources */,
 				EA0C0E575B5F1256F7E02BA5 /* MenuStateFixtureCatalog.swift in Sources */,
 				79D6D8323F4347E9ABFE8701 /* PodLogStreamer.swift in Sources */,
+				A30000000000000000000005 /* PodDiagnosticLogReader.swift in Sources */,
 				A6FCE353AEC1C8483F645A4C /* RefreshCadence.swift in Sources */,
 				F11947BC8E49AFFF882FE036 /* RefreshCoordinator.swift in Sources */,
 				C37388D088AFEA095E3E172E /* RefreshGate.swift in Sources */,

--- a/Kubebar/KubebarApp.swift
+++ b/Kubebar/KubebarApp.swift
@@ -33,6 +33,10 @@ struct KubebarApp: App {
                 onUpdateAIModelID: viewModel.updateAIModelID,
                 onUpdateAIBaseURL: viewModel.updateAIBaseURL,
                 onUpdateAIAPIKeyDraft: viewModel.updateAIAPIKeyDraft,
+                onUpdateAIPodPromptInstructions: viewModel.updateAIPodPromptInstructions,
+                onResetAIPodPromptInstructions: viewModel.resetAIPodPromptInstructions,
+                onUpdateAIEventPromptInstructions: viewModel.updateAIEventPromptInstructions,
+                onResetAIEventPromptInstructions: viewModel.resetAIEventPromptInstructions,
                 onTestAIConnection: viewModel.testAIConnection
             )
         }

--- a/Kubebar/KubebarApp.swift
+++ b/Kubebar/KubebarApp.swift
@@ -80,6 +80,7 @@ struct KubebarApp: App {
     private var liveMenuRootView: some View {
         MenuBarRootView(
             display: viewModel.display,
+            eventDiagnosis: viewModel.eventDiagnosis,
             activeContextName: viewModel.activeContextName,
             contextSelectorContexts: viewModel.contextSelectorContexts,
             isShowingSetup: viewModel.isShowingSetup,
@@ -91,6 +92,8 @@ struct KubebarApp: App {
             k9sHandoffState: viewModel.k9sHandoffState,
             onOpenK9sHandoff: viewModel.openK9sHandoff,
             onOpenPodLogs: viewModel.openPodLogDrawer,
+            onDiagnoseWarningEvent: viewModel.diagnoseWarningEventWithAI,
+            onDismissWarningEventDiagnosis: viewModel.dismissWarningEventDiagnosis,
             onQuit: { NSApplication.shared.terminate(nil) }
         )
         .onAppear {
@@ -136,6 +139,7 @@ private struct QAFixtureMenuRootView: View {
     var body: some View {
         MenuBarRootView(
             display: fixture.display,
+            eventDiagnosis: nil,
             activeContextName: fixture.display.contextName,
             contextSelectorContexts: [fixture.display.contextName],
             isShowingSetup: fixture.isShowingSetup,
@@ -147,6 +151,8 @@ private struct QAFixtureMenuRootView: View {
             k9sHandoffState: .idle,
             onOpenK9sHandoff: { _ in },
             onOpenPodLogs: { _ in },
+            onDiagnoseWarningEvent: { _ in },
+            onDismissWarningEventDiagnosis: {},
             onQuit: { NSApplication.shared.terminate(nil) }
         )
     }

--- a/Kubebar/MenuBarViewModel.swift
+++ b/Kubebar/MenuBarViewModel.swift
@@ -383,6 +383,26 @@ final class MenuBarViewModel: ObservableObject {
         publishRuntimeState()
     }
 
+    func updateAIPodPromptInstructions(_ instructions: String) {
+        runtimeState.setupState.updateAIPodDiagnosticPromptInstructions(instructions)
+        publishRuntimeState()
+    }
+
+    func resetAIPodPromptInstructions() {
+        runtimeState.setupState.resetAIPodDiagnosticPromptInstructions()
+        publishRuntimeState()
+    }
+
+    func updateAIEventPromptInstructions(_ instructions: String) {
+        runtimeState.setupState.updateAIEventDiagnosticPromptInstructions(instructions)
+        publishRuntimeState()
+    }
+
+    func resetAIEventPromptInstructions() {
+        runtimeState.setupState.resetAIEventDiagnosticPromptInstructions()
+        publishRuntimeState()
+    }
+
     func testAIConnection() {
         guard let tester = aiConnectionTester else {
             return

--- a/Kubebar/MenuBarViewModel.swift
+++ b/Kubebar/MenuBarViewModel.swift
@@ -8,6 +8,7 @@ struct PodLogDrawerPresentation: Identifiable, Equatable {
     var target: PodLogTarget
     var state: PodLogDrawerState
     var buffer: PodLogBuffer
+    var aiDiagnosis: AIPodDiagnosisState
 
     var id: String {
         target.id
@@ -61,12 +62,15 @@ final class MenuBarViewModel: ObservableObject {
     private let healthShiftAlertNotifier: any HealthShiftAlertNotifying
     private let networkReachability: any NetworkReachability
     private let podLogStreamer: any PodLogStreaming
+    private let podDiagnosticLogReader: any PodDiagnosticLogReading
     private let aiCredentialStore: any AIProviderCredentialStoring
     private let aiConnectionTester: AIProviderConnectionTester?
+    private let aiPodDiagnosticRequester: AIPodDiagnosticRequester?
     private var isNetworkAvailable: Bool = true
     private var healthShiftAlertTracker: HealthShiftAlertTracker
     private var healthShiftAlertSettingsRequestGate: HealthShiftAlertSettingsRequestGate
     private var podLogStreamTask: Task<Void, Never>?
+    private var podDiagnosisTask: Task<Void, Never>?
     private var activePodLogSession: PodLogStreamSession?
 
     /// Delay before resuming automatic refresh after network recovery.
@@ -86,8 +90,13 @@ final class MenuBarViewModel: ObservableObject {
         healthShiftAlertNotifier: any HealthShiftAlertNotifying = SystemHealthShiftAlertNotifier(),
         networkReachability: any NetworkReachability = NetworkReachabilityMonitor(),
         podLogStreamer: any PodLogStreaming = ProcessPodLogStreamer(),
+        podDiagnosticLogReader: any PodDiagnosticLogReading = CommandPodDiagnosticLogReader(),
         aiCredentialStore: any AIProviderCredentialStoring = KeychainAIProviderCredentialStore(),
         aiConnectionTester: AIProviderConnectionTester? = AIProviderConnectionTester(
+            credentialStore: KeychainAIProviderCredentialStore(),
+            httpClient: URLSessionHTTPClient()
+        ),
+        aiPodDiagnosticRequester: AIPodDiagnosticRequester? = AIPodDiagnosticRequester(
             credentialStore: KeychainAIProviderCredentialStore(),
             httpClient: URLSessionHTTPClient()
         ),
@@ -103,8 +112,10 @@ final class MenuBarViewModel: ObservableObject {
         self.healthShiftAlertNotifier = healthShiftAlertNotifier
         self.networkReachability = networkReachability
         self.podLogStreamer = podLogStreamer
+        self.podDiagnosticLogReader = podDiagnosticLogReader
         self.aiCredentialStore = aiCredentialStore
         self.aiConnectionTester = aiConnectionTester
+        self.aiPodDiagnosticRequester = aiPodDiagnosticRequester
 
         do {
             self.config = try configStore.load()
@@ -154,6 +165,7 @@ final class MenuBarViewModel: ObservableObject {
         watchTargetLoadTask?.cancel()
         networkRecoveryTask?.cancel()
         podLogStreamTask?.cancel()
+        podDiagnosisTask?.cancel()
         networkReachability.stopMonitoring()
     }
 
@@ -703,7 +715,8 @@ final class MenuBarViewModel: ObservableObject {
             session: session,
             target: target,
             state: .loading,
-            buffer: PodLogBuffer()
+            buffer: PodLogBuffer(),
+            aiDiagnosis: .idle
         )
 
         podLogStreamTask = Task { [weak self] in
@@ -732,7 +745,9 @@ final class MenuBarViewModel: ObservableObject {
 
     func closePodLogDrawer() {
         podLogStreamTask?.cancel()
+        podDiagnosisTask?.cancel()
         podLogStreamTask = nil
+        podDiagnosisTask = nil
         activePodLogSession = nil
         podLogDrawer = nil
         podLogSearchQuery = ""
@@ -745,6 +760,60 @@ final class MenuBarViewModel: ObservableObject {
 
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    func diagnoseCurrentPodWithAI() {
+        guard var drawer = podLogDrawer else {
+            return
+        }
+
+        guard let requester = aiPodDiagnosticRequester else {
+            drawer.aiDiagnosis = .failed("AI diagnosis is unavailable.")
+            podLogDrawer = drawer
+            return
+        }
+
+        podDiagnosisTask?.cancel()
+
+        let target = drawer.target
+        let request = PodDiagnosticLogReadRequest(target: target, config: config)
+        let logReader = podDiagnosticLogReader
+        let provider = config.aiDiagnosticAssistant.provider
+        let aiConfig = config.aiDiagnosticAssistant
+        let contextBase = podDiagnosticContextBase(for: target)
+
+        drawer.aiDiagnosis = .loading
+        podLogDrawer = drawer
+
+        podDiagnosisTask = Task { [weak self] in
+            do {
+                let logLines = try await logReader.readLogs(for: request)
+                try Task.checkCancellation()
+                let context = AIPodDiagnosticContext(
+                    target: target,
+                    podStatus: contextBase.podStatus,
+                    warnings: contextBase.warnings,
+                    logLines: logLines,
+                    isStale: contextBase.isStale
+                )
+                let result = await requester.diagnose(context: context, config: aiConfig, provider: provider)
+
+                await MainActor.run {
+                    self?.applyAIPodDiagnosticResult(result, for: target)
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    self?.clearAIPodDiagnosisTask(for: target)
+                }
+            } catch {
+                await MainActor.run {
+                    self?.applyAIPodDiagnosticResult(
+                        .failed("Could not read recent logs: \(Self.failureReason(from: error))"),
+                        for: target
+                    )
+                }
+            }
+        }
     }
 
     private func resetK9sHandoffStateForCurrentDisplay() {
@@ -812,6 +881,74 @@ final class MenuBarViewModel: ObservableObject {
         }
 
         return drawer
+    }
+
+    private func applyAIPodDiagnosticResult(_ result: AIPodDiagnosticResult, for target: PodLogTarget) {
+        guard var drawer = podLogDrawer, drawer.target == target else {
+            return
+        }
+
+        switch result {
+        case let .success(markdown):
+            drawer.aiDiagnosis = .success(markdown: markdown)
+        case let .failed(message):
+            drawer.aiDiagnosis = .failed(message)
+        }
+        podLogDrawer = drawer
+        podDiagnosisTask = nil
+    }
+
+    private func clearAIPodDiagnosisTask(for target: PodLogTarget) {
+        guard podLogDrawer?.target == target else {
+            return
+        }
+
+        podDiagnosisTask = nil
+    }
+
+    private struct AIPodDiagnosticContextBase {
+        let podStatus: AIPodStatusContext
+        let warnings: [AIPodWarningContext]
+        let isStale: Bool
+    }
+
+    private func podDiagnosticContextBase(for target: PodLogTarget) -> AIPodDiagnosticContextBase {
+        let pod = podItem(for: target)
+        return AIPodDiagnosticContextBase(
+            podStatus: AIPodStatusContext(
+                state: pod?.state.label ?? "Unknown",
+                ready: pod?.readyLabel ?? "unknown",
+                reason: pod?.issueText,
+                detail: pod?.helpText
+            ),
+            warnings: relatedWarnings(for: target),
+            isStale: display.state == .stale
+        )
+    }
+
+    private func podItem(for target: PodLogTarget) -> PodItemDisplay? {
+        display.podTab.sections
+            .first { $0.namespace == target.namespace }?
+            .rows
+            .first { $0.name == target.podName }
+    }
+
+    private func relatedWarnings(for target: PodLogTarget) -> [AIPodWarningContext] {
+        display.eventsTab.rows
+            .filter { row in
+                row.location.contains(target.podName) ||
+                    row.helpText.contains(target.podName) ||
+                    row.accessibilityLabel.contains(target.podName)
+            }
+            .prefix(3)
+            .map { row in
+                AIPodWarningContext(
+                    reason: row.reason,
+                    location: row.location,
+                    age: row.age,
+                    message: row.fullMessage
+                )
+            }
     }
 
     private func scheduleFreshnessTimer(now: Date = Date()) {

--- a/Kubebar/MenuBarViewModel.swift
+++ b/Kubebar/MenuBarViewModel.swift
@@ -23,6 +23,15 @@ struct PodLogDrawerPresentation: Identifiable, Equatable {
     }
 }
 
+struct EventDiagnosisPresentation: Identifiable, Equatable {
+    var target: WarningEventDiagnosticTarget
+    var state: AIEventDiagnosisState
+
+    var id: String {
+        target.id
+    }
+}
+
 @MainActor
 final class MenuBarViewModel: ObservableObject {
     @Published private(set) var display: MenuDisplayModel
@@ -40,6 +49,7 @@ final class MenuBarViewModel: ObservableObject {
     @Published private(set) var isRefreshing: Bool
     @Published private(set) var k9sHandoffState: K9sHandoffLaunchState
     @Published private(set) var podLogDrawer: PodLogDrawerPresentation?
+    @Published private(set) var eventDiagnosis: EventDiagnosisPresentation?
     @Published var podLogSearchQuery: String = ""
 
     private let configStore: AppConfigStore
@@ -63,14 +73,17 @@ final class MenuBarViewModel: ObservableObject {
     private let networkReachability: any NetworkReachability
     private let podLogStreamer: any PodLogStreaming
     private let podDiagnosticLogReader: any PodDiagnosticLogReading
+    private let warningEventDiagnosticReader: any WarningEventDiagnosticReading
     private let aiCredentialStore: any AIProviderCredentialStoring
     private let aiConnectionTester: AIProviderConnectionTester?
     private let aiPodDiagnosticRequester: AIPodDiagnosticRequester?
+    private let aiEventDiagnosticRequester: AIEventDiagnosticRequester?
     private var isNetworkAvailable: Bool = true
     private var healthShiftAlertTracker: HealthShiftAlertTracker
     private var healthShiftAlertSettingsRequestGate: HealthShiftAlertSettingsRequestGate
     private var podLogStreamTask: Task<Void, Never>?
     private var podDiagnosisTask: Task<Void, Never>?
+    private var eventDiagnosisTask: Task<Void, Never>?
     private var activePodLogSession: PodLogStreamSession?
 
     /// Delay before resuming automatic refresh after network recovery.
@@ -91,12 +104,17 @@ final class MenuBarViewModel: ObservableObject {
         networkReachability: any NetworkReachability = NetworkReachabilityMonitor(),
         podLogStreamer: any PodLogStreaming = ProcessPodLogStreamer(),
         podDiagnosticLogReader: any PodDiagnosticLogReading = CommandPodDiagnosticLogReader(),
+        warningEventDiagnosticReader: any WarningEventDiagnosticReading = CommandWarningEventDiagnosticReader(),
         aiCredentialStore: any AIProviderCredentialStoring = KeychainAIProviderCredentialStore(),
         aiConnectionTester: AIProviderConnectionTester? = AIProviderConnectionTester(
             credentialStore: KeychainAIProviderCredentialStore(),
             httpClient: URLSessionHTTPClient()
         ),
         aiPodDiagnosticRequester: AIPodDiagnosticRequester? = AIPodDiagnosticRequester(
+            credentialStore: KeychainAIProviderCredentialStore(),
+            httpClient: URLSessionHTTPClient()
+        ),
+        aiEventDiagnosticRequester: AIEventDiagnosticRequester? = AIEventDiagnosticRequester(
             credentialStore: KeychainAIProviderCredentialStore(),
             httpClient: URLSessionHTTPClient()
         ),
@@ -113,9 +131,11 @@ final class MenuBarViewModel: ObservableObject {
         self.networkReachability = networkReachability
         self.podLogStreamer = podLogStreamer
         self.podDiagnosticLogReader = podDiagnosticLogReader
+        self.warningEventDiagnosticReader = warningEventDiagnosticReader
         self.aiCredentialStore = aiCredentialStore
         self.aiConnectionTester = aiConnectionTester
         self.aiPodDiagnosticRequester = aiPodDiagnosticRequester
+        self.aiEventDiagnosticRequester = aiEventDiagnosticRequester
 
         do {
             self.config = try configStore.load()
@@ -136,6 +156,7 @@ final class MenuBarViewModel: ObservableObject {
         self.activeContextName = config.selectedContext
         self.k9sHandoffState = .idle
         self.podLogDrawer = nil
+        self.eventDiagnosis = nil
         self.activePodLogSession = nil
         self.healthShiftAlertTracker = HealthShiftAlertTracker()
         self.healthShiftAlertSettingsRequestGate = HealthShiftAlertSettingsRequestGate()
@@ -166,6 +187,7 @@ final class MenuBarViewModel: ObservableObject {
         networkRecoveryTask?.cancel()
         podLogStreamTask?.cancel()
         podDiagnosisTask?.cancel()
+        eventDiagnosisTask?.cancel()
         networkReachability.stopMonitoring()
     }
 
@@ -638,6 +660,9 @@ final class MenuBarViewModel: ObservableObject {
         staleReason = nil
         k9sHandoffCoordinator.clear()
         healthShiftAlertTracker.reset()
+        eventDiagnosisTask?.cancel()
+        eventDiagnosisTask = nil
+        eventDiagnosis = nil
 
         if clearSnapshot {
             snapshot = nil
@@ -816,6 +841,57 @@ final class MenuBarViewModel: ObservableObject {
         }
     }
 
+    func dismissWarningEventDiagnosis() {
+        eventDiagnosisTask?.cancel()
+        eventDiagnosisTask = nil
+        eventDiagnosis = nil
+    }
+
+    func diagnoseWarningEventWithAI(_ target: WarningEventDiagnosticTarget) {
+        guard let requester = aiEventDiagnosticRequester else {
+            eventDiagnosis = EventDiagnosisPresentation(target: target, state: .failed("AI diagnosis is unavailable."))
+            return
+        }
+
+        eventDiagnosisTask?.cancel()
+
+        let request = WarningEventDiagnosticReadRequest(target: target, config: config)
+        let reader = warningEventDiagnosticReader
+        let provider = config.aiDiagnosticAssistant.provider
+        let aiConfig = config.aiDiagnosticAssistant
+        let isStale = display.state == .stale
+
+        eventDiagnosis = EventDiagnosisPresentation(target: target, state: .loading)
+
+        eventDiagnosisTask = Task { [weak self] in
+            do {
+                let records = try await reader.readEvents(for: request)
+                try Task.checkCancellation()
+                let context = AIEventDiagnosticContext(
+                    target: target,
+                    events: records.map(AIEventDiagnosticEvent.init(record:)),
+                    isStale: isStale
+                )
+                let result = await requester.diagnose(context: context, config: aiConfig, provider: provider)
+
+                await MainActor.run {
+                    self?.applyAIEventDiagnosticResult(result, for: target)
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    self?.clearAIEventDiagnosisTask(for: target)
+                }
+            } catch {
+                await MainActor.run {
+                    self?.applyAIEventDiagnosticResult(
+                        .failed("Could not read recent warning events: \(Self.failureReason(from: error))"),
+                        for: target
+                    )
+                }
+            }
+        }
+    }
+
     private func resetK9sHandoffStateForCurrentDisplay() {
         guard let target = k9sHandoffCoordinator.state.target else {
             return
@@ -904,6 +980,29 @@ final class MenuBarViewModel: ObservableObject {
         }
 
         podDiagnosisTask = nil
+    }
+
+    private func applyAIEventDiagnosticResult(_ result: AIEventDiagnosticResult, for target: WarningEventDiagnosticTarget) {
+        guard var presentation = eventDiagnosis, presentation.target == target else {
+            return
+        }
+
+        switch result {
+        case let .success(markdown):
+            presentation.state = .success(markdown: markdown)
+        case let .failed(message):
+            presentation.state = .failed(message)
+        }
+        eventDiagnosis = presentation
+        eventDiagnosisTask = nil
+    }
+
+    private func clearAIEventDiagnosisTask(for target: WarningEventDiagnosticTarget) {
+        guard eventDiagnosis?.target == target else {
+            return
+        }
+
+        eventDiagnosisTask = nil
     }
 
     private struct AIPodDiagnosticContextBase {

--- a/Kubebar/Views/AIDiagnosisContentView.swift
+++ b/Kubebar/Views/AIDiagnosisContentView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+/// Renders an AI diagnosis Markdown string as structured, glanceable sections
+/// instead of a single wall of raw Markdown text.
+///
+/// The diagnosis is split on `##` headings into sections. Each section renders
+/// as a titled card with a heading icon derived from the leading emoji (🔍
+/// causes, 🛠️ fixes), followed by the section body as styled Markdown. Content
+/// before the first heading is discarded — `AIDiagnosticResponseFormatter`
+/// already strips reasoning traces, so any remaining preamble is model chatter.
+struct AIDiagnosisContentView: View {
+    let markdown: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(sections, id: \.id) { section in
+                AIDiagnosisSectionView(section: section)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var sections: [AIDiagnosisSection] {
+        AIDiagnosisSectionParser.parse(markdown: markdown)
+    }
+}
+
+private struct AIDiagnosisSectionView: View {
+    let section: AIDiagnosisSection
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 5) {
+                Image(systemName: section.icon)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(section.tint)
+
+                Text(section.title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(section.tint)
+
+                Spacer(minLength: 0)
+            }
+
+            if !section.body.isEmpty {
+                Text(section.attributedBody)
+                    .font(.caption)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 8)
+        .background(section.background, in: RoundedRectangle(cornerRadius: 6))
+        .accessibilityElement(children: .combine)
+    }
+}
+
+struct AIDiagnosisSection: Identifiable {
+    let id = UUID()
+    let title: String
+    let body: String
+    let icon: String
+    let tint: Color
+    let background: Color
+}
+
+enum AIDiagnosisSectionParser {
+    static func parse(markdown: String) -> [AIDiagnosisSection] {
+        let lines = markdown.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var sections: [AIDiagnosisSection] = []
+        var currentTitle: String?
+        var currentBody: [String] = []
+
+        func flush() {
+            guard let title = currentTitle else { return }
+            let body = currentBody
+                .joined(separator: "\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalized = title.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalized.isEmpty else { return }
+            let style = AIDiagnosisSectionStyle(for: normalized)
+            sections.append(
+                AIDiagnosisSection(
+                    title: normalized,
+                    body: body,
+                    icon: style.icon,
+                    tint: style.tint,
+                    background: style.background
+                )
+            )
+        }
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("##") {
+                flush()
+                currentTitle = String(trimmed.dropFirst(2))
+                    .trimmingCharacters(in: .whitespaces)
+                currentBody = []
+            } else if currentTitle != nil {
+                currentBody.append(line)
+            }
+        }
+
+        flush()
+        return sections
+    }
+}
+
+private struct AIDiagnosisSectionStyle {
+    let icon: String
+    let tint: Color
+    let background: Color
+
+    init(for title: String) {
+        let lowered = title.lowercased()
+
+        if lowered.contains("possible cause") || lowered.contains("caus") {
+            self.icon = "magnifyingglass"
+            self.tint = .orange
+            self.background = Color.orange.opacity(0.1)
+        } else if lowered.contains("fix") || lowered.contains("action") || lowered.contains("next") || lowered.contains("remedi") {
+            self.icon = "wrench.and.screwdriver"
+            self.tint = .green
+            self.background = Color.green.opacity(0.1)
+        } else {
+            self.icon = "doc.text"
+            self.tint = .secondary
+            self.background = Color.secondary.opacity(0.08)
+        }
+    }
+}
+
+private extension AIDiagnosisSection {
+    var attributedBody: AttributedString {
+        (try? AttributedString(markdown: body)) ?? AttributedString(body)
+    }
+}

--- a/Kubebar/Views/MenuBarRootView.swift
+++ b/Kubebar/Views/MenuBarRootView.swift
@@ -239,6 +239,7 @@ struct PodLogDrawerView: View {
     let drawer: PodLogDrawerPresentation
     @Binding var searchQuery: String
     let onCopyLogs: () -> Void
+    let onDiagnoseWithAI: () -> Void
 
     private var matchCount: Int {
         drawer.matchCount(for: searchQuery)
@@ -249,9 +250,10 @@ struct PodLogDrawerView: View {
             header
             controls
             logText
+            aiDiagnosisPanel
         }
         .padding(16)
-        .frame(width: 640, height: 480)
+        .frame(width: 680, height: 620)
     }
 
     private var header: some View {
@@ -302,6 +304,16 @@ struct PodLogDrawerView: View {
             .disabled(drawer.visibleText.isEmpty)
             .help(Text("Copy logs"))
             .accessibilityLabel("Copy logs")
+
+            Button {
+                onDiagnoseWithAI()
+            } label: {
+                Label("AI Diagnose this Pod", systemImage: "sparkles")
+                    .labelStyle(.iconOnly)
+            }
+            .disabled(drawer.aiDiagnosis.isLoading)
+            .help(Text("AI Diagnose this Pod"))
+            .accessibilityLabel("AI Diagnose this Pod")
         }
     }
 
@@ -311,10 +323,70 @@ struct PodLogDrawerView: View {
             placeholder: placeholderText,
             isPlaceholder: drawer.visibleText.isEmpty
         )
+        .frame(minHeight: 240)
         .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
         .overlay {
             RoundedRectangle(cornerRadius: 6)
                 .stroke(Color.secondary.opacity(0.18))
+        }
+    }
+
+    private var aiDiagnosisPanel: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 6) {
+                    Label("AI Diagnosis", systemImage: "sparkles")
+                        .font(.caption.weight(.semibold))
+
+                    Spacer()
+
+                    if drawer.aiDiagnosis.isLoading {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+
+                Text("Manual action. Sends this Pod status, latest related warnings, and a fresh `kubectl logs --tail=50` sample to your configured AI Provider.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                aiDiagnosisContent
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private var aiDiagnosisContent: some View {
+        switch drawer.aiDiagnosis {
+        case .idle:
+            Text("Click the sparkles button to generate a transient diagnosis. Kubebar will not execute suggested commands.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .loading:
+            Text("Analyzing last 50 log lines...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case let .failed(message):
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer()
+
+                Button("Retry", action: onDiagnoseWithAI)
+                    .controlSize(.small)
+            }
+        case let .success(markdown):
+            ScrollView {
+                AIDiagnosisMarkdownView(markdown: markdown)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+            .frame(maxHeight: 160)
         }
     }
 
@@ -326,6 +398,20 @@ struct PodLogDrawerView: View {
         searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? ""
             : "\(matchCount) matches"
+    }
+}
+
+private struct AIDiagnosisMarkdownView: View {
+    let markdown: String
+
+    var body: some View {
+        if let attributed = try? AttributedString(markdown: markdown) {
+            Text(attributed)
+                .font(.caption)
+        } else {
+            Text(markdown)
+                .font(.caption)
+        }
     }
 }
 

--- a/Kubebar/Views/MenuBarRootView.swift
+++ b/Kubebar/Views/MenuBarRootView.swift
@@ -4,6 +4,7 @@ import KubebarCore
 
 struct MenuBarRootView: View {
     let display: MenuDisplayModel
+    let eventDiagnosis: EventDiagnosisPresentation?
     let activeContextName: String?
     let contextSelectorContexts: [String]
     let isShowingSetup: Bool
@@ -15,6 +16,8 @@ struct MenuBarRootView: View {
     let k9sHandoffState: K9sHandoffLaunchState
     let onOpenK9sHandoff: (OverviewK9sHandoff) -> Void
     let onOpenPodLogs: (PodLogTarget) -> Void
+    let onDiagnoseWarningEvent: (WarningEventDiagnosticTarget) -> Void
+    let onDismissWarningEventDiagnosis: () -> Void
     let onQuit: () -> Void
     @Environment(\.openSettings) private var openSettings
     @State private var selectedTab: MenuTab = .overview
@@ -133,8 +136,11 @@ struct MenuBarRootView: View {
         case .overview:
             OverviewTabView(
                 display: display,
+                eventDiagnosis: eventDiagnosis,
                 k9sHandoffState: k9sHandoffState,
-                onOpenK9sHandoff: onOpenK9sHandoff
+                onOpenK9sHandoff: onOpenK9sHandoff,
+                onDiagnoseWarningEvent: onDiagnoseWarningEvent,
+                onDismissWarningEventDiagnosis: onDismissWarningEventDiagnosis
             )
         case .nodes:
             NodesTabView(
@@ -382,7 +388,7 @@ struct PodLogDrawerView: View {
             }
         case let .success(markdown):
             ScrollView {
-                AIDiagnosisMarkdownView(markdown: markdown)
+                AIDiagnosisContentView(markdown: markdown)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .textSelection(.enabled)
             }
@@ -398,20 +404,6 @@ struct PodLogDrawerView: View {
         searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? ""
             : "\(matchCount) matches"
-    }
-}
-
-private struct AIDiagnosisMarkdownView: View {
-    let markdown: String
-
-    var body: some View {
-        if let attributed = try? AttributedString(markdown: markdown) {
-            Text(attributed)
-                .font(.caption)
-        } else {
-            Text(markdown)
-                .font(.caption)
-        }
     }
 }
 

--- a/Kubebar/Views/OverviewTabView.swift
+++ b/Kubebar/Views/OverviewTabView.swift
@@ -3,8 +3,11 @@ import KubebarCore
 
 struct OverviewTabView: View {
     let display: MenuDisplayModel
+    let eventDiagnosis: EventDiagnosisPresentation?
     let k9sHandoffState: K9sHandoffLaunchState
     let onOpenK9sHandoff: (OverviewK9sHandoff) -> Void
+    let onDiagnoseWarningEvent: (WarningEventDiagnosticTarget) -> Void
+    let onDismissWarningEventDiagnosis: () -> Void
 
     private let columns = [
         GridItem(.flexible(), spacing: 8),
@@ -26,7 +29,12 @@ struct OverviewTabView: View {
                 }
             }
 
-            RecentWarningsOverviewView(display: display.overview)
+            RecentWarningsOverviewView(
+                display: display.overview,
+                eventDiagnosis: eventDiagnosis,
+                onDiagnoseWarningEvent: onDiagnoseWarningEvent,
+                onDismissWarningEventDiagnosis: onDismissWarningEventDiagnosis
+            )
         }
     }
 }
@@ -111,6 +119,9 @@ private struct OverviewCardView: View {
 
 private struct RecentWarningsOverviewView: View {
     let display: OverviewDisplay
+    let eventDiagnosis: EventDiagnosisPresentation?
+    let onDiagnoseWarningEvent: (WarningEventDiagnosticTarget) -> Void
+    let onDismissWarningEventDiagnosis: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -136,12 +147,49 @@ private struct RecentWarningsOverviewView: View {
                 readableText(display.recentWarningsEmptyMessage)
             } else {
                 ForEach(display.recentWarnings) { row in
-                    WarningEventRowView(row: row)
+                    recentWarningRow(row)
                 }
             }
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilitySummary)
+    }
+
+    private func recentWarningRow(_ row: WarningEventDisplay) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                WarningEventRowView(row: row)
+
+                if let target = row.diagnosticTarget {
+                    Button {
+                        onDiagnoseWarningEvent(target)
+                    } label: {
+                        Label("AI Diagnose warning", systemImage: "sparkles")
+                            .labelStyle(.iconOnly)
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+                    .disabled(eventDiagnosis?.target == target && eventDiagnosis?.state.isLoading == true)
+                    .help(Text(aiDiagnosisHelp(for: row)))
+                    .accessibilityLabel(aiDiagnosisHelp(for: row))
+                }
+            }
+
+            if let eventDiagnosis, eventDiagnosis.target == row.diagnosticTarget {
+                EventDiagnosisPanel(
+                    diagnosis: eventDiagnosis,
+                    onRetry: {
+                        onDiagnoseWarningEvent(eventDiagnosis.target)
+                    },
+                    onDismiss: onDismissWarningEventDiagnosis
+                )
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func aiDiagnosisHelp(for row: WarningEventDisplay) -> String {
+        "AI Diagnose \(row.reason) warning for \(row.location)"
     }
 
     private func readableText(_ value: String) -> some View {
@@ -175,5 +223,80 @@ private struct RecentWarningsOverviewView: View {
         }
 
         return parts.joined(separator: ", ")
+    }
+}
+
+private struct EventDiagnosisPanel: View {
+    let diagnosis: EventDiagnosisPresentation
+    let onRetry: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 6) {
+                    Label("AI Diagnosis", systemImage: "sparkles")
+                        .font(.caption.weight(.semibold))
+
+                    Spacer()
+
+                    if diagnosis.state.isLoading {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+
+                    Button {
+                        onDismiss()
+                    } label: {
+                        Image(systemName: "xmark.circle")
+                    }
+                    .buttonStyle(.borderless)
+                    .controlSize(.small)
+                    .help(Text("Dismiss AI diagnosis"))
+                    .accessibilityLabel("Dismiss AI diagnosis")
+                }
+
+                Text("Manual action. Sends the latest 5 matching Warning Events to your configured AI Provider. Kubebar will not execute suggested commands.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                content
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch diagnosis.state {
+        case .idle:
+            Text("Click the sparkles button to generate a transient diagnosis.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .loading:
+            Text("Analyzing latest matching warning events...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case let .failed(message):
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer()
+
+                Button("Retry", action: onRetry)
+                    .controlSize(.small)
+            }
+        case let .success(markdown):
+            ScrollView {
+                AIDiagnosisContentView(markdown: markdown)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+            .frame(maxHeight: 160)
+        }
     }
 }

--- a/Kubebar/Views/PodLogWindowPresenter.swift
+++ b/Kubebar/Views/PodLogWindowPresenter.swift
@@ -101,7 +101,8 @@ private struct PodLogWindowContent: View {
             PodLogDrawerView(
                 drawer: drawer,
                 searchQuery: $viewModel.podLogSearchQuery,
-                onCopyLogs: viewModel.copyCurrentPodLogs
+                onCopyLogs: viewModel.copyCurrentPodLogs,
+                onDiagnoseWithAI: viewModel.diagnoseCurrentPodWithAI
             )
         }
     }

--- a/Kubebar/Views/SettingsRootView.swift
+++ b/Kubebar/Views/SettingsRootView.swift
@@ -21,6 +21,10 @@ struct SettingsRootView: View {
     let onUpdateAIModelID: (String) -> Void
     let onUpdateAIBaseURL: (String) -> Void
     let onUpdateAIAPIKeyDraft: (String) -> Void
+    let onUpdateAIPodPromptInstructions: (String) -> Void
+    let onResetAIPodPromptInstructions: () -> Void
+    let onUpdateAIEventPromptInstructions: (String) -> Void
+    let onResetAIEventPromptInstructions: () -> Void
     let onTestAIConnection: () -> Void
     @Environment(\.dismiss) private var dismiss
 
@@ -43,6 +47,10 @@ struct SettingsRootView: View {
             onUpdateAIModelID: onUpdateAIModelID,
             onUpdateAIBaseURL: onUpdateAIBaseURL,
             onUpdateAIAPIKeyDraft: onUpdateAIAPIKeyDraft,
+            onUpdateAIPodPromptInstructions: onUpdateAIPodPromptInstructions,
+            onResetAIPodPromptInstructions: onResetAIPodPromptInstructions,
+            onUpdateAIEventPromptInstructions: onUpdateAIEventPromptInstructions,
+            onResetAIEventPromptInstructions: onResetAIEventPromptInstructions,
             onTestAIConnection: onTestAIConnection
         )
         .frame(

--- a/Kubebar/Views/SetupView.swift
+++ b/Kubebar/Views/SetupView.swift
@@ -19,6 +19,10 @@ struct SetupView: View {
     let onUpdateAIModelID: (String) -> Void
     let onUpdateAIBaseURL: (String) -> Void
     let onUpdateAIAPIKeyDraft: (String) -> Void
+    let onUpdateAIPodPromptInstructions: (String) -> Void
+    let onResetAIPodPromptInstructions: () -> Void
+    let onUpdateAIEventPromptInstructions: (String) -> Void
+    let onResetAIEventPromptInstructions: () -> Void
     let onTestAIConnection: () -> Void
 
     init(
@@ -39,6 +43,10 @@ struct SetupView: View {
         onUpdateAIModelID: @escaping (String) -> Void = { _ in },
         onUpdateAIBaseURL: @escaping (String) -> Void = { _ in },
         onUpdateAIAPIKeyDraft: @escaping (String) -> Void = { _ in },
+        onUpdateAIPodPromptInstructions: @escaping (String) -> Void = { _ in },
+        onResetAIPodPromptInstructions: @escaping () -> Void = {},
+        onUpdateAIEventPromptInstructions: @escaping (String) -> Void = { _ in },
+        onResetAIEventPromptInstructions: @escaping () -> Void = {},
         onTestAIConnection: @escaping () -> Void = {}
     ) {
         _state = state
@@ -58,6 +66,10 @@ struct SetupView: View {
         self.onUpdateAIModelID = onUpdateAIModelID
         self.onUpdateAIBaseURL = onUpdateAIBaseURL
         self.onUpdateAIAPIKeyDraft = onUpdateAIAPIKeyDraft
+        self.onUpdateAIPodPromptInstructions = onUpdateAIPodPromptInstructions
+        self.onResetAIPodPromptInstructions = onResetAIPodPromptInstructions
+        self.onUpdateAIEventPromptInstructions = onUpdateAIEventPromptInstructions
+        self.onResetAIEventPromptInstructions = onResetAIEventPromptInstructions
         self.onTestAIConnection = onTestAIConnection
     }
 
@@ -260,6 +272,29 @@ struct SetupView: View {
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                     }
+                }
+            }
+
+            SettingsSection(title: "Diagnostic prompts") {
+                Text("Edit diagnosis instructions only. Kubebar still attaches bounded diagnostic context and fixed safety instructions.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                SettingsRow(label: "Pod diagnosis") {
+                    aiPromptEditor(
+                        text: aiPodPromptInstructionsBinding,
+                        resetAction: onResetAIPodPromptInstructions,
+                        accessibilityLabel: "AI Pod diagnosis prompt"
+                    )
+                }
+
+                SettingsRow(label: "Warning Events") {
+                    aiPromptEditor(
+                        text: aiEventPromptInstructionsBinding,
+                        resetAction: onResetAIEventPromptInstructions,
+                        accessibilityLabel: "AI Warning Event diagnosis prompt"
+                    )
                 }
             }
         }
@@ -507,6 +542,37 @@ struct SetupView: View {
             get: { state.aiDiagnosticAssistant.apiKeyDraft },
             set: { onUpdateAIAPIKeyDraft($0) }
         )
+    }
+
+    private var aiPodPromptInstructionsBinding: Binding<String> {
+        Binding(
+            get: { state.aiDiagnosticAssistant.config.effectivePodPromptInstructions },
+            set: { onUpdateAIPodPromptInstructions($0) }
+        )
+    }
+
+    private var aiEventPromptInstructionsBinding: Binding<String> {
+        Binding(
+            get: { state.aiDiagnosticAssistant.config.effectiveEventPromptInstructions },
+            set: { onUpdateAIEventPromptInstructions($0) }
+        )
+    }
+
+    private func aiPromptEditor(
+        text: Binding<String>,
+        resetAction: @escaping () -> Void,
+        accessibilityLabel: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TextEditor(text: text)
+                .font(.system(.caption, design: .monospaced))
+                .frame(minHeight: 118)
+                .accessibilityLabel(Text(accessibilityLabel))
+
+            Button("Reset to default", action: resetAction)
+                .buttonStyle(.bordered)
+                .accessibilityLabel(Text("Reset \(accessibilityLabel) to default"))
+        }
     }
 
     private var kubeconfigPathsHelpText: String {

--- a/KubebarCore/Models/AIDiagnosticAssistantConfig.swift
+++ b/KubebarCore/Models/AIDiagnosticAssistantConfig.swift
@@ -4,28 +4,69 @@ import Foundation
 ///
 /// `API key` material is intentionally excluded from this value type so it can
 /// never be persisted through `AppConfig` or appear in `config.json`. Secret
-/// credentials belong to the Keychain credential store introduced in a later
-/// step.
+/// credentials belong to the Keychain credential store.
 public struct AIDiagnosticAssistantConfig: Codable, Equatable, Sendable {
+    public static let defaultPodPromptInstructions = """
+    Diagnose this Kubernetes Pod for a human operator.
+
+    Return concise Markdown with exactly these sections:
+    ## 🔍 **Possible causes**
+    - 2-4 likely causes grounded in the status, warnings, and logs.
+
+    ## 🛠️ **Actionable fixes**
+    - 2-5 practical next actions.
+    - Include copy-ready kubectl command suggestions in fenced bash blocks when useful.
+    - Commands are suggestions only; the app will not execute them.
+    """
+
+    public static let defaultEventPromptInstructions = """
+    Diagnose these Kubernetes Warning Events for a human operator.
+
+    Return concise Markdown with exactly these sections:
+    ## 🔍 **Possible causes**
+    - 2-4 likely causes grounded only in the Warning Events above.
+
+    ## 🛠️ **Actionable fixes**
+    - 2-5 practical next actions.
+    - Include copy-ready kubectl command suggestions in fenced bash blocks when useful.
+    - Commands are suggestions only; the app will not execute them.
+    """
+
     public let provider: AIProvider
     public var modelID: String
     public let baseURL: String?
+    public let podPromptInstructions: String?
+    public let eventPromptInstructions: String?
 
     public init(
         provider: AIProvider = .openAI,
         modelID: String = "",
-        baseURL: String? = nil
+        baseURL: String? = nil,
+        podPromptInstructions: String? = nil,
+        eventPromptInstructions: String? = nil
     ) {
         self.provider = provider
         self.modelID = modelID
         self.baseURL = baseURL
+        self.podPromptInstructions = Self.normalizedPromptOverride(podPromptInstructions)
+        self.eventPromptInstructions = Self.normalizedPromptOverride(eventPromptInstructions)
+    }
+
+    public var effectivePodPromptInstructions: String {
+        Self.normalizedPromptOverride(podPromptInstructions) ?? Self.defaultPodPromptInstructions
+    }
+
+    public var effectiveEventPromptInstructions: String {
+        Self.normalizedPromptOverride(eventPromptInstructions) ?? Self.defaultEventPromptInstructions
     }
 
     public func with(modelID: String) -> AIDiagnosticAssistantConfig {
         AIDiagnosticAssistantConfig(
             provider: provider,
             modelID: modelID,
-            baseURL: baseURL
+            baseURL: baseURL,
+            podPromptInstructions: podPromptInstructions,
+            eventPromptInstructions: eventPromptInstructions
         )
     }
 
@@ -33,8 +74,49 @@ public struct AIDiagnosticAssistantConfig: Codable, Equatable, Sendable {
         AIDiagnosticAssistantConfig(
             provider: provider,
             modelID: modelID,
-            baseURL: baseURL
+            baseURL: baseURL,
+            podPromptInstructions: podPromptInstructions,
+            eventPromptInstructions: eventPromptInstructions
         )
+    }
+
+    public func with(provider: AIProvider) -> AIDiagnosticAssistantConfig {
+        AIDiagnosticAssistantConfig(
+            provider: provider,
+            modelID: modelID,
+            baseURL: baseURL,
+            podPromptInstructions: podPromptInstructions,
+            eventPromptInstructions: eventPromptInstructions
+        )
+    }
+
+    public func with(podPromptInstructions: String?) -> AIDiagnosticAssistantConfig {
+        AIDiagnosticAssistantConfig(
+            provider: provider,
+            modelID: modelID,
+            baseURL: baseURL,
+            podPromptInstructions: podPromptInstructions,
+            eventPromptInstructions: eventPromptInstructions
+        )
+    }
+
+    public func with(eventPromptInstructions: String?) -> AIDiagnosticAssistantConfig {
+        AIDiagnosticAssistantConfig(
+            provider: provider,
+            modelID: modelID,
+            baseURL: baseURL,
+            podPromptInstructions: podPromptInstructions,
+            eventPromptInstructions: eventPromptInstructions
+        )
+    }
+
+    private static func normalizedPromptOverride(_ prompt: String?) -> String? {
+        let trimmed = prompt?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmed, !trimmed.isEmpty else {
+            return nil
+        }
+
+        return prompt
     }
 }
 

--- a/KubebarCore/Models/AIDiagnosticAssistantState.swift
+++ b/KubebarCore/Models/AIDiagnosticAssistantState.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// UI-facing state for the AI Diagnostic Assistant Settings section.
 ///
-/// Holds the non-secret provider configuration editing fields plus the
-/// transient API key draft and Test Connection result. The API key draft
+/// Holds the non-secret provider configuration and prompt editing fields plus
+/// the transient API key draft and Test Connection result. The API key draft
 /// is never persisted through `AppConfig`; it is saved to the Keychain
 /// credential store only when Settings is saved.
 public struct AIDiagnosticAssistantState: Equatable, Sendable {

--- a/KubebarCore/Models/AIEventDiagnosis.swift
+++ b/KubebarCore/Models/AIEventDiagnosis.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+public struct WarningEventDiagnosticTarget: Equatable, Sendable, Identifiable {
+    public let contextName: String
+    public let namespace: String?
+    public let objectKind: String
+    public let objectName: String
+    public let reason: String
+
+    public var id: String {
+        [contextName, namespace ?? "-", objectKind, objectName, reason]
+            .joined(separator: "|")
+    }
+
+    public init(
+        contextName: String,
+        namespace: String?,
+        objectKind: String,
+        objectName: String,
+        reason: String
+    ) {
+        self.contextName = contextName
+        self.namespace = namespace
+        self.objectKind = objectKind
+        self.objectName = objectName
+        self.reason = reason
+    }
+
+    public static func make(
+        contextName: String,
+        namespace: String?,
+        objectKind: String?,
+        objectName: String?,
+        reason: String
+    ) -> WarningEventDiagnosticTarget? {
+        guard let objectKind = normalized(objectKind), let objectName = normalized(objectName) else {
+            return nil
+        }
+
+        let reason = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !reason.isEmpty else {
+            return nil
+        }
+
+        return WarningEventDiagnosticTarget(
+            contextName: contextName,
+            namespace: normalized(namespace),
+            objectKind: objectKind,
+            objectName: objectName,
+            reason: reason
+        )
+    }
+
+    public func matches(_ event: WarningEventRecord) -> Bool {
+        event.reason == reason &&
+            normalized(event.namespace) == namespace &&
+            normalized(event.objectKind) == objectKind &&
+            normalized(event.objectName) == objectName
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        let text = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let text, !text.isEmpty else {
+            return nil
+        }
+        return text
+    }
+
+    private func normalized(_ value: String?) -> String? {
+        Self.normalized(value)
+    }
+}
+
+public struct AIEventDiagnosticEvent: Equatable, Sendable {
+    public let reason: String
+    public let namespace: String?
+    public let objectKind: String?
+    public let objectName: String?
+    public let message: String?
+    public let observedAt: String?
+    public let count: Int
+
+    public init(
+        reason: String,
+        namespace: String?,
+        objectKind: String?,
+        objectName: String?,
+        message: String?,
+        observedAt: String?,
+        count: Int
+    ) {
+        self.reason = reason
+        self.namespace = namespace
+        self.objectKind = objectKind
+        self.objectName = objectName
+        self.message = message
+        self.observedAt = observedAt
+        self.count = count
+    }
+
+    public init(record: WarningEventRecord) {
+        self.init(
+            reason: record.reason,
+            namespace: record.namespace,
+            objectKind: record.objectKind,
+            objectName: record.objectName,
+            message: record.message,
+            observedAt: record.observedAt.map(Self.isoString),
+            count: max(1, record.count)
+        )
+    }
+
+    private static func isoString(from date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+}
+
+public struct AIEventDiagnosticContext: Equatable, Sendable {
+    public let target: WarningEventDiagnosticTarget
+    public let events: [AIEventDiagnosticEvent]
+    public let isStale: Bool
+
+    public init(target: WarningEventDiagnosticTarget, events: [AIEventDiagnosticEvent], isStale: Bool = false) {
+        self.target = target
+        self.events = events
+        self.isStale = isStale
+    }
+}
+
+public typealias AIEventDiagnosticResult = AIPodDiagnosticResult
+public typealias AIEventDiagnosisState = AIPodDiagnosisState

--- a/KubebarCore/Models/AIPodDiagnosis.swift
+++ b/KubebarCore/Models/AIPodDiagnosis.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+public struct AIPodStatusContext: Equatable, Sendable {
+    public let state: String
+    public let ready: String
+    public let reason: String?
+    public let detail: String?
+
+    public init(state: String, ready: String, reason: String? = nil, detail: String? = nil) {
+        self.state = state
+        self.ready = ready
+        self.reason = reason
+        self.detail = detail
+    }
+}
+
+public struct AIPodWarningContext: Equatable, Sendable {
+    public let reason: String
+    public let location: String
+    public let age: String
+    public let message: String?
+
+    public init(reason: String, location: String, age: String, message: String? = nil) {
+        self.reason = reason
+        self.location = location
+        self.age = age
+        self.message = message
+    }
+}
+
+public struct AIPodDiagnosticContext: Equatable, Sendable {
+    public let target: PodLogTarget
+    public let podStatus: AIPodStatusContext
+    public let warnings: [AIPodWarningContext]
+    public let logLines: [String]
+    public let isStale: Bool
+
+    public init(
+        target: PodLogTarget,
+        podStatus: AIPodStatusContext,
+        warnings: [AIPodWarningContext] = [],
+        logLines: [String] = [],
+        isStale: Bool = false
+    ) {
+        self.target = target
+        self.podStatus = podStatus
+        self.warnings = warnings
+        self.logLines = logLines
+        self.isStale = isStale
+    }
+}
+
+public enum AIPodDiagnosticResult: Equatable, Sendable {
+    case success(markdown: String)
+    case failed(String)
+}
+
+public enum AIPodDiagnosisState: Equatable, Sendable {
+    case idle
+    case loading
+    case success(markdown: String)
+    case failed(String)
+
+    public var isLoading: Bool {
+        if case .loading = self {
+            return true
+        }
+
+        return false
+    }
+}

--- a/KubebarCore/Models/MenuDisplayModel.swift
+++ b/KubebarCore/Models/MenuDisplayModel.swift
@@ -15,6 +15,7 @@ public struct WarningEventDisplay: Equatable, Sendable, Identifiable {
     public let message: String?
     public let fullMessage: String?
     public let isTracked: Bool
+    public let diagnosticTarget: WarningEventDiagnosticTarget?
 
     public var summary: String {
         let base = "\(reason) \(location) \(age)"
@@ -86,7 +87,8 @@ public struct WarningEventDisplay: Equatable, Sendable, Identifiable {
         occurrenceCount: Int,
         message: String?,
         fullMessage: String? = nil,
-        isTracked: Bool = false
+        isTracked: Bool = false,
+        diagnosticTarget: WarningEventDiagnosticTarget? = nil
     ) {
         self.id = id
         self.reason = reason
@@ -96,6 +98,7 @@ public struct WarningEventDisplay: Equatable, Sendable, Identifiable {
         self.message = message
         self.fullMessage = fullMessage ?? message
         self.isTracked = isTracked
+        self.diagnosticTarget = diagnosticTarget
     }
 }
 

--- a/KubebarCore/Models/SetupFlowState.swift
+++ b/KubebarCore/Models/SetupFlowState.swift
@@ -352,12 +352,28 @@ public struct SetupFlowState: Equatable, Sendable {
     }
 
     public mutating func updateAIDiagnosticAssistant(provider: AIProvider) {
-        aiDiagnosticAssistant.config = AIDiagnosticAssistantConfig(
-            provider: provider,
-            modelID: aiDiagnosticAssistant.config.modelID,
-            baseURL: aiDiagnosticAssistant.config.baseURL
-        )
+        aiDiagnosticAssistant.config = aiDiagnosticAssistant.config.with(provider: provider)
         aiDiagnosticAssistant.testConnectionResult = nil
+        configurationMessage = nil
+    }
+
+    public mutating func updateAIPodDiagnosticPromptInstructions(_ instructions: String) {
+        aiDiagnosticAssistant.config = aiDiagnosticAssistant.config.with(podPromptInstructions: instructions)
+        configurationMessage = nil
+    }
+
+    public mutating func updateAIEventDiagnosticPromptInstructions(_ instructions: String) {
+        aiDiagnosticAssistant.config = aiDiagnosticAssistant.config.with(eventPromptInstructions: instructions)
+        configurationMessage = nil
+    }
+
+    public mutating func resetAIPodDiagnosticPromptInstructions() {
+        aiDiagnosticAssistant.config = aiDiagnosticAssistant.config.with(podPromptInstructions: nil)
+        configurationMessage = nil
+    }
+
+    public mutating func resetAIEventDiagnosticPromptInstructions() {
+        aiDiagnosticAssistant.config = aiDiagnosticAssistant.config.with(eventPromptInstructions: nil)
         configurationMessage = nil
     }
 

--- a/KubebarCore/Services/AIDiagnosticResponseFormatter.swift
+++ b/KubebarCore/Services/AIDiagnosticResponseFormatter.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Cleans raw AI provider responses before they reach the UI.
+///
+/// Some OpenAI-compatible reasoning models (DeepSeek-R1, Qwen-QwQ, GLM-Zero,
+/// and similar) emit an intermediate reasoning trace wrapped in `<think>…</think>`
+/// blocks before the final answer. Other models leave trailing prose before the
+/// first Markdown heading. This formatter strips both so the diagnosis panel
+/// shows only the structured answer, never the model's internal monologue.
+public enum AIDiagnosticResponseFormatter {
+    /// Returns a compact Markdown string with reasoning blocks and leading
+    /// chatter removed. Empty input yields an empty string.
+    public static func cleanedMarkdown(from raw: String) -> String {
+        let withoutThink = stripThinkBlocks(from: raw)
+        let trimmedPreamble = stripLeadingPreamble(from: withoutThink)
+        return collapseBlankLines(trimmedPreamble)
+    }
+
+    /// Removes every complete `<think>…</think>` block and, if a block is never
+    /// closed, drops everything from the opening tag to the end of the response.
+    static func stripThinkBlocks(from raw: String) -> String {
+        var remaining = raw
+        var output = ""
+
+        while let openRange = remaining.range(of: "<think>", options: [.caseInsensitive]) {
+            output += remaining[remaining.startIndex..<openRange.lowerBound]
+
+            let afterOpen = openRange.upperBound
+            if let closeRange = remaining.range(of: "</think>", options: [.caseInsensitive], range: afterOpen..<remaining.endIndex) {
+                remaining = String(remaining[closeRange.upperBound...])
+            } else {
+                // Unmatched opening tag: drop the rest of the response.
+                remaining = ""
+            }
+        }
+
+        output += remaining
+        return output
+    }
+
+    /// Drops any non-heading lines that appear before the first Markdown heading
+    /// (a line starting with `#`). If no heading exists, the text is kept as-is
+    /// so short freeform answers still render.
+    static func stripLeadingPreamble(from raw: String) -> String {
+        let lines = raw.split(separator: "\n", omittingEmptySubsequences: false)
+        var firstHeading = lines.count
+
+        for (index, line) in lines.enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("#") {
+                firstHeading = index
+                break
+            }
+        }
+
+        guard firstHeading < lines.count else {
+            return raw
+        }
+
+        return lines[firstHeading...].joined(separator: "\n")
+    }
+
+    /// Collapses runs of two or more blank lines into a single blank line and
+    /// trims leading/trailing whitespace from the whole string.
+    static func collapseBlankLines(_ raw: String) -> String {
+        let lines = raw.split(separator: "\n", omittingEmptySubsequences: false)
+        var result: [String] = []
+        var previousBlank = false
+
+        for line in lines {
+            let isBlank = line.trimmingCharacters(in: .whitespaces).isEmpty
+
+            if isBlank {
+                if previousBlank {
+                    continue
+                }
+                previousBlank = true
+            } else {
+                previousBlank = false
+            }
+
+            result.append(String(line))
+        }
+
+        while result.last?.trimmingCharacters(in: .whitespaces).isEmpty == true {
+            result.removeLast()
+        }
+
+        while result.first?.trimmingCharacters(in: .whitespaces).isEmpty == true {
+            result.removeFirst()
+        }
+
+        return result.joined(separator: "\n")
+    }
+}

--- a/KubebarCore/Services/AIEventDiagnosticRequester.swift
+++ b/KubebarCore/Services/AIEventDiagnosticRequester.swift
@@ -66,23 +66,31 @@ public struct AIEventDiagnosticRequester: Sendable {
         apiKey: String,
         context: AIEventDiagnosticContext
     ) -> URLRequest? {
+        let promptInstructions = config.effectiveEventPromptInstructions
         switch provider {
         case .openAI:
             return chatCompletionsRequest(
                 url: "https://api.openai.com/v1/chat/completions",
                 apiKey: apiKey,
                 model: config.modelID,
-                context: context
+                context: context,
+                promptInstructions: promptInstructions
             )
         case .anthropic:
             return anthropicRequest(
                 url: "https://api.anthropic.com/v1/messages",
                 apiKey: apiKey,
                 model: config.modelID,
-                context: context
+                context: context,
+                promptInstructions: promptInstructions
             )
         case .gemini:
-            return geminiRequest(model: config.modelID, apiKey: apiKey, context: context)
+            return geminiRequest(
+                model: config.modelID,
+                apiKey: apiKey,
+                context: context,
+                promptInstructions: promptInstructions
+            )
         case .openAICompatible:
             guard let baseURL = config.baseURL?.trimmingCharacters(in: .whitespacesAndNewlines), !baseURL.isEmpty else {
                 return nil
@@ -92,7 +100,8 @@ public struct AIEventDiagnosticRequester: Sendable {
                 url: "\(normalized)/chat/completions",
                 apiKey: apiKey,
                 model: config.modelID,
-                context: context
+                context: context,
+                promptInstructions: promptInstructions
             )
         }
     }
@@ -101,7 +110,8 @@ public struct AIEventDiagnosticRequester: Sendable {
         url: String,
         apiKey: String,
         model: String,
-        context: AIEventDiagnosticContext
+        context: AIEventDiagnosticContext,
+        promptInstructions: String
     ) -> URLRequest? {
         guard let url = URL(string: url) else { return nil }
         var request = URLRequest(url: url, timeoutInterval: 45)
@@ -113,7 +123,7 @@ public struct AIEventDiagnosticRequester: Sendable {
             "model": model,
             "messages": [
                 ["role": "system", "content": Self.systemPrompt],
-                ["role": "user", "content": diagnosticPrompt(from: context)]
+                ["role": "user", "content": diagnosticPrompt(from: context, promptInstructions: promptInstructions)]
             ],
             "temperature": 0.2,
             "max_tokens": 900
@@ -126,7 +136,8 @@ public struct AIEventDiagnosticRequester: Sendable {
         url: String,
         apiKey: String,
         model: String,
-        context: AIEventDiagnosticContext
+        context: AIEventDiagnosticContext,
+        promptInstructions: String
     ) -> URLRequest? {
         guard let url = URL(string: url) else { return nil }
         var request = URLRequest(url: url, timeoutInterval: 45)
@@ -139,13 +150,18 @@ public struct AIEventDiagnosticRequester: Sendable {
             "model": model,
             "system": Self.systemPrompt,
             "max_tokens": 900,
-            "messages": [["role": "user", "content": diagnosticPrompt(from: context)]]
+            "messages": [["role": "user", "content": diagnosticPrompt(from: context, promptInstructions: promptInstructions)]]
         ]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
         return request
     }
 
-    private func geminiRequest(model: String, apiKey: String, context: AIEventDiagnosticContext) -> URLRequest? {
+    private func geminiRequest(
+        model: String,
+        apiKey: String,
+        context: AIEventDiagnosticContext,
+        promptInstructions: String
+    ) -> URLRequest? {
         guard let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent") else {
             return nil
         }
@@ -156,7 +172,7 @@ public struct AIEventDiagnosticRequester: Sendable {
 
         let body: [String: Any] = [
             "contents": [[
-                "parts": [["text": "\(Self.systemPrompt)\n\n\(diagnosticPrompt(from: context))"]]
+                "parts": [["text": "\(Self.systemPrompt)\n\n\(diagnosticPrompt(from: context, promptInstructions: promptInstructions))"]]
             ]],
             "generationConfig": [
                 "temperature": 0.2,
@@ -167,7 +183,7 @@ public struct AIEventDiagnosticRequester: Sendable {
         return request
     }
 
-    private func diagnosticPrompt(from context: AIEventDiagnosticContext) -> String {
+    private func diagnosticPrompt(from context: AIEventDiagnosticContext, promptInstructions: String) -> String {
         let eventText = context.events
             .suffix(5)
             .enumerated()
@@ -186,8 +202,10 @@ public struct AIEventDiagnosticRequester: Sendable {
         let staleText = context.isStale ? "stale" : "fresh"
 
         return """
-        Diagnose these Kubernetes Warning Events for a human operator.
+        Prompt instructions:
+        \(promptInstructions)
 
+        Kubernetes diagnostic context supplied by Kubebar:
         Target warning group:
         - Context: \(context.target.contextName)
         - Namespace: \(context.target.namespace ?? "none")
@@ -199,13 +217,8 @@ public struct AIEventDiagnosticRequester: Sendable {
         Latest matching Warning Events, capped at 5 and redacted before submission:
         \(eventText.isEmpty ? "- No matching warning events returned" : eventText)
 
-        Return concise Markdown with exactly these sections:
-        ## 🔍 **Possible causes**
-        - 2-4 likely causes grounded only in the Warning Events above.
-
-        ## 🛠️ **Actionable fixes**
-        - 2-5 practical next actions.
-        - Include copy-ready kubectl command suggestions in fenced bash blocks when useful.
+        Safety reminders:
+        - Use only the supplied event context above.
         - Commands are suggestions only; the app will not execute them.
         """
     }

--- a/KubebarCore/Services/AIEventDiagnosticRequester.swift
+++ b/KubebarCore/Services/AIEventDiagnosticRequester.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct AIPodDiagnosticRequester: Sendable {
+public struct AIEventDiagnosticRequester: Sendable {
     public static let transportFailureMessage = "Could not reach the AI provider. Check your network and Base URL."
     public static let unreadableResponseMessage = "Could not read the AI diagnosis. Try again later."
 
@@ -13,10 +13,10 @@ public struct AIPodDiagnosticRequester: Sendable {
     }
 
     public func diagnose(
-        context: AIPodDiagnosticContext,
+        context: AIEventDiagnosticContext,
         config: AIDiagnosticAssistantConfig,
         provider: AIProvider
-    ) async -> AIPodDiagnosticResult {
+    ) async -> AIEventDiagnosticResult {
         guard !config.modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return .failed(AIProviderConnectionTester.missingModelIDMessage)
         }
@@ -64,7 +64,7 @@ public struct AIPodDiagnosticRequester: Sendable {
         config: AIDiagnosticAssistantConfig,
         provider: AIProvider,
         apiKey: String,
-        context: AIPodDiagnosticContext
+        context: AIEventDiagnosticContext
     ) -> URLRequest? {
         switch provider {
         case .openAI:
@@ -101,7 +101,7 @@ public struct AIPodDiagnosticRequester: Sendable {
         url: String,
         apiKey: String,
         model: String,
-        context: AIPodDiagnosticContext
+        context: AIEventDiagnosticContext
     ) -> URLRequest? {
         guard let url = URL(string: url) else { return nil }
         var request = URLRequest(url: url, timeoutInterval: 45)
@@ -126,7 +126,7 @@ public struct AIPodDiagnosticRequester: Sendable {
         url: String,
         apiKey: String,
         model: String,
-        context: AIPodDiagnosticContext
+        context: AIEventDiagnosticContext
     ) -> URLRequest? {
         guard let url = URL(string: url) else { return nil }
         var request = URLRequest(url: url, timeoutInterval: 45)
@@ -145,7 +145,7 @@ public struct AIPodDiagnosticRequester: Sendable {
         return request
     }
 
-    private func geminiRequest(model: String, apiKey: String, context: AIPodDiagnosticContext) -> URLRequest? {
+    private func geminiRequest(model: String, apiKey: String, context: AIEventDiagnosticContext) -> URLRequest? {
         guard let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent") else {
             return nil
         }
@@ -167,42 +167,41 @@ public struct AIPodDiagnosticRequester: Sendable {
         return request
     }
 
-    private func diagnosticPrompt(from context: AIPodDiagnosticContext) -> String {
-        let warningText = context.warnings.prefix(3).map { warning in
-            "- \(warning.reason) \(warning.location) \(warning.age): \(warning.message ?? "No message")"
-        }.joined(separator: "\n")
-        let logs = context.logLines
-            .suffix(50)
-            .map(AIDiagnosticRedactor.redact)
+    private func diagnosticPrompt(from context: AIEventDiagnosticContext) -> String {
+        let eventText = context.events
+            .suffix(5)
+            .enumerated()
+            .map { index, event in
+                """
+                Event \(index + 1):
+                - Reason: \(event.reason)
+                - Namespace: \(event.namespace ?? "none")
+                - Object: \(event.objectKind ?? "unknown")/\(event.objectName ?? "unknown")
+                - Observed at: \(event.observedAt ?? "unknown")
+                - Count: \(event.count)
+                - Message: \(AIDiagnosticRedactor.redact(event.message ?? "No message"))
+                """
+            }
             .joined(separator: "\n")
         let staleText = context.isStale ? "stale" : "fresh"
 
         return """
-        Diagnose this Kubernetes Pod for a human operator.
+        Diagnose these Kubernetes Warning Events for a human operator.
 
-        Target:
+        Target warning group:
         - Context: \(context.target.contextName)
-        - Namespace: \(context.target.namespace)
-        - Pod: \(context.target.podName)
+        - Namespace: \(context.target.namespace ?? "none")
+        - Object kind: \(context.target.objectKind)
+        - Object name: \(context.target.objectName)
+        - Reason: \(context.target.reason)
         - Snapshot freshness: \(staleText)
 
-        Current Pod status:
-        - State: \(context.podStatus.state)
-        - Ready: \(context.podStatus.ready)
-        - Reason: \(context.podStatus.reason ?? "unknown")
-        - Detail: \(context.podStatus.detail ?? "none")
-
-        Latest warning summaries, capped at 3:
-        \(warningText.isEmpty ? "- No related warning summaries available" : warningText)
-
-        Last 50 log lines, redacted before submission:
-        ```text
-        \(logs.isEmpty ? "No recent log lines returned" : logs)
-        ```
+        Latest matching Warning Events, capped at 5 and redacted before submission:
+        \(eventText.isEmpty ? "- No matching warning events returned" : eventText)
 
         Return concise Markdown with exactly these sections:
         ## 🔍 **Possible causes**
-        - 2-4 likely causes grounded in the status, warnings, and logs.
+        - 2-4 likely causes grounded only in the Warning Events above.
 
         ## 🛠️ **Actionable fixes**
         - 2-5 practical next actions.
@@ -249,27 +248,5 @@ public struct AIPodDiagnosticRequester: Sendable {
         }
     }
 
-    private static let systemPrompt = "You are a concise Kubernetes incident assistant. Use only the provided context. Do not claim you executed commands."
-}
-
-public enum AIDiagnosticRedactor {
-    public static func redact(_ text: String) -> String {
-        var redacted = text
-        let replacements: [(String, String)] = [
-            (#"(?i)(authorization\s*[:=]\s*bearer\s+)[^\s,;]+"#, "$1[REDACTED]"),
-            (#"(?i)(bearer\s+)[A-Za-z0-9._\-]+"#, "$1[REDACTED]"),
-            (#"(?i)((?:api[_-]?key|token|password|passwd|secret)\s*[:=]\s*)[^\s,;]+"#, "$1[REDACTED]"),
-            (#"(?i)(x-api-key\s*[:=]\s*)[^\s,;]+"#, "$1[REDACTED]")
-        ]
-
-        for (pattern, replacement) in replacements {
-            redacted = redacted.replacingOccurrences(
-                of: pattern,
-                with: replacement,
-                options: .regularExpression
-            )
-        }
-
-        return redacted
-    }
+    private static let systemPrompt = "You are a concise Kubernetes incident assistant. Use only the provided event context. Do not claim you executed commands."
 }

--- a/KubebarCore/Services/AIPodDiagnosticRequester.swift
+++ b/KubebarCore/Services/AIPodDiagnosticRequester.swift
@@ -1,0 +1,270 @@
+import Foundation
+
+public struct AIPodDiagnosticRequester: Sendable {
+    public static let transportFailureMessage = "Could not reach the AI provider. Check your network and Base URL."
+    public static let unreadableResponseMessage = "Could not read the AI diagnosis. Try again later."
+
+    private let credentialStore: any AIProviderCredentialStoring
+    private let httpClient: any HTTPClient
+
+    public init(credentialStore: any AIProviderCredentialStoring, httpClient: any HTTPClient) {
+        self.credentialStore = credentialStore
+        self.httpClient = httpClient
+    }
+
+    public func diagnose(
+        context: AIPodDiagnosticContext,
+        config: AIDiagnosticAssistantConfig,
+        provider: AIProvider
+    ) async -> AIPodDiagnosticResult {
+        guard !config.modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .failed(AIProviderConnectionTester.missingModelIDMessage)
+        }
+
+        let apiKey: String
+        do {
+            guard let stored = try credentialStore.loadAPIKey(for: provider), !stored.isEmpty else {
+                return .failed(AIProviderConnectionTester.missingAPIKeyMessage)
+            }
+            apiKey = stored
+        } catch {
+            return .failed(AIProviderConnectionTester.credentialStoreErrorMessage)
+        }
+
+        guard let request = buildRequest(config: config, provider: provider, apiKey: apiKey, context: context) else {
+            return .failed(AIProviderConnectionTester.missingBaseURLMessage)
+        }
+
+        do {
+            let (data, response) = try await httpClient.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return .failed(Self.unreadableResponseMessage)
+            }
+
+            guard (200..<300).contains(http.statusCode) else {
+                return .failed(resultMessage(for: http.statusCode))
+            }
+
+            guard let markdown = markdown(from: data, provider: provider), !markdown.isEmpty else {
+                return .failed(Self.unreadableResponseMessage)
+            }
+
+            return .success(markdown: markdown)
+        } catch {
+            return .failed(Self.transportFailureMessage)
+        }
+    }
+
+    private func buildRequest(
+        config: AIDiagnosticAssistantConfig,
+        provider: AIProvider,
+        apiKey: String,
+        context: AIPodDiagnosticContext
+    ) -> URLRequest? {
+        switch provider {
+        case .openAI:
+            return chatCompletionsRequest(
+                url: "https://api.openai.com/v1/chat/completions",
+                apiKey: apiKey,
+                model: config.modelID,
+                context: context
+            )
+        case .anthropic:
+            return anthropicRequest(
+                url: "https://api.anthropic.com/v1/messages",
+                apiKey: apiKey,
+                model: config.modelID,
+                context: context
+            )
+        case .gemini:
+            return geminiRequest(model: config.modelID, apiKey: apiKey, context: context)
+        case .openAICompatible:
+            guard let baseURL = config.baseURL?.trimmingCharacters(in: .whitespacesAndNewlines), !baseURL.isEmpty else {
+                return nil
+            }
+            let normalized = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
+            return chatCompletionsRequest(
+                url: "\(normalized)/chat/completions",
+                apiKey: apiKey,
+                model: config.modelID,
+                context: context
+            )
+        }
+    }
+
+    private func chatCompletionsRequest(
+        url: String,
+        apiKey: String,
+        model: String,
+        context: AIPodDiagnosticContext
+    ) -> URLRequest? {
+        guard let url = URL(string: url) else { return nil }
+        var request = URLRequest(url: url, timeoutInterval: 45)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "system", "content": Self.systemPrompt],
+                ["role": "user", "content": diagnosticPrompt(from: context)]
+            ],
+            "temperature": 0.2,
+            "max_tokens": 900
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private func anthropicRequest(
+        url: String,
+        apiKey: String,
+        model: String,
+        context: AIPodDiagnosticContext
+    ) -> URLRequest? {
+        guard let url = URL(string: url) else { return nil }
+        var request = URLRequest(url: url, timeoutInterval: 45)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+
+        let body: [String: Any] = [
+            "model": model,
+            "system": Self.systemPrompt,
+            "max_tokens": 900,
+            "messages": [["role": "user", "content": diagnosticPrompt(from: context)]]
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private func geminiRequest(model: String, apiKey: String, context: AIPodDiagnosticContext) -> URLRequest? {
+        guard let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent") else {
+            return nil
+        }
+        var request = URLRequest(url: url, timeoutInterval: 45)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+
+        let body: [String: Any] = [
+            "contents": [[
+                "parts": [["text": "\(Self.systemPrompt)\n\n\(diagnosticPrompt(from: context))"]]
+            ]],
+            "generationConfig": [
+                "temperature": 0.2,
+                "maxOutputTokens": 900
+            ]
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    private func diagnosticPrompt(from context: AIPodDiagnosticContext) -> String {
+        let warningText = context.warnings.prefix(3).map { warning in
+            "- \(warning.reason) \(warning.location) \(warning.age): \(warning.message ?? "No message")"
+        }.joined(separator: "\n")
+        let logs = context.logLines
+            .suffix(50)
+            .map(AIDiagnosticRedactor.redact)
+            .joined(separator: "\n")
+        let staleText = context.isStale ? "stale" : "fresh"
+
+        return """
+        Diagnose this Kubernetes Pod for a human operator.
+
+        Target:
+        - Context: \(context.target.contextName)
+        - Namespace: \(context.target.namespace)
+        - Pod: \(context.target.podName)
+        - Snapshot freshness: \(staleText)
+
+        Current Pod status:
+        - State: \(context.podStatus.state)
+        - Ready: \(context.podStatus.ready)
+        - Reason: \(context.podStatus.reason ?? "unknown")
+        - Detail: \(context.podStatus.detail ?? "none")
+
+        Latest warning summaries, capped at 3:
+        \(warningText.isEmpty ? "- No related warning summaries available" : warningText)
+
+        Last 50 log lines, redacted before submission:
+        ```text
+        \(logs.isEmpty ? "No recent log lines returned" : logs)
+        ```
+
+        Return concise Markdown with exactly these sections:
+        ## 🔍 **Possible causes**
+        - 2-4 likely causes grounded in the status, warnings, and logs.
+
+        ## 🛠️ **Actionable fixes**
+        - 2-5 practical next actions.
+        - Include copy-ready kubectl command suggestions in fenced bash blocks when useful.
+        - Commands are suggestions only; the app will not execute them.
+        """
+    }
+
+    private func resultMessage(for statusCode: Int) -> String {
+        switch statusCode {
+        case 401, 403:
+            "Authentication failed. Check your API key."
+        case 400..<500:
+            "AI diagnosis request failed (HTTP \(statusCode))."
+        default:
+            "AI provider error (HTTP \(statusCode)). Try again later."
+        }
+    }
+
+    private func markdown(from data: Data, provider: AIProvider) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        switch provider {
+        case .openAI, .openAICompatible:
+            let choices = object["choices"] as? [[String: Any]]
+            let message = choices?.first?["message"] as? [String: Any]
+            return (message?["content"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        case .anthropic:
+            let content = object["content"] as? [[String: Any]]
+            let text = content?
+                .compactMap { $0["text"] as? String }
+                .joined(separator: "\n")
+            return text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        case .gemini:
+            let candidates = object["candidates"] as? [[String: Any]]
+            let content = candidates?.first?["content"] as? [String: Any]
+            let parts = content?["parts"] as? [[String: Any]]
+            let text = parts?
+                .compactMap { $0["text"] as? String }
+                .joined(separator: "\n")
+            return text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    private static let systemPrompt = "You are a concise Kubernetes incident assistant. Use only the provided context. Do not claim you executed commands."
+}
+
+public enum AIDiagnosticRedactor {
+    public static func redact(_ text: String) -> String {
+        var redacted = text
+        let replacements: [(String, String)] = [
+            (#"(?i)(authorization\s*[:=]\s*bearer\s+)[^\s,;]+"#, "$1[REDACTED]"),
+            (#"(?i)(bearer\s+)[A-Za-z0-9._\-]+"#, "$1[REDACTED]"),
+            (#"(?i)((?:api[_-]?key|token|password|passwd|secret)\s*[:=]\s*)[^\s,;]+"#, "$1[REDACTED]"),
+            (#"(?i)(x-api-key\s*[:=]\s*)[^\s,;]+"#, "$1[REDACTED]")
+        ]
+
+        for (pattern, replacement) in replacements {
+            redacted = redacted.replacingOccurrences(
+                of: pattern,
+                with: replacement,
+                options: .regularExpression
+            )
+        }
+
+        return redacted
+    }
+}

--- a/KubebarCore/Services/AIPodDiagnosticRequester.swift
+++ b/KubebarCore/Services/AIPodDiagnosticRequester.swift
@@ -66,23 +66,31 @@ public struct AIPodDiagnosticRequester: Sendable {
         apiKey: String,
         context: AIPodDiagnosticContext
     ) -> URLRequest? {
+        let promptInstructions = config.effectivePodPromptInstructions
         switch provider {
         case .openAI:
             return chatCompletionsRequest(
                 url: "https://api.openai.com/v1/chat/completions",
                 apiKey: apiKey,
                 model: config.modelID,
-                context: context
+                context: context,
+                promptInstructions: promptInstructions
             )
         case .anthropic:
             return anthropicRequest(
                 url: "https://api.anthropic.com/v1/messages",
                 apiKey: apiKey,
                 model: config.modelID,
-                context: context
+                context: context,
+                promptInstructions: promptInstructions
             )
         case .gemini:
-            return geminiRequest(model: config.modelID, apiKey: apiKey, context: context)
+            return geminiRequest(
+                model: config.modelID,
+                apiKey: apiKey,
+                context: context,
+                promptInstructions: promptInstructions
+            )
         case .openAICompatible:
             guard let baseURL = config.baseURL?.trimmingCharacters(in: .whitespacesAndNewlines), !baseURL.isEmpty else {
                 return nil
@@ -92,7 +100,8 @@ public struct AIPodDiagnosticRequester: Sendable {
                 url: "\(normalized)/chat/completions",
                 apiKey: apiKey,
                 model: config.modelID,
-                context: context
+                context: context,
+                promptInstructions: promptInstructions
             )
         }
     }
@@ -101,7 +110,8 @@ public struct AIPodDiagnosticRequester: Sendable {
         url: String,
         apiKey: String,
         model: String,
-        context: AIPodDiagnosticContext
+        context: AIPodDiagnosticContext,
+        promptInstructions: String
     ) -> URLRequest? {
         guard let url = URL(string: url) else { return nil }
         var request = URLRequest(url: url, timeoutInterval: 45)
@@ -113,7 +123,7 @@ public struct AIPodDiagnosticRequester: Sendable {
             "model": model,
             "messages": [
                 ["role": "system", "content": Self.systemPrompt],
-                ["role": "user", "content": diagnosticPrompt(from: context)]
+                ["role": "user", "content": diagnosticPrompt(from: context, promptInstructions: promptInstructions)]
             ],
             "temperature": 0.2,
             "max_tokens": 900
@@ -126,7 +136,8 @@ public struct AIPodDiagnosticRequester: Sendable {
         url: String,
         apiKey: String,
         model: String,
-        context: AIPodDiagnosticContext
+        context: AIPodDiagnosticContext,
+        promptInstructions: String
     ) -> URLRequest? {
         guard let url = URL(string: url) else { return nil }
         var request = URLRequest(url: url, timeoutInterval: 45)
@@ -139,13 +150,18 @@ public struct AIPodDiagnosticRequester: Sendable {
             "model": model,
             "system": Self.systemPrompt,
             "max_tokens": 900,
-            "messages": [["role": "user", "content": diagnosticPrompt(from: context)]]
+            "messages": [["role": "user", "content": diagnosticPrompt(from: context, promptInstructions: promptInstructions)]]
         ]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
         return request
     }
 
-    private func geminiRequest(model: String, apiKey: String, context: AIPodDiagnosticContext) -> URLRequest? {
+    private func geminiRequest(
+        model: String,
+        apiKey: String,
+        context: AIPodDiagnosticContext,
+        promptInstructions: String
+    ) -> URLRequest? {
         guard let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent") else {
             return nil
         }
@@ -156,7 +172,7 @@ public struct AIPodDiagnosticRequester: Sendable {
 
         let body: [String: Any] = [
             "contents": [[
-                "parts": [["text": "\(Self.systemPrompt)\n\n\(diagnosticPrompt(from: context))"]]
+                "parts": [["text": "\(Self.systemPrompt)\n\n\(diagnosticPrompt(from: context, promptInstructions: promptInstructions))"]]
             ]],
             "generationConfig": [
                 "temperature": 0.2,
@@ -167,7 +183,7 @@ public struct AIPodDiagnosticRequester: Sendable {
         return request
     }
 
-    private func diagnosticPrompt(from context: AIPodDiagnosticContext) -> String {
+    private func diagnosticPrompt(from context: AIPodDiagnosticContext, promptInstructions: String) -> String {
         let warningText = context.warnings.prefix(3).map { warning in
             "- \(warning.reason) \(warning.location) \(warning.age): \(warning.message ?? "No message")"
         }.joined(separator: "\n")
@@ -178,8 +194,10 @@ public struct AIPodDiagnosticRequester: Sendable {
         let staleText = context.isStale ? "stale" : "fresh"
 
         return """
-        Diagnose this Kubernetes Pod for a human operator.
+        Prompt instructions:
+        \(promptInstructions)
 
+        Kubernetes diagnostic context supplied by Kubebar:
         Target:
         - Context: \(context.target.contextName)
         - Namespace: \(context.target.namespace)
@@ -200,13 +218,8 @@ public struct AIPodDiagnosticRequester: Sendable {
         \(logs.isEmpty ? "No recent log lines returned" : logs)
         ```
 
-        Return concise Markdown with exactly these sections:
-        ## 🔍 **Possible causes**
-        - 2-4 likely causes grounded in the status, warnings, and logs.
-
-        ## 🛠️ **Actionable fixes**
-        - 2-5 practical next actions.
-        - Include copy-ready kubectl command suggestions in fenced bash blocks when useful.
+        Safety reminders:
+        - Use only the supplied context above.
         - Commands are suggestions only; the app will not execute them.
         """
     }

--- a/KubebarCore/Services/HealthEvaluator.swift
+++ b/KubebarCore/Services/HealthEvaluator.swift
@@ -89,12 +89,14 @@ public struct HealthEvaluator: Sendable {
         let pinnedWarningIDs = pinnedWarningIDs(from: snapshot.trackedItems)
         let warningEventSummaries = makeWarningEventSummaries(
             from: snapshot.warningEventsSection.value ?? [],
+            contextName: snapshot.contextName,
             now: now,
             pinnedWarningIDs: [],
             limit: warningEventSummaryLimit
         )
         let overviewWarningRows = makeWarningEventSummaries(
             from: snapshot.warningEventsSection.value ?? [],
+            contextName: snapshot.contextName,
             now: now,
             pinnedWarningIDs: pinnedWarningIDs,
             limit: Int.max
@@ -1175,7 +1177,7 @@ public struct HealthEvaluator: Sendable {
                 reason: item.reason,
                 affectedPodCount: item.affectedPodCount,
                 examplePodNames: Array(item.examplePodNames.prefix(3)),
-                latestWarning: item.latestWarning.map { makeWarningEventDisplay(from: $0, now: now) }
+                latestWarning: item.latestWarning.map { makeWarningEventDisplay(from: $0, contextName: contextName, now: now) }
             ),
             k9sHandoff: resourceHandoff(
                 contextName: contextName,
@@ -1196,6 +1198,7 @@ public struct HealthEvaluator: Sendable {
 
     private func makeWarningEventSummaries(
         from warningEvents: [WarningEventRecord],
+        contextName: String,
         now: Date,
         pinnedWarningIDs: Set<String>,
         limit: Int
@@ -1248,7 +1251,14 @@ public struct HealthEvaluator: Sendable {
                     occurrenceCount: group.occurrenceCount,
                     message: shortenedWarningMessage(fullMessage),
                     fullMessage: fullMessage,
-                    isTracked: isTracked
+                    isTracked: isTracked,
+                    diagnosticTarget: WarningEventDiagnosticTarget.make(
+                        contextName: contextName,
+                        namespace: group.key.namespace,
+                        objectKind: group.key.objectKind,
+                        objectName: group.key.objectName,
+                        reason: group.reason
+                    )
                 )
             }
     }
@@ -1259,7 +1269,7 @@ public struct HealthEvaluator: Sendable {
         })
     }
 
-    private func makeWarningEventDisplay(from event: WarningEventRecord, now: Date) -> WarningEventDisplay {
+    private func makeWarningEventDisplay(from event: WarningEventRecord, contextName: String, now: Date) -> WarningEventDisplay {
         WarningEventDisplay(
             id: WarningEventGroupKey(event: event).id,
             reason: event.reason,
@@ -1271,7 +1281,14 @@ public struct HealthEvaluator: Sendable {
             age: warningAge(from: event.observedAt, to: now),
             occurrenceCount: max(1, event.count),
             message: shortenedWarningMessage(event.message),
-            fullMessage: normalizedText(event.message)
+            fullMessage: normalizedText(event.message),
+            diagnosticTarget: WarningEventDiagnosticTarget.make(
+                contextName: contextName,
+                namespace: event.namespace,
+                objectKind: event.objectKind,
+                objectName: event.objectName,
+                reason: event.reason
+            )
         )
     }
 

--- a/KubebarCore/Services/PodDiagnosticLogReader.swift
+++ b/KubebarCore/Services/PodDiagnosticLogReader.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+public struct PodDiagnosticLogReadRequest: Equatable, Sendable {
+    public let target: PodLogTarget
+    public let tailLineCount: Int
+    public let command: CommandRequest
+
+    public init(
+        target: PodLogTarget,
+        config: AppConfig,
+        tailLineCount: Int = 50,
+        kubectlEnvironment: KubectlEnvironment? = nil
+    ) {
+        self.target = target
+        self.tailLineCount = tailLineCount
+        let environment = kubectlEnvironment ?? KubectlEnvironment(config: config)
+        self.command = CommandRequest(
+            executable: "kubectl",
+            arguments: [
+                "--context", target.contextName,
+                "logs",
+                "--tail=\(tailLineCount)",
+                "-n", target.namespace,
+                target.podName
+            ],
+            environmentOverrides: environment.environmentOverrides,
+            timeoutSeconds: 10
+        )
+    }
+
+    init(target: PodLogTarget, tailLineCount: Int = 50, command: CommandRequest) {
+        self.target = target
+        self.tailLineCount = tailLineCount
+        self.command = command
+    }
+}
+
+public enum PodDiagnosticLogReadError: Error, Equatable, Sendable {
+    case launchFailed
+    case timedOut
+    case commandFailed(String)
+}
+
+extension PodDiagnosticLogReadError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .launchFailed:
+            "kubectl logs failed to launch"
+        case .timedOut:
+            "kubectl logs timed out"
+        case let .commandFailed(message):
+            message
+        }
+    }
+}
+
+public protocol PodDiagnosticLogReading: Sendable {
+    func readLogs(for request: PodDiagnosticLogReadRequest) async throws -> [String]
+}
+
+public struct CommandPodDiagnosticLogReader: PodDiagnosticLogReading, Sendable {
+    private let runner: any CommandRunning
+
+    public init(runner: any CommandRunning = ProcessCommandRunner()) {
+        self.runner = runner
+    }
+
+    public func readLogs(for request: PodDiagnosticLogReadRequest) async throws -> [String] {
+        let runner = runner
+        return try await Task.detached(priority: .userInitiated) {
+            do {
+                let result = try runner.run(request.command)
+                guard result.exitCode == 0 else {
+                    throw PodDiagnosticLogReadError.commandFailed(
+                        Self.safeFailureDetail(from: result.stderr)
+                    )
+                }
+
+                return Self.lastLines(from: result.stdout, limit: request.tailLineCount)
+            } catch CommandRunnerError.launchFailed {
+                throw PodDiagnosticLogReadError.launchFailed
+            } catch CommandRunnerError.timedOut {
+                throw PodDiagnosticLogReadError.timedOut
+            }
+        }.value
+    }
+
+    private static func lastLines(from output: String, limit: Int) -> [String] {
+        let lines = output
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        let trimmedLines = lines.last == "" ? lines.dropLast() : ArraySlice(lines)
+        return Array(trimmedLines.suffix(max(1, limit)))
+    }
+
+    private static func safeFailureDetail(from stderr: String) -> String {
+        let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return "kubectl logs failed"
+        }
+
+        if let range = trimmed.range(of: "): ") {
+            return String(trimmed[range.upperBound...])
+        }
+
+        return trimmed
+    }
+}

--- a/KubebarCore/Services/PodLogStreamer.swift
+++ b/KubebarCore/Services/PodLogStreamer.swift
@@ -245,6 +245,17 @@ public final class ProcessPodLogStreamer: PodLogStreaming, @unchecked Sendable {
                 stdout.fileHandleForReading.readabilityHandler = nil
                 stderr.fileHandleForReading.readabilityHandler = nil
                 terminatedProcess.terminationHandler = nil
+
+                let remainingStdout = stdout.fileHandleForReading.readDataToEndOfFile()
+                if let chunk = String(data: remainingStdout, encoding: .utf8), !chunk.isEmpty {
+                    continuation.yield(chunk)
+                }
+
+                let remainingStderr = stderr.fileHandleForReading.readDataToEndOfFile()
+                if !remainingStderr.isEmpty {
+                    processBox.appendStderr(remainingStderr)
+                }
+
                 processBox.clearProcess()
 
                 if terminatedProcess.terminationStatus == 0 || processBox.wasCancelled {

--- a/KubebarCore/Services/WarningEventDiagnosticReader.swift
+++ b/KubebarCore/Services/WarningEventDiagnosticReader.swift
@@ -1,0 +1,252 @@
+import Foundation
+
+public struct WarningEventDiagnosticReadRequest: Equatable, Sendable {
+    public let target: WarningEventDiagnosticTarget
+    public let limit: Int
+    public let command: CommandRequest
+
+    public init(
+        target: WarningEventDiagnosticTarget,
+        config: AppConfig,
+        limit: Int = 5,
+        kubectlEnvironment: KubectlEnvironment? = nil
+    ) {
+        self.target = target
+        self.limit = limit
+        let environment = kubectlEnvironment ?? KubectlEnvironment(config: config)
+        self.command = CommandRequest(
+            executable: "kubectl",
+            arguments: [
+                "--context", target.contextName,
+                "get", "events",
+                "--all-namespaces",
+                "--field-selector", "type=Warning",
+                "-o", "json"
+            ],
+            environmentOverrides: environment.environmentOverrides,
+            timeoutSeconds: 10
+        )
+    }
+
+    init(target: WarningEventDiagnosticTarget, limit: Int = 5, command: CommandRequest) {
+        self.target = target
+        self.limit = limit
+        self.command = command
+    }
+}
+
+public enum WarningEventDiagnosticReadError: Error, Equatable, Sendable {
+    case launchFailed
+    case timedOut
+    case invalidJSON
+    case commandFailed(String)
+    case noMatchingEvents
+}
+
+extension WarningEventDiagnosticReadError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .launchFailed:
+            "kubectl events failed to launch"
+        case .timedOut:
+            "kubectl events timed out"
+        case .invalidJSON:
+            "invalid event JSON"
+        case let .commandFailed(message):
+            message
+        case .noMatchingEvents:
+            "No matching warning events were found. Refresh and try again."
+        }
+    }
+}
+
+public protocol WarningEventDiagnosticReading: Sendable {
+    func readEvents(for request: WarningEventDiagnosticReadRequest) async throws -> [WarningEventRecord]
+}
+
+public struct CommandWarningEventDiagnosticReader: WarningEventDiagnosticReading, Sendable {
+    private let runner: any CommandRunning
+
+    public init(runner: any CommandRunning = ProcessCommandRunner()) {
+        self.runner = runner
+    }
+
+    public func readEvents(for request: WarningEventDiagnosticReadRequest) async throws -> [WarningEventRecord] {
+        let runner = runner
+        return try await Task.detached(priority: .userInitiated) {
+            do {
+                let result = try runner.run(request.command)
+                guard result.exitCode == 0 else {
+                    throw WarningEventDiagnosticReadError.commandFailed(
+                        Self.safeFailureDetail(from: result.stderr)
+                    )
+                }
+
+                let records = try Self.decodeWarningEvents(result.stdout)
+                let matches = records
+                    .filter(request.target.matches)
+                    .sorted(by: Self.newestFirst)
+                    .prefix(max(1, request.limit))
+
+                guard !matches.isEmpty else {
+                    throw WarningEventDiagnosticReadError.noMatchingEvents
+                }
+
+                return Array(matches)
+            } catch CommandRunnerError.launchFailed {
+                throw WarningEventDiagnosticReadError.launchFailed
+            } catch CommandRunnerError.timedOut {
+                throw WarningEventDiagnosticReadError.timedOut
+            }
+        }.value
+    }
+
+    private static func newestFirst(_ left: WarningEventRecord, _ right: WarningEventRecord) -> Bool {
+        let leftDate = left.observedAt ?? .distantPast
+        let rightDate = right.observedAt ?? .distantPast
+
+        if leftDate != rightDate {
+            return leftDate > rightDate
+        }
+
+        if left.reason != right.reason {
+            return left.reason < right.reason
+        }
+
+        return (left.message ?? "") < (right.message ?? "")
+    }
+
+    private static func decodeWarningEvents(_ json: String) throws -> [WarningEventRecord] {
+        do {
+            return try JSONDecoder()
+                .decode(EventList.self, from: Data(json.utf8))
+                .items
+                .map(makeWarningEventRecord)
+        } catch let error as WarningEventDiagnosticReadError {
+            throw error
+        } catch {
+            throw WarningEventDiagnosticReadError.invalidJSON
+        }
+    }
+
+    private static func makeWarningEventRecord(_ event: EventRecord) -> WarningEventRecord {
+        let object = event.involvedObject ?? event.regarding
+        let reason = normalizedText(event.reason) ?? "Unknown"
+        let count = max(1, event.series?.count ?? event.deprecatedCount ?? event.count ?? 1)
+
+        return WarningEventRecord(
+            reason: reason,
+            namespace: normalizedText(object?.namespace) ?? normalizedText(event.metadata?.namespace),
+            objectKind: normalizedText(object?.kind),
+            objectName: normalizedText(object?.name),
+            message: normalizedText(event.message) ?? normalizedText(event.note),
+            observedAt: parsedTimestamp([
+                event.series?.lastObservedTime,
+                event.deprecatedLastTimestamp,
+                event.lastTimestamp,
+                event.eventTime,
+                event.metadata?.creationTimestamp
+            ]),
+            count: count
+        )
+    }
+
+    private static func parsedTimestamp(_ values: [String?]) -> Date? {
+        for value in values.compactMap({ normalizedText($0) }) {
+            if let date = parsedTimestamp(value) {
+                return date
+            }
+        }
+
+        return nil
+    }
+
+    private static func parsedTimestamp(_ value: String) -> Date? {
+        let standardFormatter = ISO8601DateFormatter()
+        if let date = standardFormatter.date(from: value) {
+            return date
+        }
+
+        let fractionalFormatter = ISO8601DateFormatter()
+        fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractionalFormatter.date(from: value)
+    }
+
+    private static func normalizedText(_ value: String?) -> String? {
+        let text = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let text, !text.isEmpty else {
+            return nil
+        }
+
+        return text
+    }
+
+    private static func safeFailureDetail(from stderr: String) -> String {
+        let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return "kubectl events failed"
+        }
+
+        if containsSensitiveMarker(trimmed) {
+            return "kubectl events failed"
+        }
+
+        if let range = trimmed.range(of: "): ") {
+            return String(trimmed[range.upperBound...])
+        }
+
+        guard trimmed.count > 96 else {
+            return trimmed
+        }
+
+        return String(trimmed.prefix(96))
+    }
+
+    private static func containsSensitiveMarker(_ text: String) -> Bool {
+        let lowercased = text.lowercased()
+        return [
+            "token",
+            "password",
+            "client-key-data",
+            "client-certificate-data",
+            "certificate-authority-data",
+            "authorization",
+            "bearer"
+        ].contains { lowercased.contains($0) }
+    }
+}
+
+private struct EventList: Decodable {
+    let items: [EventRecord]
+}
+
+private struct EventRecord: Decodable {
+    struct Metadata: Decodable {
+        let namespace: String?
+        let creationTimestamp: String?
+    }
+
+    struct ObjectReference: Decodable {
+        let kind: String?
+        let namespace: String?
+        let name: String?
+    }
+
+    struct Series: Decodable {
+        let count: Int?
+        let lastObservedTime: String?
+    }
+
+    let metadata: Metadata?
+    let reason: String?
+    let message: String?
+    let note: String?
+    let involvedObject: ObjectReference?
+    let regarding: ObjectReference?
+    let lastTimestamp: String?
+    let eventTime: String?
+    let count: Int?
+    let deprecatedCount: Int?
+    let deprecatedLastTimestamp: String?
+    let series: Series?
+}

--- a/KubebarTests/Models/AppConfigTests.swift
+++ b/KubebarTests/Models/AppConfigTests.swift
@@ -63,6 +63,56 @@ struct AppConfigTests {
 
         #expect(config.aiDiagnosticAssistant == AIDiagnosticAssistantConfig())
         #expect(config.aiDiagnosticAssistant.modelID.isEmpty)
+        #expect(config.aiDiagnosticAssistant.podPromptInstructions == nil)
+        #expect(config.aiDiagnosticAssistant.eventPromptInstructions == nil)
+        #expect(config.aiDiagnosticAssistant.effectivePodPromptInstructions == AIDiagnosticAssistantConfig.defaultPodPromptInstructions)
+        #expect(config.aiDiagnosticAssistant.effectiveEventPromptInstructions == AIDiagnosticAssistantConfig.defaultEventPromptInstructions)
+    }
+
+    @Test("existing config without prompts decodes defaults")
+    func existingConfigWithoutPromptsDecodesDefaults() throws {
+        let json = """
+        {
+          "selectedContext": "prod",
+          "watchTargets": [{ "namespace": { "_0": "api" } }],
+          "aiDiagnosticAssistant": {
+            "provider": "openAI",
+            "modelID": "gpt-4o-mini"
+          }
+        }
+        """
+
+        let config = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+
+        #expect(config.aiDiagnosticAssistant.podPromptInstructions == nil)
+        #expect(config.aiDiagnosticAssistant.eventPromptInstructions == nil)
+        #expect(config.aiDiagnosticAssistant.effectivePodPromptInstructions == AIDiagnosticAssistantConfig.defaultPodPromptInstructions)
+        #expect(config.aiDiagnosticAssistant.effectiveEventPromptInstructions == AIDiagnosticAssistantConfig.defaultEventPromptInstructions)
+    }
+
+    @Test("custom prompt overrides round trip without api key")
+    func customPromptOverridesRoundTripWithoutAPIKey() throws {
+        let config = AppConfig(
+            selectedContext: "prod",
+            watchTargets: [.namespace("api")],
+            aiDiagnosticAssistant: AIDiagnosticAssistantConfig(
+                provider: .openAI,
+                modelID: "gpt-4o-mini",
+                podPromptInstructions: "Custom Pod instructions",
+                eventPromptInstructions: "Custom Event instructions"
+            )
+        )
+
+        let data = try JSONEncoder().encode(config)
+        let json = String(data: data, encoding: .utf8) ?? ""
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.aiDiagnosticAssistant.podPromptInstructions == "Custom Pod instructions")
+        #expect(decoded.aiDiagnosticAssistant.eventPromptInstructions == "Custom Event instructions")
+        #expect(json.contains("Custom Pod instructions"))
+        #expect(json.contains("Custom Event instructions"))
+        #expect(!json.contains("apiKey"))
+        #expect(!json.contains("sk-test-secret"))
     }
 
     @Test("selecting context preserves ai diagnostic assistant config")
@@ -90,7 +140,8 @@ struct AppConfigTests {
             aiDiagnosticAssistant: AIDiagnosticAssistantConfig(
                 provider: .openAICompatible,
                 modelID: "gpt-4o-mini",
-                baseURL: "https://example.test/v1"
+                baseURL: "https://example.test/v1",
+                podPromptInstructions: "Secret-free custom instructions"
             )
         )
 

--- a/KubebarTests/Models/MenuDisplayModelTests.swift
+++ b/KubebarTests/Models/MenuDisplayModelTests.swift
@@ -1313,6 +1313,39 @@ struct MenuDisplayModelTests {
         #expect(display.warningEventSummaries.first?.summary == "BackOff api/pod/checkout 2m ago x4")
         #expect(display.warningEventSummaries.first?.message == "newest warning")
         #expect(display.warningEventSummaries.first?.secondaryText == "api/pod/checkout - newest warning")
+        #expect(display.warningEventSummaries.first?.diagnosticTarget == WarningEventDiagnosticTarget(
+            contextName: "prod",
+            namespace: "api",
+            objectKind: "Pod",
+            objectName: "checkout",
+            reason: "BackOff"
+        ))
+    }
+
+    @Test("warning rows without structured object target do not expose AI diagnostic target")
+    func warningRowsWithoutStructuredObjectTargetDoNotExposeDiagnosticTarget() {
+        let snapshot = ClusterSnapshot(
+            contextName: "prod",
+            nodesSection: .available(NodeSummary(ready: 3, total: 3)),
+            podsSection: .available(PodSummary(running: 12, total: 12)),
+            warningEventsSection: .available([
+                warningEvent(
+                    reason: "BackOff",
+                    namespace: nil,
+                    objectKind: nil,
+                    objectName: nil,
+                    observedAt: Date(timeIntervalSince1970: 100),
+                    count: 1
+                )
+            ]),
+            workloadsSection: .available([]),
+            capturedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let display = HealthEvaluator().evaluate(snapshot: snapshot, now: Date(timeIntervalSince1970: 220))
+
+        #expect(display.warningEventSummaries.first?.diagnosticTarget == nil)
+        #expect(display.overview.recentWarnings.first?.diagnosticTarget == nil)
     }
 
     @Test("warning summaries are capped at three rows")

--- a/KubebarTests/Models/MenuRuntimeStateTests.swift
+++ b/KubebarTests/Models/MenuRuntimeStateTests.swift
@@ -464,7 +464,9 @@ struct MenuRuntimeStateTests {
                 aiDiagnosticAssistant: AIDiagnosticAssistantConfig(
                     provider: .openAICompatible,
                     modelID: "gpt-4o-mini",
-                    baseURL: "https://example.test/v1"
+                    baseURL: "https://example.test/v1",
+                    podPromptInstructions: "Custom Pod instructions",
+                    eventPromptInstructions: "Custom Event instructions"
                 )
             )
         )
@@ -475,6 +477,8 @@ struct MenuRuntimeStateTests {
         #expect(config.aiDiagnosticAssistant.provider == .openAICompatible)
         #expect(config.aiDiagnosticAssistant.modelID == "gpt-4o")
         #expect(config.aiDiagnosticAssistant.baseURL == "https://example.test/v1")
+        #expect(config.aiDiagnosticAssistant.podPromptInstructions == "Custom Pod instructions")
+        #expect(config.aiDiagnosticAssistant.eventPromptInstructions == "Custom Event instructions")
     }
 
     @Test("changed ai diagnostic assistant config marks settings unsaved")
@@ -494,6 +498,21 @@ struct MenuRuntimeStateTests {
         state.prepareSettings(config: savedConfig)
 
         #expect(state.setupState.aiDiagnosticAssistant.config.modelID == "gpt-4o")
+    }
+
+    @Test("changed ai prompt instructions mark settings unsaved")
+    func changedAIPromptInstructionsMarkSettingsUnsaved() {
+        let savedConfig = AppConfig(
+            selectedContext: "prod",
+            watchTargets: [.namespace("api")],
+            aiDiagnosticAssistant: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini")
+        )
+        var state = MenuRuntimeState(config: savedConfig)
+        state.setupState.updateAIPodDiagnosticPromptInstructions("Custom Pod instructions")
+
+        state.prepareSettings(config: savedConfig)
+
+        #expect(state.setupState.aiDiagnosticAssistant.config.podPromptInstructions == "Custom Pod instructions")
     }
 
     @Test("replacing available contexts hides missing context tabs without dropping saved watchlists")

--- a/KubebarTests/Models/SetupFlowStateTests.swift
+++ b/KubebarTests/Models/SetupFlowStateTests.swift
@@ -422,6 +422,77 @@ struct SetupFlowStateTests {
         #expect(state.configurationMessage == nil)
     }
 
+    @Test("updating ai prompt instructions stores custom overrides")
+    func updatingAIPromptInstructionsStoresCustomOverrides() {
+        var state = SetupFlowState(
+            configurationMessage: "Could not save settings. Try again."
+        )
+
+        state.updateAIPodDiagnosticPromptInstructions("Custom Pod instructions")
+        state.updateAIEventDiagnosticPromptInstructions("Custom Event instructions")
+
+        #expect(state.aiDiagnosticAssistant.config.podPromptInstructions == "Custom Pod instructions")
+        #expect(state.aiDiagnosticAssistant.config.eventPromptInstructions == "Custom Event instructions")
+        #expect(state.configurationMessage == nil)
+    }
+
+    @Test("blank ai prompt instructions fall back to default")
+    func blankAIPromptInstructionsFallBackToDefault() {
+        var state = SetupFlowState()
+
+        state.updateAIPodDiagnosticPromptInstructions("   \n  ")
+        state.updateAIEventDiagnosticPromptInstructions("")
+
+        #expect(state.aiDiagnosticAssistant.config.podPromptInstructions == nil)
+        #expect(state.aiDiagnosticAssistant.config.eventPromptInstructions == nil)
+        #expect(state.aiDiagnosticAssistant.config.effectivePodPromptInstructions == AIDiagnosticAssistantConfig.defaultPodPromptInstructions)
+        #expect(state.aiDiagnosticAssistant.config.effectiveEventPromptInstructions == AIDiagnosticAssistantConfig.defaultEventPromptInstructions)
+    }
+
+    @Test("resetting ai prompts clears overrides")
+    func resettingAIPromptsClearsOverrides() {
+        var state = SetupFlowState(
+            aiDiagnosticAssistant: AIDiagnosticAssistantState(
+                config: AIDiagnosticAssistantConfig(
+                    provider: .openAI,
+                    modelID: "gpt-4o-mini",
+                    podPromptInstructions: "Custom Pod instructions",
+                    eventPromptInstructions: "Custom Event instructions"
+                )
+            )
+        )
+
+        state.resetAIPodDiagnosticPromptInstructions()
+        state.resetAIEventDiagnosticPromptInstructions()
+
+        #expect(state.aiDiagnosticAssistant.config.podPromptInstructions == nil)
+        #expect(state.aiDiagnosticAssistant.config.eventPromptInstructions == nil)
+        #expect(state.aiDiagnosticAssistant.config.effectivePodPromptInstructions == AIDiagnosticAssistantConfig.defaultPodPromptInstructions)
+        #expect(state.aiDiagnosticAssistant.config.effectiveEventPromptInstructions == AIDiagnosticAssistantConfig.defaultEventPromptInstructions)
+    }
+
+    @Test("updating ai provider preserves prompt overrides")
+    func updatingAIProviderPreservesPromptOverrides() {
+        var state = SetupFlowState(
+            aiDiagnosticAssistant: AIDiagnosticAssistantState(
+                config: AIDiagnosticAssistantConfig(
+                    provider: .openAI,
+                    modelID: "gpt-4o-mini",
+                    podPromptInstructions: "Custom Pod instructions",
+                    eventPromptInstructions: "Custom Event instructions"
+                ),
+                testConnectionResult: .success
+            )
+        )
+
+        state.updateAIDiagnosticAssistant(provider: .anthropic)
+
+        #expect(state.aiDiagnosticAssistant.config.provider == .anthropic)
+        #expect(state.aiDiagnosticAssistant.config.podPromptInstructions == "Custom Pod instructions")
+        #expect(state.aiDiagnosticAssistant.config.eventPromptInstructions == "Custom Event instructions")
+        #expect(state.aiDiagnosticAssistant.testConnectionResult == nil)
+    }
+
     @Test("updating ai provider clears test connection result")
     func updatingAIProviderClearsTestConnectionResult() {
         var state = SetupFlowState(

--- a/KubebarTests/Services/AIDiagnosticResponseFormatterTests.swift
+++ b/KubebarTests/Services/AIDiagnosticResponseFormatterTests.swift
@@ -1,0 +1,91 @@
+import Testing
+@testable import KubebarCore
+
+@Suite("AI diagnostic response formatter")
+struct AIDiagnosticResponseFormatterTests {
+    @Test("strips a complete think block and keeps the answer")
+    func stripsCompleteThinkBlock() {
+        let raw = """
+        <think>
+        I should analyze the pod state. CrashLoopBackOff means the container keeps restarting.
+        </think>
+
+        ## 🔍 **Possible causes**
+        - OOMKilled: exit code 137 hints at memory limits.
+        """
+        let cleaned = AIDiagnosticResponseFormatter.cleanedMarkdown(from: raw)
+
+        #expect(!cleaned.contains("<think>"))
+        #expect(!cleaned.contains("I should analyze"))
+        #expect(!cleaned.contains("CrashLoopBackOff means"))
+        #expect(cleaned.contains("## 🔍 **Possible causes**"))
+        #expect(cleaned.contains("- OOMKilled"))
+    }
+
+    @Test("strips an unclosed think block, dropping the trailing content")
+    func stripsUnclosedThinkBlock() {
+        let raw = "<think> reasoning that never closes, plus an unfinished answer"
+        let cleaned = AIDiagnosticResponseFormatter.cleanedMarkdown(from: raw)
+
+        #expect(cleaned.isEmpty)
+    }
+
+    @Test("strips multiple think blocks between sections")
+    func stripsMultipleThinkBlocks() {
+        let raw = """
+        <think>step one</think>
+        ## 🔍 **Possible causes**
+        - image pull backoff
+        <think>step two</think>
+        ## 🛠️ **Actionable fixes**
+        ```bash
+        kubectl describe pod checkout-7f9d -n api
+        ```
+        """
+        let cleaned = AIDiagnosticResponseFormatter.cleanedMarkdown(from: raw)
+
+        #expect(!cleaned.contains("step one"))
+        #expect(!cleaned.contains("step two"))
+        #expect(cleaned.contains("## 🔍 **Possible causes**"))
+        #expect(cleaned.contains("## 🛠️ **Actionable fixes**"))
+        #expect(cleaned.contains("kubectl describe pod checkout-7f9d -n api"))
+    }
+
+    @Test("strips leading chatter before the first heading")
+    func stripsLeadingPreamble() {
+        let raw = """
+        Sure, here is a diagnosis.
+
+        ## 🔍 **Possible causes**
+        - cause
+        """
+        let cleaned = AIDiagnosticResponseFormatter.cleanedMarkdown(from: raw)
+
+        #expect(!cleaned.contains("Sure, here is a diagnosis"))
+        #expect(cleaned.hasPrefix("## 🔍"))
+    }
+
+    @Test("keeps a short freeform answer that has no heading")
+    func keepsFreeformAnswerWithoutHeading() {
+        let raw = "The pod is crashing because of an OOMKilled event."
+        let cleaned = AIDiagnosticResponseFormatter.cleanedMarkdown(from: raw)
+
+        #expect(cleaned == raw)
+    }
+
+    @Test("collapses runs of repeated blank lines")
+    func collapsesRepeatedBlankLines() {
+        let raw = "## 🔍 **Possible causes**\n\n\n\n- cause\n\n\n## 🛠️ **Actionable fixes**\n- fix"
+        let cleaned = AIDiagnosticResponseFormatter.cleanedMarkdown(from: raw)
+
+        #expect(!cleaned.contains("\n\n\n"))
+        #expect(cleaned.contains("## 🔍 **Possible causes**"))
+        #expect(cleaned.contains("## 🛠️ **Actionable fixes**"))
+    }
+
+    @Test("empty input returns empty")
+    func emptyInputReturnsEmpty() {
+        #expect(AIDiagnosticResponseFormatter.cleanedMarkdown(from: "").isEmpty)
+        #expect(AIDiagnosticResponseFormatter.cleanedMarkdown(from: "   \n  \n").isEmpty)
+    }
+}

--- a/KubebarTests/Services/AIEventDiagnosticRequesterTests.swift
+++ b/KubebarTests/Services/AIEventDiagnosticRequesterTests.swift
@@ -82,6 +82,55 @@ struct AIEventDiagnosticRequesterTests {
         #expect(!jsonString.contains("Secret object"))
     }
 
+    @Test("custom event prompt instructions are included with fixed safety context")
+    func customEventPromptInstructionsAreIncludedWithFixedSafetyContext() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(statusCode: 200, body: Self.openAIResponse("## 🔍 **Possible causes**\nCause\n\n## 🛠️ **Actionable fixes**\nFix"))
+        let requester = AIEventDiagnosticRequester(credentialStore: store, httpClient: http)
+
+        _ = await requester.diagnose(
+            context: Self.sampleContext(),
+            config: AIDiagnosticAssistantConfig(
+                provider: .openAI,
+                modelID: "gpt-4o-mini",
+                eventPromptInstructions: "Custom Event instructions: focus on the newest warning."
+            ),
+            provider: .openAI
+        )
+
+        let body = try #require(http.lastRequest?.httpBody)
+        let jsonString = String(data: body, encoding: .utf8) ?? ""
+        #expect(jsonString.contains("Custom Event instructions: focus on the newest warning."))
+        #expect(!jsonString.contains("Diagnose these Kubernetes Warning Events for a human operator."))
+        #expect(jsonString.contains("Use only the provided event context"))
+        #expect(jsonString.contains("Latest matching Warning Events, capped at 5 and redacted before submission"))
+        #expect(jsonString.contains("Commands are suggestions only; the app will not execute them."))
+        #expect(!jsonString.contains("Last 50 log lines"))
+    }
+
+    @Test("blank event prompt instructions fall back to default")
+    func blankEventPromptInstructionsFallBackToDefault() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(statusCode: 200, body: Self.openAIResponse("## 🔍 **Possible causes**\nCause\n\n## 🛠️ **Actionable fixes**\nFix"))
+        let requester = AIEventDiagnosticRequester(credentialStore: store, httpClient: http)
+
+        _ = await requester.diagnose(
+            context: Self.sampleContext(),
+            config: AIDiagnosticAssistantConfig(
+                provider: .openAI,
+                modelID: "gpt-4o-mini",
+                eventPromptInstructions: "   \n  "
+            ),
+            provider: .openAI
+        )
+
+        let body = try #require(http.lastRequest?.httpBody)
+        let jsonString = String(data: body, encoding: .utf8) ?? ""
+        #expect(jsonString.contains("Diagnose these Kubernetes Warning Events for a human operator."))
+    }
+
     @Test("diagnostic request limits event payload to latest five")
     func diagnosticRequestLimitsEventsToLatestFive() async throws {
         let store = FakeAIProviderCredentialStore()

--- a/KubebarTests/Services/AIEventDiagnosticRequesterTests.swift
+++ b/KubebarTests/Services/AIEventDiagnosticRequesterTests.swift
@@ -2,13 +2,13 @@ import Foundation
 import Testing
 @testable import KubebarCore
 
-@Suite("AI Pod diagnostic requester")
-struct AIPodDiagnosticRequesterTests {
+@Suite("AI Event diagnostic requester")
+struct AIEventDiagnosticRequesterTests {
     @Test("missing model ID returns safe local failure")
     func missingModelIDReturnsSafeLocalFailure() async {
         let store = FakeAIProviderCredentialStore()
         try? store.saveAPIKey("sk-test-secret", for: .openAI)
-        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: FakeHTTPClient())
+        let requester = AIEventDiagnosticRequester(credentialStore: store, httpClient: FakeHTTPClient())
 
         let result = await requester.diagnose(
             context: Self.sampleContext(),
@@ -21,7 +21,7 @@ struct AIPodDiagnosticRequesterTests {
 
     @Test("missing API key returns safe local failure")
     func missingAPIKeyReturnsSafeLocalFailure() async {
-        let requester = AIPodDiagnosticRequester(
+        let requester = AIEventDiagnosticRequester(
             credentialStore: FakeAIProviderCredentialStore(),
             httpClient: FakeHTTPClient()
         )
@@ -35,34 +35,24 @@ struct AIPodDiagnosticRequesterTests {
         #expect(result == .failed(AIProviderConnectionTester.missingAPIKeyMessage))
     }
 
-    @Test("OpenAI-compatible missing base URL returns safe local failure")
-    func openAICompatibleMissingBaseURLReturnsSafeLocalFailure() async {
-        let store = FakeAIProviderCredentialStore()
-        try? store.saveAPIKey("sk-test-secret", for: .openAICompatible)
-        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: FakeHTTPClient())
-
-        let result = await requester.diagnose(
-            context: Self.sampleContext(),
-            config: AIDiagnosticAssistantConfig(provider: .openAICompatible, modelID: "gpt-4o-mini"),
-            provider: .openAICompatible
-        )
-
-        #expect(result == .failed(AIProviderConnectionTester.missingBaseURLMessage))
-    }
-
-    @Test("diagnostic request includes pod context warnings redacted logs and required headings")
-    func diagnosticRequestIncludesMinimalRedactedContext() async throws {
+    @Test("diagnostic request includes event context redacts messages and excludes pod logs")
+    func diagnosticRequestIncludesMinimalRedactedEventContext() async throws {
         let store = FakeAIProviderCredentialStore()
         try? store.saveAPIKey("sk-test-secret", for: .openAI)
-        let http = FakeHTTPClient(statusCode: 200, body: Self.openAIResponse("## 🔍 **Possible causes**\nOOMKilled\n\n## 🛠️ **Actionable fixes**\n```bash\nkubectl describe pod checkout-7f9d -n api\n```"))
-        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: http)
+        let http = FakeHTTPClient(statusCode: 200, body: Self.openAIResponse("## 🔍 **Possible causes**\nBackOff\n\n## 🛠️ **Actionable fixes**\n```bash\nkubectl describe pod checkout-7f9d -n api\n```"))
+        let requester = AIEventDiagnosticRequester(credentialStore: store, httpClient: http)
 
         _ = await requester.diagnose(
-            context: Self.sampleContext(logLines: [
-                "starting checkout",
-                "Authorization: Bearer sk-live-token",
-                "password=super-secret",
-                "panic: heap exhausted"
+            context: Self.sampleContext(events: [
+                AIEventDiagnosticEvent(
+                    reason: "BackOff",
+                    namespace: "api",
+                    objectKind: "Pod",
+                    objectName: "checkout-7f9d",
+                    message: "Authorization: Bearer sk-live-token password=super-secret",
+                    observedAt: "2026-07-02T00:07:00Z",
+                    count: 7
+                )
             ]),
             config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
             provider: .openAI
@@ -74,49 +64,62 @@ struct AIPodDiagnosticRequesterTests {
         let body = try #require(request.httpBody)
         let jsonString = String(data: body, encoding: .utf8) ?? ""
 
+        #expect(jsonString.contains("Diagnose these Kubernetes Warning Events"))
         #expect(jsonString.contains("prod"))
         #expect(jsonString.contains("api"))
+        #expect(jsonString.contains("Pod"))
         #expect(jsonString.contains("checkout-7f9d"))
-        #expect(jsonString.contains("CrashLoopBackOff"))
         #expect(jsonString.contains("BackOff"))
-        #expect(jsonString.contains("panic: heap exhausted"))
+        #expect(jsonString.contains("2026-07-02T00:07:00Z"))
         #expect(jsonString.contains("🔍 **Possible causes**"))
         #expect(jsonString.contains("🛠️ **Actionable fixes**"))
         #expect(!jsonString.contains("sk-live-token"))
         #expect(!jsonString.contains("super-secret"))
         #expect(!jsonString.contains("Authorization: Bearer sk-live-token"))
+        #expect(!jsonString.contains("Last 50 log lines"))
+        #expect(!jsonString.contains("panic: heap exhausted"))
         #expect(!jsonString.contains("kubeconfig"))
         #expect(!jsonString.contains("Secret object"))
     }
 
-    @Test("diagnostic request limits logs to last fifty lines")
-    func diagnosticRequestLimitsLogsToLastFiftyLines() async throws {
+    @Test("diagnostic request limits event payload to latest five")
+    func diagnosticRequestLimitsEventsToLatestFive() async throws {
         let store = FakeAIProviderCredentialStore()
         try? store.saveAPIKey("sk-test-secret", for: .openAI)
         let http = FakeHTTPClient(statusCode: 200, body: Self.openAIResponse("## 🔍 **Possible causes**\nCause\n\n## 🛠️ **Actionable fixes**\nFix"))
-        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: http)
-        let logLines = (1...60).map { "line-\($0)" }
+        let requester = AIEventDiagnosticRequester(credentialStore: store, httpClient: http)
+        let events = (1...7).map { index in
+            AIEventDiagnosticEvent(
+                reason: "BackOff",
+                namespace: "api",
+                objectKind: "Pod",
+                objectName: "checkout-7f9d",
+                message: "event-\(index)",
+                observedAt: "2026-07-02T00:0\(index):00Z",
+                count: index
+            )
+        }
 
         _ = await requester.diagnose(
-            context: Self.sampleContext(logLines: logLines),
+            context: Self.sampleContext(events: events),
             config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
             provider: .openAI
         )
 
         let body = try #require(http.lastRequest?.httpBody)
         let jsonString = String(data: body, encoding: .utf8) ?? ""
-        #expect(!jsonString.contains("line-9"))
-        #expect(!jsonString.contains("line-10"))
-        #expect(jsonString.contains("line-11"))
-        #expect(jsonString.contains("line-60"))
+        #expect(!jsonString.contains("event-1"))
+        #expect(!jsonString.contains("event-2"))
+        #expect(jsonString.contains("event-3"))
+        #expect(jsonString.contains("event-7"))
     }
 
     @Test("HTTP and transport failures redact secrets")
     func failuresRedactSecrets() async {
         let store = FakeAIProviderCredentialStore()
         try? store.saveAPIKey("sk-test-secret", for: .openAI)
-        let http = FakeHTTPClient(throwError: LocalTestError("Authorization: Bearer sk-test-secret failed"))
-        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: http)
+        let http = FakeHTTPClient(throwError: LocalAIEventTestError("Authorization: Bearer sk-test-secret failed"))
+        let requester = AIEventDiagnosticRequester(credentialStore: store, httpClient: http)
 
         let result = await requester.diagnose(
             context: Self.sampleContext(),
@@ -128,7 +131,7 @@ struct AIPodDiagnosticRequesterTests {
             Issue.record("Expected failure")
             return
         }
-        #expect(message == AIPodDiagnosticRequester.transportFailureMessage)
+        #expect(message == AIEventDiagnosticRequester.transportFailureMessage)
         #expect(!message.contains("sk-test-secret"))
         #expect(!message.contains("Bearer"))
     }
@@ -137,8 +140,8 @@ struct AIPodDiagnosticRequesterTests {
     func successfulProviderResponseReturnsMarkdownDiagnosis() async {
         let store = FakeAIProviderCredentialStore()
         try? store.saveAPIKey("sk-test-secret", for: .openAI)
-        let markdown = "## 🔍 **Possible causes**\nLikely OOMKilled.\n\n## 🛠️ **Actionable fixes**\n```bash\nkubectl describe pod checkout-7f9d -n api\n```"
-        let requester = AIPodDiagnosticRequester(
+        let markdown = "## 🔍 **Possible causes**\nLikely image pull backoff.\n\n## 🛠️ **Actionable fixes**\n```bash\nkubectl describe pod checkout-7f9d -n api\n```"
+        let requester = AIEventDiagnosticRequester(
             credentialStore: store,
             httpClient: FakeHTTPClient(statusCode: 200, body: Self.openAIResponse(markdown))
         )
@@ -152,24 +155,22 @@ struct AIPodDiagnosticRequesterTests {
         #expect(result == .success(markdown: markdown))
     }
 
-    @Test("reasoning think blocks are stripped before reaching the UI")
-    func reasoningThinkBlocksAreStripped() async {
+    @Test("reasoning think blocks are stripped from event diagnosis")
+    func eventReasoningThinkBlocksAreStripped() async {
         let store = FakeAIProviderCredentialStore()
         try? store.saveAPIKey("sk-test-secret", for: .openAI)
         let raw = """
-         <think>
-        The exit code 137 suggests an OOMKill. I should mention memory limits.
-         </think>
+        <think>The image pull is failing, so the pod stays in BackOff.</think>
 
         ## 🔍 **Possible causes**
-        - OOMKilled: container exceeded its memory limit.
+        - ImagePullBackOff: registry credentials or tag mismatch.
 
         ## 🛠️ **Actionable fixes**
         ```bash
         kubectl describe pod checkout-7f9d -n api
         ```
         """
-        let requester = AIPodDiagnosticRequester(
+        let requester = AIEventDiagnosticRequester(
             credentialStore: store,
             httpClient: FakeHTTPClient(statusCode: 200, body: Self.openAIResponse(raw))
         )
@@ -184,49 +185,34 @@ struct AIPodDiagnosticRequesterTests {
             Issue.record("Expected success")
             return
         }
-        #expect(!markdown.contains(" <think>"))
-        #expect(!markdown.contains("I should mention memory limits"))
+        #expect(!markdown.contains("<think>"))
+        #expect(!markdown.contains("image pull is failing, so the pod"))
         #expect(markdown.contains("## 🔍 **Possible causes**"))
         #expect(markdown.contains("kubectl describe pod checkout-7f9d -n api"))
     }
 
-    @Test("response that is only reasoning returns an unreadable failure")
-    func responseThatIsOnlyReasoningReturnsUnreadableFailure() async {
-        let store = FakeAIProviderCredentialStore()
-        try? store.saveAPIKey("sk-test-secret", for: .openAI)
-        let raw = " <think>The pod is crashing but I never produced a final answer."
-        let requester = AIPodDiagnosticRequester(
-            credentialStore: store,
-            httpClient: FakeHTTPClient(statusCode: 200, body: Self.openAIResponse(raw))
-        )
-
-        let result = await requester.diagnose(
-            context: Self.sampleContext(),
-            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "deepseek-reasoner"),
-            provider: .openAI
-        )
-
-        #expect(result == .failed(AIPodDiagnosticRequester.unreadableResponseMessage))
-    }
-
-    private static func sampleContext(logLines: [String] = ["panic: heap exhausted"]) -> AIPodDiagnosticContext {
-        AIPodDiagnosticContext(
-            target: PodLogTarget(contextName: "prod", namespace: "api", podName: "checkout-7f9d"),
-            podStatus: AIPodStatusContext(
-                state: "Bad",
-                ready: "0/1 ready",
-                reason: "CrashLoopBackOff",
-                detail: "Container terminated with exit code 137"
+    private static func sampleContext(
+        events: [AIEventDiagnosticEvent] = [
+            AIEventDiagnosticEvent(
+                reason: "BackOff",
+                namespace: "api",
+                objectKind: "Pod",
+                objectName: "checkout-7f9d",
+                message: "Back-off restarting failed container",
+                observedAt: "2026-07-02T00:07:00Z",
+                count: 7
+            )
+        ]
+    ) -> AIEventDiagnosticContext {
+        AIEventDiagnosticContext(
+            target: WarningEventDiagnosticTarget(
+                contextName: "prod",
+                namespace: "api",
+                objectKind: "Pod",
+                objectName: "checkout-7f9d",
+                reason: "BackOff"
             ),
-            warnings: [
-                AIPodWarningContext(
-                    reason: "BackOff",
-                    location: "api/pod/checkout-7f9d",
-                    age: "2m ago",
-                    message: "Back-off restarting failed container"
-                )
-            ],
-            logLines: logLines,
+            events: events,
             isStale: false
         )
     }
@@ -239,7 +225,7 @@ struct AIPodDiagnosticRequesterTests {
     }
 }
 
-private struct LocalTestError: Error {
+private struct LocalAIEventTestError: Error {
     let message: String
     init(_ message: String) { self.message = message }
 }

--- a/KubebarTests/Services/AIPodDiagnosticRequesterTests.swift
+++ b/KubebarTests/Services/AIPodDiagnosticRequesterTests.swift
@@ -89,6 +89,54 @@ struct AIPodDiagnosticRequesterTests {
         #expect(!jsonString.contains("Secret object"))
     }
 
+    @Test("custom pod prompt instructions are included with fixed safety context")
+    func customPodPromptInstructionsAreIncludedWithFixedSafetyContext() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(statusCode: 200, body: Self.openAIResponse("## 🔍 **Possible causes**\nCause\n\n## 🛠️ **Actionable fixes**\nFix"))
+        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: http)
+
+        _ = await requester.diagnose(
+            context: Self.sampleContext(),
+            config: AIDiagnosticAssistantConfig(
+                provider: .openAI,
+                modelID: "gpt-4o-mini",
+                podPromptInstructions: "Custom Pod instructions: answer in one paragraph."
+            ),
+            provider: .openAI
+        )
+
+        let body = try #require(http.lastRequest?.httpBody)
+        let jsonString = String(data: body, encoding: .utf8) ?? ""
+        #expect(jsonString.contains("Custom Pod instructions: answer in one paragraph."))
+        #expect(!jsonString.contains("Diagnose this Kubernetes Pod for a human operator."))
+        #expect(jsonString.contains("Use only the provided context"))
+        #expect(jsonString.contains("Last 50 log lines, redacted before submission"))
+        #expect(jsonString.contains("Commands are suggestions only; the app will not execute them."))
+    }
+
+    @Test("blank pod prompt instructions fall back to default")
+    func blankPodPromptInstructionsFallBackToDefault() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(statusCode: 200, body: Self.openAIResponse("## 🔍 **Possible causes**\nCause\n\n## 🛠️ **Actionable fixes**\nFix"))
+        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: http)
+
+        _ = await requester.diagnose(
+            context: Self.sampleContext(),
+            config: AIDiagnosticAssistantConfig(
+                provider: .openAI,
+                modelID: "gpt-4o-mini",
+                podPromptInstructions: "   \n  "
+            ),
+            provider: .openAI
+        )
+
+        let body = try #require(http.lastRequest?.httpBody)
+        let jsonString = String(data: body, encoding: .utf8) ?? ""
+        #expect(jsonString.contains("Diagnose this Kubernetes Pod for a human operator."))
+    }
+
     @Test("diagnostic request limits logs to last fifty lines")
     func diagnosticRequestLimitsLogsToLastFiftyLines() async throws {
         let store = FakeAIProviderCredentialStore()

--- a/KubebarTests/Services/AIPodDiagnosticRequesterTests.swift
+++ b/KubebarTests/Services/AIPodDiagnosticRequesterTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+@testable import KubebarCore
+
+@Suite("AI Pod diagnostic requester")
+struct AIPodDiagnosticRequesterTests {
+    @Test("missing model ID returns safe local failure")
+    func missingModelIDReturnsSafeLocalFailure() async {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: FakeHTTPClient())
+
+        let result = await requester.diagnose(
+            context: Self.sampleContext(),
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: ""),
+            provider: .openAI
+        )
+
+        #expect(result == .failed(AIProviderConnectionTester.missingModelIDMessage))
+    }
+
+    @Test("missing API key returns safe local failure")
+    func missingAPIKeyReturnsSafeLocalFailure() async {
+        let requester = AIPodDiagnosticRequester(
+            credentialStore: FakeAIProviderCredentialStore(),
+            httpClient: FakeHTTPClient()
+        )
+
+        let result = await requester.diagnose(
+            context: Self.sampleContext(),
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        #expect(result == .failed(AIProviderConnectionTester.missingAPIKeyMessage))
+    }
+
+    @Test("OpenAI-compatible missing base URL returns safe local failure")
+    func openAICompatibleMissingBaseURLReturnsSafeLocalFailure() async {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAICompatible)
+        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: FakeHTTPClient())
+
+        let result = await requester.diagnose(
+            context: Self.sampleContext(),
+            config: AIDiagnosticAssistantConfig(provider: .openAICompatible, modelID: "gpt-4o-mini"),
+            provider: .openAICompatible
+        )
+
+        #expect(result == .failed(AIProviderConnectionTester.missingBaseURLMessage))
+    }
+
+    @Test("diagnostic request includes pod context warnings redacted logs and required headings")
+    func diagnosticRequestIncludesMinimalRedactedContext() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(statusCode: 200, body: Self.openAIResponse("## 🔍 **Possible causes**\nOOMKilled\n\n## 🛠️ **Actionable fixes**\n```bash\nkubectl describe pod checkout-7f9d -n api\n```"))
+        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: http)
+
+        _ = await requester.diagnose(
+            context: Self.sampleContext(logLines: [
+                "starting checkout",
+                "Authorization: Bearer sk-live-token",
+                "password=super-secret",
+                "panic: heap exhausted"
+            ]),
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        let request = try #require(http.lastRequest)
+        #expect(request.url?.absoluteString == "https://api.openai.com/v1/chat/completions")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-test-secret")
+        let body = try #require(request.httpBody)
+        let jsonString = String(data: body, encoding: .utf8) ?? ""
+
+        #expect(jsonString.contains("prod"))
+        #expect(jsonString.contains("api"))
+        #expect(jsonString.contains("checkout-7f9d"))
+        #expect(jsonString.contains("CrashLoopBackOff"))
+        #expect(jsonString.contains("BackOff"))
+        #expect(jsonString.contains("panic: heap exhausted"))
+        #expect(jsonString.contains("🔍 **Possible causes**"))
+        #expect(jsonString.contains("🛠️ **Actionable fixes**"))
+        #expect(!jsonString.contains("sk-live-token"))
+        #expect(!jsonString.contains("super-secret"))
+        #expect(!jsonString.contains("Authorization: Bearer sk-live-token"))
+        #expect(!jsonString.contains("kubeconfig"))
+        #expect(!jsonString.contains("Secret object"))
+    }
+
+    @Test("diagnostic request limits logs to last fifty lines")
+    func diagnosticRequestLimitsLogsToLastFiftyLines() async throws {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(statusCode: 200, body: Self.openAIResponse("## 🔍 **Possible causes**\nCause\n\n## 🛠️ **Actionable fixes**\nFix"))
+        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: http)
+        let logLines = (1...60).map { "line-\($0)" }
+
+        _ = await requester.diagnose(
+            context: Self.sampleContext(logLines: logLines),
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        let body = try #require(http.lastRequest?.httpBody)
+        let jsonString = String(data: body, encoding: .utf8) ?? ""
+        #expect(!jsonString.contains("line-9"))
+        #expect(!jsonString.contains("line-10"))
+        #expect(jsonString.contains("line-11"))
+        #expect(jsonString.contains("line-60"))
+    }
+
+    @Test("HTTP and transport failures redact secrets")
+    func failuresRedactSecrets() async {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let http = FakeHTTPClient(throwError: LocalTestError("Authorization: Bearer sk-test-secret failed"))
+        let requester = AIPodDiagnosticRequester(credentialStore: store, httpClient: http)
+
+        let result = await requester.diagnose(
+            context: Self.sampleContext(),
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        guard case let .failed(message) = result else {
+            Issue.record("Expected failure")
+            return
+        }
+        #expect(message == AIPodDiagnosticRequester.transportFailureMessage)
+        #expect(!message.contains("sk-test-secret"))
+        #expect(!message.contains("Bearer"))
+    }
+
+    @Test("successful provider response returns Markdown diagnosis")
+    func successfulProviderResponseReturnsMarkdownDiagnosis() async {
+        let store = FakeAIProviderCredentialStore()
+        try? store.saveAPIKey("sk-test-secret", for: .openAI)
+        let markdown = "## 🔍 **Possible causes**\nLikely OOMKilled.\n\n## 🛠️ **Actionable fixes**\n```bash\nkubectl describe pod checkout-7f9d -n api\n```"
+        let requester = AIPodDiagnosticRequester(
+            credentialStore: store,
+            httpClient: FakeHTTPClient(statusCode: 200, body: Self.openAIResponse(markdown))
+        )
+
+        let result = await requester.diagnose(
+            context: Self.sampleContext(),
+            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            provider: .openAI
+        )
+
+        #expect(result == .success(markdown: markdown))
+    }
+
+    private static func sampleContext(logLines: [String] = ["panic: heap exhausted"]) -> AIPodDiagnosticContext {
+        AIPodDiagnosticContext(
+            target: PodLogTarget(contextName: "prod", namespace: "api", podName: "checkout-7f9d"),
+            podStatus: AIPodStatusContext(
+                state: "Bad",
+                ready: "0/1 ready",
+                reason: "CrashLoopBackOff",
+                detail: "Container terminated with exit code 137"
+            ),
+            warnings: [
+                AIPodWarningContext(
+                    reason: "BackOff",
+                    location: "api/pod/checkout-7f9d",
+                    age: "2m ago",
+                    message: "Back-off restarting failed container"
+                )
+            ],
+            logLines: logLines,
+            isStale: false
+        )
+    }
+
+    private static func openAIResponse(_ markdown: String) -> Data {
+        let body: [String: Any] = [
+            "choices": [["message": ["content": markdown]]]
+        ]
+        return (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+    }
+}
+
+private struct LocalTestError: Error {
+    let message: String
+    init(_ message: String) { self.message = message }
+}

--- a/KubebarTests/Services/AIProviderConnectionTesterTests.swift
+++ b/KubebarTests/Services/AIProviderConnectionTesterTests.swift
@@ -294,7 +294,12 @@ struct AIProviderConnectionTesterTests {
         let tester = AIProviderConnectionTester(credentialStore: store, httpClient: http)
 
         _ = await tester.testConnection(
-            config: AIDiagnosticAssistantConfig(provider: .openAI, modelID: "gpt-4o-mini"),
+            config: AIDiagnosticAssistantConfig(
+                provider: .openAI,
+                modelID: "gpt-4o-mini",
+                podPromptInstructions: "Custom Pod prompt should stay out of Test Connection",
+                eventPromptInstructions: "Custom Event prompt should stay out of Test Connection"
+            ),
             provider: .openAI
         )
 
@@ -307,6 +312,8 @@ struct AIProviderConnectionTesterTests {
         #expect(!jsonString.contains("warning"))
         #expect(!jsonString.contains("kubectl"))
         #expect(!jsonString.contains("pod"))
+        #expect(!jsonString.contains("Custom Pod prompt"))
+        #expect(!jsonString.contains("Custom Event prompt"))
     }
 }
 

--- a/KubebarTests/Services/PodLogStreamerTests.swift
+++ b/KubebarTests/Services/PodLogStreamerTests.swift
@@ -24,6 +24,64 @@ struct PodLogStreamerTests {
         #expect(request.command.environmentOverrides == ["KUBECONFIG": "/tmp/dev.yaml:/tmp/prod.yaml"])
     }
 
+    @Test("builds finite diagnostic logs request without follow and with kubeconfig")
+    func buildsFiniteDiagnosticLogsRequest() {
+        let target = PodLogTarget(contextName: "prod", namespace: "api", podName: "checkout-7f9d")
+        let request = PodDiagnosticLogReadRequest(
+            target: target,
+            config: AppConfig(kubeconfigPaths: ["/tmp/dev.yaml", "/tmp/prod.yaml"])
+        )
+
+        #expect(request.command.executable == "kubectl")
+        #expect(request.command.arguments == [
+            "--context", "prod",
+            "logs",
+            "--tail=50",
+            "-n", "api",
+            "checkout-7f9d"
+        ])
+        #expect(!request.command.arguments.contains("-f"))
+        #expect(request.command.environmentOverrides == ["KUBECONFIG": "/tmp/dev.yaml:/tmp/prod.yaml"])
+    }
+
+    @Test("finite diagnostic log reader keeps last fifty stdout lines")
+    func finiteDiagnosticLogReaderKeepsLastFiftyStdoutLines() async throws {
+        let runner = FakeCommandRunner(result: CommandResult(
+            stdout: (1...60).map { "line-\($0)" }.joined(separator: "\n"),
+            stderr: "",
+            exitCode: 0
+        ))
+        let reader = CommandPodDiagnosticLogReader(runner: runner)
+        let request = PodDiagnosticLogReadRequest(
+            target: PodLogTarget(contextName: "prod", namespace: "api", podName: "checkout"),
+            command: CommandRequest(executable: "/bin/echo", arguments: [])
+        )
+
+        let lines = try await reader.readLogs(for: request)
+
+        #expect(lines.count == 50)
+        #expect(lines.first == "line-11")
+        #expect(lines.last == "line-60")
+    }
+
+    @Test("finite diagnostic log reader reports safe stderr on failure")
+    func finiteDiagnosticLogReaderReportsSafeStderrOnFailure() async throws {
+        let runner = FakeCommandRunner(result: CommandResult(
+            stdout: "",
+            stderr: "Error from server (BadRequest): container required",
+            exitCode: 2
+        ))
+        let reader = CommandPodDiagnosticLogReader(runner: runner)
+        let request = PodDiagnosticLogReadRequest(
+            target: PodLogTarget(contextName: "prod", namespace: "api", podName: "checkout"),
+            command: CommandRequest(executable: "/bin/echo", arguments: [])
+        )
+
+        await #expect(throws: PodDiagnosticLogReadError.commandFailed("container required")) {
+            _ = try await reader.readLogs(for: request)
+        }
+    }
+
     @Test("stream session separates repeated opens for the same pod target")
     func streamSessionSeparatesRepeatedOpensForSamePodTarget() {
         let target = PodLogTarget(contextName: "prod", namespace: "api", podName: "checkout")
@@ -175,5 +233,17 @@ struct PodLogStreamerTests {
         }
 
         #expect((try? String(contentsOf: marker, encoding: .utf8)) == "terminated")
+    }
+}
+
+private final class FakeCommandRunner: CommandRunning, @unchecked Sendable {
+    private let result: CommandResult
+
+    init(result: CommandResult) {
+        self.result = result
+    }
+
+    func run(_ request: CommandRequest) throws -> CommandResult {
+        result
     }
 }

--- a/KubebarTests/Services/WarningEventDiagnosticReaderTests.swift
+++ b/KubebarTests/Services/WarningEventDiagnosticReaderTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import KubebarCore
+
+@Suite("Warning Event diagnostic reader")
+struct WarningEventDiagnosticReaderTests {
+    @Test("builds fresh kubectl warning events request with context and kubeconfig")
+    func buildsFreshWarningEventsRequest() {
+        let target = WarningEventDiagnosticTarget(
+            contextName: "prod",
+            namespace: "api",
+            objectKind: "Pod",
+            objectName: "checkout-7f9d",
+            reason: "BackOff"
+        )
+        let request = WarningEventDiagnosticReadRequest(
+            target: target,
+            config: AppConfig(kubeconfigPaths: ["/tmp/dev.yaml", "/tmp/prod.yaml"])
+        )
+
+        #expect(request.command.executable == "kubectl")
+        #expect(request.command.arguments == [
+            "--context", "prod",
+            "get", "events",
+            "--all-namespaces",
+            "--field-selector", "type=Warning",
+            "-o", "json"
+        ])
+        #expect(request.command.environmentOverrides == ["KUBECONFIG": "/tmp/dev.yaml:/tmp/prod.yaml"])
+    }
+
+    @Test("filters by exact event group key sorts newest first and caps at five")
+    func filtersByExactKeySortsNewestAndCapsAtFive() async throws {
+        let target = WarningEventDiagnosticTarget(
+            contextName: "prod",
+            namespace: "api",
+            objectKind: "Pod",
+            objectName: "checkout-7f9d",
+            reason: "BackOff"
+        )
+        let runner = FakeWarningEventCommandRunner(result: CommandResult(
+            stdout: Self.warningEventsJSON,
+            stderr: "",
+            exitCode: 0
+        ))
+        let reader = CommandWarningEventDiagnosticReader(runner: runner)
+        let request = WarningEventDiagnosticReadRequest(
+            target: target,
+            command: CommandRequest(executable: "kubectl", arguments: [])
+        )
+
+        let events = try await reader.readEvents(for: request)
+
+        #expect(events.count == 5)
+        #expect(events.map(\.message) == ["match-7 token=[REDACTED-LATER]", "match-6", "match-5", "match-4", "match-3"])
+        #expect(events.allSatisfy { event in
+            event.namespace == "api" &&
+                event.objectKind == "Pod" &&
+                event.objectName == "checkout-7f9d" &&
+                event.reason == "BackOff"
+        })
+        #expect(!events.contains { $0.objectName == "checkout-other" })
+        #expect(!events.contains { $0.reason == "FailedScheduling" })
+    }
+
+    @Test("reports safe stderr on kubectl failure")
+    func reportsSafeStderrOnFailure() async throws {
+        let target = WarningEventDiagnosticTarget(
+            contextName: "prod",
+            namespace: "api",
+            objectKind: "Pod",
+            objectName: "checkout-7f9d",
+            reason: "BackOff"
+        )
+        let runner = FakeWarningEventCommandRunner(result: CommandResult(
+            stdout: "",
+            stderr: "Error from server (Forbidden): token secret denied",
+            exitCode: 1
+        ))
+        let reader = CommandWarningEventDiagnosticReader(runner: runner)
+        let request = WarningEventDiagnosticReadRequest(
+            target: target,
+            command: CommandRequest(executable: "kubectl", arguments: [])
+        )
+
+        await #expect(throws: WarningEventDiagnosticReadError.commandFailed("kubectl events failed")) {
+            _ = try await reader.readEvents(for: request)
+        }
+    }
+
+    private static let warningEventsJSON = """
+    {
+      "items": [
+        {"reason":"BackOff","message":"match-1","involvedObject":{"kind":"Pod","namespace":"api","name":"checkout-7f9d"},"lastTimestamp":"2026-07-02T00:01:00Z","type":"Warning","count":1},
+        {"reason":"BackOff","message":"match-2","involvedObject":{"kind":"Pod","namespace":"api","name":"checkout-7f9d"},"lastTimestamp":"2026-07-02T00:02:00Z","type":"Warning","count":1},
+        {"reason":"BackOff","message":"match-3","involvedObject":{"kind":"Pod","namespace":"api","name":"checkout-7f9d"},"lastTimestamp":"2026-07-02T00:03:00Z","type":"Warning","count":1},
+        {"reason":"BackOff","message":"match-4","involvedObject":{"kind":"Pod","namespace":"api","name":"checkout-7f9d"},"lastTimestamp":"2026-07-02T00:04:00Z","type":"Warning","count":1},
+        {"reason":"BackOff","message":"match-5","involvedObject":{"kind":"Pod","namespace":"api","name":"checkout-7f9d"},"lastTimestamp":"2026-07-02T00:05:00Z","type":"Warning","count":1},
+        {"reason":"BackOff","message":"match-6","involvedObject":{"kind":"Pod","namespace":"api","name":"checkout-7f9d"},"lastTimestamp":"2026-07-02T00:06:00Z","type":"Warning","count":1},
+        {"reason":"BackOff","message":"match-7 token=[REDACTED-LATER]","involvedObject":{"kind":"Pod","namespace":"api","name":"checkout-7f9d"},"lastTimestamp":"2026-07-02T00:07:00Z","type":"Warning","count":1},
+        {"reason":"BackOff","message":"wrong pod","involvedObject":{"kind":"Pod","namespace":"api","name":"checkout-other"},"lastTimestamp":"2026-07-02T00:08:00Z","type":"Warning","count":1},
+        {"reason":"FailedScheduling","message":"wrong reason","involvedObject":{"kind":"Pod","namespace":"api","name":"checkout-7f9d"},"lastTimestamp":"2026-07-02T00:09:00Z","type":"Warning","count":1}
+      ]
+    }
+    """
+}
+
+private final class FakeWarningEventCommandRunner: CommandRunning, @unchecked Sendable {
+    private let result: CommandResult
+
+    init(result: CommandResult) {
+        self.result = result
+    }
+
+    func run(_ request: CommandRequest) throws -> CommandResult {
+        result
+    }
+}

--- a/changelog.d/ai-diagnostic-prompt-customization.added.md
+++ b/changelog.d/ai-diagnostic-prompt-customization.added.md
@@ -1,0 +1,6 @@
+---
+type: added
+module: ai-diagnostic-assistant
+---
+
+Add Pod and Warning Event AI diagnostic prompt customization with reset-to-default controls while preserving fixed safety prompts and bounded diagnostic context.

--- a/changelog.d/ai-event-diagnostics.added.md
+++ b/changelog.d/ai-event-diagnostics.added.md
@@ -1,0 +1,1 @@
+Added a manual AI diagnosis action to Overview Recent Warnings that sends the latest five matching Warning Events to the configured AI Provider.

--- a/changelog.d/ai-pod-diagnostics.added.md
+++ b/changelog.d/ai-pod-diagnostics.added.md
@@ -1,0 +1,1 @@
+- Add a manual `AI Diagnose this Pod` action to the Pod Micro-Logs Drawer that sends bounded, redacted Pod status, warning summaries, and last 50 log lines to the configured AI Provider and renders a transient Markdown diagnosis.

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -121,8 +121,16 @@ These are the rules Kubebar must keep true at runtime.
 - AI Test Connection is manually triggered. It sends a minimal provider probe
   with no Kubernetes data: no warning text, Pod logs, kubeconfig content, raw
   `kubectl` output, or cluster JSON.
-- AI diagnostic input, when implemented in a future plan, is limited to
-  user-approved warning summary text and must remain manually triggered.
+- AI Pod diagnosis is manually triggered from a specific Pod Micro-Logs Drawer
+  target. It may send only the selected Pod's display-ready status, up to 3
+  related warning summaries, and a freshly read, bounded, redacted
+  `kubectl logs --tail=50` sample to the configured AI Provider.
+- AI Pod diagnosis must clearly disclose the submitted context before or while
+  running, must store no diagnosis history, and must not feed Health State Shift
+  Alerts, watchlist ordering, `HealthEvaluator`, or menu bar icon state.
+- AI Pod diagnosis must not query Kubernetes Secrets, send kubeconfig content,
+  send full raw command transcripts, send raw cluster JSON, expose provider raw
+  response bodies, or automatically execute suggested `kubectl` commands.
 - Events warning summaries are capped at 3. Overview `Recent Warnings` is capped
   at 2 visible rows by default so it cannot push the top status row or cards out
   of the first scan.

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -131,6 +131,13 @@ These are the rules Kubebar must keep true at runtime.
 - AI Pod diagnosis must not query Kubernetes Secrets, send kubeconfig content,
   send full raw command transcripts, send raw cluster JSON, expose provider raw
   response bodies, or automatically execute suggested `kubectl` commands.
+- AI Event diagnosis is manually triggered only from `Overview` `Recent Warnings`
+  in its first slice. It may send only a fresh, exact-key matched, latest-5
+  Warning Event payload to the configured AI Provider.
+- AI Event diagnosis must not read Pod logs, query Kubernetes Secrets, send
+  kubeconfig content, send full raw command transcripts, send raw cluster JSON,
+  expose provider raw response bodies, persist report history, feed
+  `HealthEvaluator`, or automatically execute suggested `kubectl` commands.
 - Events warning summaries are capped at 3. Overview `Recent Warnings` is capped
   at 2 visible rows by default so it cannot push the top status row or cards out
   of the first scan.

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -118,6 +118,10 @@ These are the rules Kubebar must keep true at runtime.
   icon category.
 - AI Provider API keys must be stored in macOS Keychain, never in `AppConfig`,
   `config.json`, command output, diagnostics, or visible error text.
+- AI diagnostic prompt instructions are non-secret local settings. They may be
+  persisted in `AppConfig`, but they must not replace Kubebar's fixed safety
+  prompt, expand submitted Kubernetes context, affect Health category, or enable
+  automatic command execution.
 - AI Test Connection is manually triggered. It sends a minimal provider probe
   with no Kubernetes data: no warning text, Pod logs, kubeconfig content, raw
   `kubectl` output, or cluster JSON.

--- a/docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md
+++ b/docs/plans/2026-07-02-001-feat-ai-pod-diagnostics-plan.md
@@ -1,0 +1,161 @@
+---
+title: "feat: add manual AI Pod diagnostics"
+type: feat
+status: planned
+date: 2026-07-02
+origin: .imm/specs/2026-07-02-ai-pod-diagnostics.md
+---
+
+# feat: add manual AI Pod diagnostics
+
+## Summary
+
+- Summary: Add a contextual, manually triggered `AI Diagnose this Pod` action to the Pod Micro-Logs Drawer that rereads the last 50 Pod log lines, sends bounded redacted context to the configured AI Provider, and renders a transient Markdown diagnosis.
+
+This plan implements the user-confirmed adjustment from a possible footer action to a Pod-context action. The feature deliberately avoids a global footer diagnosis button because the AI request is target-specific and may send Pod logs. AI output remains display/help behavior only.
+
+## Current Slice
+
+- Roadmap source: none
+- Execution scope: Pod Micro-Logs Drawer AI action, finite `kubectl logs --tail=50` read boundary, Pod diagnostic prompt/request boundary, transient diagnosis UI state, provider error redaction, docs/tests
+- Deferred phases: primary Warning Events diagnosis, footer shortcut menu, multi-container selection, previous-container logs, report persistence/history, chat UX, and auto-remediation are outside this plan
+- This is not a global AI cluster diagnosis roadmap.
+
+## Task
+
+- Type: feat
+- Scope: Pod Micro-Logs Drawer, AI provider request service, finite Pod log read, transient report rendering, docs/tests
+- Owner: imm-work
+- Verification: focused Swift tests, Swift build, and full Swift quality gate when practical
+
+## Output Language
+
+Spec and Plan prose are English. Code identifiers, schema fields, CLI commands, file paths, provider names, API names, enum cases, Markdown headings, and Immune-Brain fields remain literal.
+
+## Origin
+
+The user requested one-click `AI Lightning Diagnostics` and then confirmed this direction:
+
+- Prefer a contextual `AI Diagnose this Pod` entry over a footer primary button.
+- Allow sending the selected Pod's last 50 log lines to the configured AI Provider.
+- Reread logs with `kubectl logs --tail=50` instead of using the current live drawer buffer.
+- Never automatically execute AI-suggested `kubectl` commands.
+- Provide safe failure-state recommendations.
+
+No persisted Brainstorm manifest was created before this plan; the confirmed scope above is the closed input for this executable slice.
+
+## Research
+
+- `CONTEXT.md` defines `AI Diagnostic Assistant`, `AI Provider configuration`, `AI Provider API key`, `AI Pod diagnostic input`, and `Pod Micro-Logs Drawer`. This plan revises the earlier warning-only diagnostic boundary now that the user approved Pod log submission.
+- `docs/architecture/runtime-invariants.md` already requires AI to remain display/help behavior only, API keys to stay in Keychain, Test Connection to send no Kubernetes data, and Pod logs to stay outside health evaluation.
+- `KubebarCore/Services/AIProviderConnectionTester.swift` provides the provider-specific request and redacted-result pattern for OpenAI, Anthropic, Gemini, and OpenAI-compatible endpoints.
+- `KubebarCore/Services/AIProviderCredentialStore.swift` and `Kubebar/Services/KeychainAIProviderCredentialStore.swift` own the Keychain-only credential boundary.
+- `KubebarCore/Services/HTTPClient.swift` is the injectable HTTP boundary for provider requests.
+- `KubebarCore/Services/PodLogStreamer.swift` owns app-context `kubectl logs --tail=100 -f`; its request shape is the closest pattern for a finite `--tail=50` read.
+- `Kubebar/MenuBarViewModel.swift` owns Pod log drawer lifecycle, active app config, provider connection testing, and task cancellation. It is the correct owner for starting/cancelling the AI diagnostic request.
+- `Kubebar/Views/MenuBarRootView.swift` owns `PodLogDrawerView`; `Kubebar/Views/PodLogWindowPresenter.swift` hosts it in the focusable log window.
+- `KubebarCore/Models/MenuDisplayModel.swift` and `HealthEvaluator.swift` already prepare display-ready Pod rows and warning summaries; SwiftUI views must not infer health.
+- Read-only planner research inspected AI provider boundaries and identified credential leakage, log PII, request-size, stale-data, and boundary isolation risks. A second read-only probe for Pod log UI returned no output, so the planner fell back to inline file inspection.
+
+## Decisions
+
+- Put the primary action in the Pod Micro-Logs Drawer toolbar, near search/copy, not in the menu footer.
+- Ship Pod-level diagnostics only in this MVP; Warning Events can later deep-link to Pod diagnostics when a reliable Pod target exists.
+- Add a finite Pod log reader boundary that uses `kubectl --context <context> logs --tail=50 -n <namespace> <pod>` and the same effective kubeconfig environment rules as other `kubectl` reads.
+- Add a separate AI diagnostic requester instead of mixing diagnostic payloads into `AIProviderConnectionTester`.
+- Reuse the existing AI Provider configuration, Keychain credential store, and HTTP client abstractions.
+- Keep the generated report transient in `MenuBarViewModel` state; do not persist reports or logs.
+- Redact obvious secrets from log payloads before provider submission and from all visible failure text.
+- Render Markdown as readable text/code blocks enough for the MVP; commands are copyable by text selection/copy, not executed by Kubebar.
+- Keep all AI diagnosis results outside `HealthEvaluator`, `MenuDisplayModel` health categories, Health State Shift Alerts, watchlist ordering, and menu bar icon state.
+
+## Assumptions
+
+- The selected Pod target from `PodLogTarget` is sufficient for this slice; container selection and previous-container logs remain deferred.
+- `WarningEventDisplay` rows are acceptable as the latest 3 related warning summaries for the first version; exact event-to-Pod matching can be strengthened later.
+- If warning rows or finite logs are unavailable, diagnosis can either fail safely or proceed with explicit unavailable text, depending on which boundary failed.
+- Provider responses are plain text/Markdown; a full Markdown parser dependency is not required for the MVP.
+- Focused tests can cover Core service behavior; app-target UI wiring is primarily build/quality-gate verified because current package tests target `KubebarCore` only.
+
+## Planning Quality Gate Notes
+
+- Contract surface: `CONTEXT.md`, `.imm/specs/2026-07-02-ai-pod-diagnostics.md`, `docs/architecture/runtime-invariants.md`, `KubebarCore/Services/AIProviderConnectionTester.swift`, new diagnostic requester/finite log reader services, `KubebarCore/Services/PodLogStreamer.swift`, `Kubebar/MenuBarViewModel.swift`, `Kubebar/Views/MenuBarRootView.swift`, `Kubebar/Views/PodLogWindowPresenter.swift`, and focused tests.
+- Compatibility: no persisted config migration is needed; the feature uses existing AI Provider configuration and stores no diagnosis history.
+- Interruption recovery: if service work compiles but UI wiring is incomplete, no user path should invoke the new request. If UI wiring fails, revert the app-target view/model changes while keeping or reverting Core tests coherently.
+- Rollback path: revert the new services, ViewModel/UI wiring, docs/spec/plan/changelog, and tests. No Kubernetes resources or persisted cluster data are modified.
+- Verification strength: request-construction tests must fail if logs are not bounded/redacted, if provider payload omits required Markdown sections, if credentials leak into visible errors, or if the finite log read uses the wrong context/kubeconfig.
+- Scope discipline: this plan intentionally excludes global/footer diagnosis and auto-remediation; those are product expansions, not hidden MVP tasks.
+
+## Devil's Advocate Audit
+
+### Rollback resilience
+
+The plan keeps AI diagnosis behind explicit UI and injectable boundaries. If provider-request tests fail, the UI can stay unexposed. If UI wiring fails, reverting `MenuBarViewModel` and Pod drawer view changes removes the feature without touching existing Settings/Test Connection. No step mutates Kubernetes resources.
+
+### Verification vanity
+
+Label-existence is not enough. Verification must inspect generated `kubectl` arguments, request bodies, redacted log payloads, safe failure messages, required Markdown instructions, and cancellation/empty-state behavior. The full quality gate confirms Xcode and SwiftPM surfaces compile with the new files.
+
+### Spec dilution detection
+
+The plan covers the user-approved changes: contextual Pod drawer placement, last 50 logs, fresh reread, no auto-execution, and safe failure states. It explicitly documents the privacy-boundary expansion from warning-only input to user-approved redacted Pod logs instead of silently preserving the old boundary.
+
+## Scope Boundaries
+
+- In scope: Pod drawer `AI Diagnose this Pod`, finite last-50 log reread, current Pod display status, latest warning summaries, redacted provider request, transient Markdown report, safe failures, docs/tests.
+- Out of scope: menu-footer primary diagnosis, global cluster diagnosis, Warning Events primary diagnosis, automatic/background diagnosis, auto-executed fixes, Secret reads, kubeconfig transmission, full raw kubectl transcripts, raw cluster JSON, persistence/history, chat UX, previous-container logs, and multi-container selection.
+
+## Deferred Work
+
+- Add Warning Events row-level `sparkles` only when a reliable Pod target can be derived.
+- Add a footer secondary menu only if users need a shortcut after a selected/open Pod concept exists.
+- Add explicit multi-container and previous-container log diagnostics.
+- Add a richer Markdown renderer or copy-code-block controls if the basic report surface is not enough.
+- Add enterprise privacy docs after the first Pod-log diagnostic slice ships.
+
+## Implementation Units
+
+### Step 1
+
+- Step ID: U1
+- Result: The Pod Micro-Logs Drawer manually renders a safe AI diagnosis for its selected Pod.
+- Verification: swift test --filter AIProviderConnectionTesterTests && swift test --filter PodLogStreamerTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check
+- Depends on: None
+- Test scenarios: Pod AI action is only in the Pod log drawer; finite log request uses `--context`, `logs`, `--tail=50`, namespace, and pod name without `-f`; explicit kubeconfig paths flow into the finite log environment; missing provider model/key/base URL returns safe local failure; diagnostic request body includes Pod status, 3 warning summaries, redacted last 50 log lines, and required Markdown headings; obvious secrets in logs are redacted before submission; provider/network errors never expose API keys/Bearer tokens/raw response body; report state supports loading, success, retryable failure, unavailable logs, and empty logs; AI suggested commands remain text only and no mutation command is executed by Kubebar; docs preserve Health category independence
+- Discovery cache: KubebarCore/Services/AIProviderConnectionTester.swift (provider request/redaction pattern); KubebarCore/Services/AIProviderCredentialStore.swift (Keychain protocol); KubebarCore/Services/HTTPClient.swift (provider HTTP boundary); KubebarCore/Services/PodLogStreamer.swift (kubectl logs context/kubeconfig pattern); Kubebar/MenuBarViewModel.swift (Pod drawer lifecycle and AI settings callbacks); Kubebar/Views/MenuBarRootView.swift (PodLogDrawerView); Kubebar/Views/PodLogWindowPresenter.swift (log window host); KubebarCore/Models/MenuDisplayModel.swift (display-ready warnings and Pod rows); docs/architecture/runtime-invariants.md (runtime safety contract); CONTEXT.md (canonical AI diagnostic vocabulary)
+
+**Goal:** Deliver the full user-visible Pod AI diagnosis loop in one coherent feature.
+
+**Verification type:** automated
+
+**Execution note:** test-first
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `CONTEXT.md`
+- Modify: `docs/architecture/runtime-invariants.md`
+- Add: `KubebarCore/Services/PodDiagnosticLogReader.swift`
+- Add: `KubebarCore/Services/AIPodDiagnosticRequester.swift`
+- Add or modify: `KubebarCore/Models/AIPodDiagnosis.swift`
+- Modify: `Kubebar/MenuBarViewModel.swift`
+- Modify: `Kubebar/Views/MenuBarRootView.swift`
+- Modify: `Kubebar/Views/PodLogWindowPresenter.swift`
+- Modify/Add: `KubebarTests/Services/PodLogStreamerTests.swift`
+- Add: `KubebarTests/Services/AIPodDiagnosticRequesterTests.swift`
+- Add: `changelog.d/ai-pod-diagnostics.added.md`
+
+**Approach:**
+- Add Core value types for Pod diagnostic context, warning summaries, report state, and diagnostic result.
+- Add a finite `PodDiagnosticLogReader` using `CommandRunning` and `KubectlEnvironment` to read `kubectl logs --tail=50` without following.
+- Add `AIPodDiagnosticRequester` that loads the provider API key from the credential store, validates model/base URL, redacts log context, constructs provider-specific requests, and returns Markdown text or safe errors.
+- Thread a transient diagnosis state through `MenuBarViewModel`, start/cancel work from a new `diagnoseCurrentPodWithAI()` method, and reset diagnosis when the drawer target changes/closes.
+- Extend `PodLogDrawerView` with a `sparkles` action, disclosure text, loading/error/success rendering, and no auto-execute controls.
+- Update docs to replace the old warning-only future diagnostic boundary with the approved manual Pod log diagnostic boundary.
+- Run focused tests first, then the quality gate.
+
+**failure_behavior:** If the Core service tests fail, stop before exposing the UI action. If the UI build fails, revert UI wiring without changing existing Pod log streaming or AI Settings behavior.
+
+**security_considerations:** This step sends user-approved Pod logs to an external provider. It must bound and redact logs, keep API keys in Keychain, show sanitized errors only, avoid Secrets/kubeconfig/raw JSON/full transcripts, and avoid automatic execution of AI suggestions.

--- a/docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md
+++ b/docs/plans/2026-07-02-002-feat-ai-event-diagnostics-plan.md
@@ -1,0 +1,187 @@
+---
+title: "feat: add Overview Recent Warnings AI event diagnostics"
+type: feat
+status: planned
+date: 2026-07-02
+origin: .imm/specs/2026-07-02-ai-event-diagnostics.md
+---
+
+# feat: add Overview Recent Warnings AI event diagnostics
+
+## Summary
+
+- Summary: Add a manual AI diagnosis action only to `Overview` `Recent Warnings` rows that rereads fresh Warning Events through `kubectl`, filters by exact `namespace`, `objectKind`, `objectName`, and `reason`, sends the latest 5 matching events to the configured AI Provider, and renders a transient Markdown diagnosis.
+
+This plan is a new executable slice after the completed Pod AI diagnostics slice. The previous Pod slice deliberately excluded primary Warning Events diagnosis. This slice keeps event diagnosis event-only: no Pod logs, no Events tab entry, no automatic remediation, and no health-category side effects.
+
+## Current Slice
+
+- Roadmap source: `.imm/specs/2026-07-02-ai-event-diagnostics.md`
+- Execution scope: Overview `Recent Warnings` row action, fresh Warning Event read boundary, exact warning-group matching, event diagnostic prompt/request boundary, transient diagnosis UI state, provider/event text redaction, docs/tests
+- Deferred phases: Events tab row diagnosis, Pod-log fallback from event diagnosis, footer/global cluster diagnosis, report persistence/history, chat UX, and auto-remediation are outside this plan
+- This is not a global AI cluster diagnosis roadmap.
+
+## Task
+
+- Type: feat
+- Scope: Overview Recent Warnings, Warning Event `kubectl` read, AI provider request service, transient report rendering, docs/tests
+- Owner: imm-work
+- Verification: focused Swift tests, Swift build, and full Swift quality gate when practical
+
+## Output Language
+
+Spec and Plan prose are English. Code identifiers, schema fields, CLI commands, file paths, provider names, API names, enum cases, Markdown headings, and Immune-Brain fields remain literal.
+
+## Origin
+
+The user reported that no AI diagnosis entry exists in warning events. The current Pod AI diagnostics plan intentionally shipped Pod-level diagnostics only and deferred warning-event diagnosis. The user then clarified the intended new scope:
+
+- Add the entry only to `Overview` `Recent Warnings`.
+- Use `namespace + objectKind + objectName + reason` to identify related Warning Events.
+- Send the latest 5 matching warning events to AI.
+
+## Brainstorm manifest
+
+- `BR-REQ-001`: Add manual AI diagnosis entry only to Overview `Recent Warnings`.
+- `BR-REQ-002`: Match related events by `namespace + objectKind + objectName + reason`.
+- `BR-REQ-003`: Send the latest 5 matching warning events to the configured AI Provider.
+- `BR-REQ-004`: Use fresh `kubectl` event reads through Kubebar’s app-owned context/kubeconfig rules.
+- `BR-REQ-005`: AI event diagnosis is display/help behavior only and must not affect health evaluation.
+- `BR-OUT-001`: Do not add the entry to Events tab in this slice.
+- `BR-OUT-002`: Do not read Pod logs for this event diagnosis.
+- `BR-OUT-003`: Do not execute AI-suggested `kubectl` commands.
+- `BR-DEC-001`: Diagnose warning-event groups, not individual Kubernetes Event object names.
+- `BR-DEC-002`: Scope payload to the latest 5 matching Warning Events.
+
+## Brainstorm Trace
+
+| Item | Status | Plan coverage |
+| --- | --- | --- |
+| `BR-REQ-001` | covered_by_step | Step 1 wires the action only into `Overview` `Recent Warnings`. |
+| `BR-REQ-002` | covered_by_step | Step 1 adds an exact diagnostic target key and matching logic. |
+| `BR-REQ-003` | covered_by_step | Step 1 caps provider input to the latest 5 matching Warning Events. |
+| `BR-REQ-004` | covered_by_step | Step 1 adds a fresh `kubectl` Warning Event read boundary using app-owned context/kubeconfig. |
+| `BR-REQ-005` | covered_by_step | Step 1 keeps results transient and outside health evaluation. |
+| `BR-OUT-001` | out_of_scope | Events tab diagnosis is explicitly excluded from this slice to keep the entry limited to Overview. |
+| `BR-OUT-002` | out_of_scope | Pod logs are excluded; this is event-only diagnosis. |
+| `BR-OUT-003` | out_of_scope | Auto-execution is excluded; suggested commands remain text only. |
+| `BR-DEC-001` | captured_as_decision | The diagnostic target is a warning-event group key, not a Kubernetes Event object name. |
+| `BR-DEC-002` | captured_as_decision | The provider payload is capped at the latest 5 matching Warning Events. |
+
+## Research
+
+- `CONTEXT.md` defines `AI Diagnostic Assistant`, `AI Provider configuration`, `AI Provider API key`, `AI Pod diagnostic input`, `Pod Micro-Logs Drawer`, app-owned context, and effective kubeconfig rules. This slice should add event-diagnostic vocabulary while preserving the existing AI safety boundary.
+- `docs/architecture/runtime-invariants.md` requires AI behavior to remain display/help only, API keys to stay in Keychain, AI Test Connection to send no Kubernetes data, and AI diagnosis not to affect Health category.
+- `.imm/memory/current_iteration.json` shows the previous Pod AI diagnostics plan is closed. A new slice is appropriate because this scope was deferred/out-of-scope in the completed Pod plan.
+- `Kubebar/Views/OverviewTabView.swift` renders `RecentWarningsOverviewView` from `display.overview.recentWarnings` and currently uses `WarningEventRowView(row:)` without an action callback.
+- `Kubebar/Views/WarningEventsView.swift` owns the shared `WarningEventRowView` rendering used by Overview and Events tab. The implementation should avoid accidentally adding the AI entry to Events tab.
+- `KubebarCore/Models/MenuDisplayModel.swift` currently exposes `WarningEventDisplay` display fields but not an explicit public diagnostic target key. A small value type is needed so SwiftUI does not infer target semantics from strings.
+- `KubebarCore/Services/HealthEvaluator.swift` groups warnings by `reason`, `objectKind`, `namespace`, and `objectName`; this matches the user-confirmed diagnostic key.
+- `KubebarCore/Services/KubectlClusterReader.swift` already reads Warning Events with `kubectl get events --all-namespaces --field-selector type=Warning -o json`, decodes both core and events.k8s.io-style fields, and sanitizes failures. A finite event diagnostic reader should reuse this command/environment pattern without exposing raw transcripts.
+- `KubebarCore/Services/AIPodDiagnosticRequester.swift` provides the provider request pattern, credential validation, provider-specific body construction, safe provider error messages, and `AIDiagnosticRedactor` helper.
+- Read-only planner probe confirmed the key implementation surfaces: Overview UI, shared warning row view, display model warning grouping, kubectl event read boundary, and AI requester/test patterns.
+
+## Decisions
+
+- Create a new event-only diagnostic path instead of extending `AIPodDiagnosticContext` or reading Pod logs.
+- Put the action only in `Overview` `Recent Warnings`; the Events tab continues to render warning rows without AI controls.
+- Represent the AI target explicitly as a value derived from `namespace`, `objectKind`, `objectName`, and `reason`; views must pass this value instead of parsing display strings.
+- Reread Warning Events at click time and filter the fresh records by exact target key. If no matching events remain, show a safe no-match failure rather than diagnosing stale rows.
+- Send at most the latest 5 matching Warning Events, sorted by observed timestamp with a deterministic fallback for missing timestamps.
+- Reuse the existing AI Provider configuration, Keychain credential store, HTTP client abstraction, and redaction helper.
+- Keep the generated report transient in `MenuBarViewModel` state; do not persist reports or event payloads.
+- Render Markdown using the existing basic report surface pattern unless implementation finds a smaller reusable component path.
+- Keep all AI event diagnosis results outside `HealthEvaluator`, `MenuDisplayModel` health categories, Health State Shift Alerts, watchlist ordering, and menu bar icon state.
+
+## Assumptions
+
+- `namespace` may be absent for cluster-scoped objects; exact matching treats nil and empty as distinct safe values rather than guessing.
+- `WarningEventDisplay` rows without enough structured target fields should not expose the AI action.
+- Provider responses are plain text/Markdown; a full Markdown parser dependency is not required for this slice.
+- Focused tests can cover Core reader/requester behavior; app-target UI wiring is primarily build/quality-gate verified because current package tests target `KubebarCore`.
+
+## Planning Quality Gate Notes
+
+- Contract surface: `CONTEXT.md`, `.imm/specs/2026-07-02-ai-event-diagnostics.md`, `docs/architecture/runtime-invariants.md`, `KubebarCore/Models/MenuDisplayModel.swift`, `KubebarCore/Models/ClusterSnapshot.swift`, `KubebarCore/Services/KubectlClusterReader.swift`, `KubebarCore/Services/AIProviderConnectionTester.swift`, `KubebarCore/Services/AIPodDiagnosticRequester.swift`, `Kubebar/MenuBarViewModel.swift`, `Kubebar/Views/OverviewTabView.swift`, `Kubebar/Views/WarningEventsView.swift`, and focused tests.
+- Compatibility: no persisted config migration is needed; the feature uses existing AI Provider configuration and stores no diagnosis history.
+- Interruption recovery: if service/requester tests fail, keep the UI action unexposed. If app-target UI wiring fails, revert the view/view-model changes while preserving coherent Core tests or revert the whole slice.
+- Rollback path: revert new event diagnostic models/services, ViewModel/UI wiring, docs/spec/plan/changelog, and tests. No Kubernetes resources or persisted cluster data are modified.
+- Verification strength: tests must fail if matching is substring-based, if more than 5 events are submitted, if stale snapshot rows are submitted without a fresh read, if provider payload contains Pod logs/raw cluster JSON/raw transcripts, or if credentials leak into visible failures.
+- Brainstorm traceability: every `BR-*` item is mapped in `Brainstorm Trace`; there are no open `BR-Q-*` items.
+
+## Devil's Advocate Audit
+
+### Rollback resilience
+
+The plan keeps event diagnosis behind an explicit Overview row action and injectable boundaries. If the reader/requester layer fails, the UI action can remain absent. If UI wiring fails, reverting `MenuBarViewModel`, `OverviewTabView`, and `WarningEventsView` removes the feature without changing refresh health evaluation or existing Pod AI diagnostics. No step mutates Kubernetes resources.
+
+### Verification vanity
+
+A button-existence test would be vanity. Verification must inspect generated `kubectl` command arguments/environment, exact target matching, latest-5 cap, fresh-read behavior, provider request bodies, redacted event messages, safe error text, and that Events tab does not receive the action. The full quality gate confirms Xcode and SwiftPM surfaces compile with the new files.
+
+### Spec dilution detection
+
+The plan preserves the user-confirmed differences from the prior Pod slice: Overview-only, event-only, exact key matching, latest 5 Warning Events, and no Events tab entry. It does not silently substitute existing Pod diagnosis or broaden into global/footer diagnosis because that would violate `BR-OUT-*` items.
+
+## Scope Boundaries
+
+- In scope: Overview `Recent Warnings` row action, exact warning-event diagnostic target, fresh Warning Event read, latest-5 matching event payload, redacted provider request, transient Markdown report, safe failures, docs/tests.
+- Out of scope: Events tab AI action, Pod log reads, global cluster diagnosis, footer shortcut, automatic/background diagnosis, auto-executed fixes, Secret reads, kubeconfig transmission, full raw kubectl transcripts, raw cluster JSON, persistence/history, chat UX, and advanced provider settings.
+
+## Deferred Work
+
+- Add Events tab row-level diagnosis only if a later plan intentionally expands the entry point beyond Overview.
+- Add an optional Pod-log follow-up from event diagnosis only after the product explicitly asks for event-to-Pod escalation and user-approved Pod log submission in that flow.
+- Add richer Markdown rendering or copy-code-block controls if the basic report surface is not enough.
+- Add enterprise privacy docs after the first event-diagnostic slice ships.
+
+## Implementation Units
+
+### Step 1
+
+- Step ID: U1
+- Result: `Overview` `Recent Warnings` manually renders a safe AI diagnosis from the latest 5 fresh matching Warning Events.
+- Verification: swift test --filter AIProviderConnectionTesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter WarningEventDiagnosticReaderTests && swift test --filter MenuDisplayModelTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check
+- Depends on: None
+- Test scenarios: Overview Recent Warnings exposes the AI action while Events tab rows do not; the diagnostic reader builds a fresh `kubectl --context <context> get events --all-namespaces --field-selector type=Warning -o json` style read with effective kubeconfig overrides; exact matching uses `namespace`, `objectKind`, `objectName`, and `reason` without substring fallback; provider input is sorted newest first and capped at 5 matching Warning Events; no matching fresh events produces a safe retryable failure; event messages are redacted before provider submission; missing provider model/key/base URL returns safe local failure; provider/network errors never expose API keys/Bearer tokens/raw response bodies; request body includes structured event context and required Markdown instructions but no Pod logs, kubeconfig content, raw cluster JSON, or raw kubectl transcript; diagnosis state supports loading, success, retryable failure, unavailable configuration, and stale-display disclosure; AI suggested commands remain text only and no mutation command is executed by Kubebar; docs preserve Health category independence
+- Discovery cache: Kubebar/Views/OverviewTabView.swift (Overview Recent Warnings UI); Kubebar/Views/WarningEventsView.swift (shared warning row view and Events-tab separation risk); KubebarCore/Models/MenuDisplayModel.swift (display-ready warnings and diagnostic target value); KubebarCore/Services/HealthEvaluator.swift (warning grouping key); KubebarCore/Services/KubectlClusterReader.swift (Warning Event kubectl decode/command pattern); KubebarCore/Services/AIProviderConnectionTester.swift (provider validation pattern); KubebarCore/Services/AIPodDiagnosticRequester.swift (diagnostic requester/redaction pattern); Kubebar/MenuBarViewModel.swift (transient AI state and app-owned config); docs/architecture/runtime-invariants.md (runtime safety contract); CONTEXT.md (canonical AI diagnostic vocabulary)
+
+**Goal:** Deliver the full user-visible Overview warning AI diagnosis loop in one coherent feature.
+
+**Verification type:** automated
+
+**Execution note:** test-first
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13, R14
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `CONTEXT.md`
+- Modify: `docs/architecture/runtime-invariants.md`
+- Add or modify: `KubebarCore/Models/AIEventDiagnosis.swift`
+- Add or modify: `KubebarCore/Models/MenuDisplayModel.swift`
+- Add: `KubebarCore/Services/WarningEventDiagnosticReader.swift`
+- Add: `KubebarCore/Services/AIEventDiagnosticRequester.swift`
+- Modify: `KubebarCore/Services/KubectlClusterReader.swift`
+- Modify: `Kubebar/MenuBarViewModel.swift`
+- Modify: `Kubebar/Views/OverviewTabView.swift`
+- Modify: `Kubebar/Views/WarningEventsView.swift`
+- Modify: `Kubebar.xcodeproj/project.pbxproj`
+- Add: `KubebarTests/Services/WarningEventDiagnosticReaderTests.swift`
+- Add: `KubebarTests/Services/AIEventDiagnosticRequesterTests.swift`
+- Modify/Add: `KubebarTests/Models/MenuDisplayModelTests.swift`
+- Add: `changelog.d/ai-event-diagnostics.added.md`
+
+**Approach:**
+- Add Core value types for an event diagnostic target, event diagnostic context, event diagnosis state/result, and latest matching event summaries.
+- Add a finite Warning Event diagnostic reader using `CommandRunning` and `KubectlEnvironment` to read Warning Events with the app-owned context, decode structured event records, filter by exact target key, sort newest first, and cap at 5.
+- Add `AIEventDiagnosticRequester` that loads the provider API key from the credential store, validates model/base URL, redacts event messages, constructs provider-specific requests, and returns Markdown text or safe errors.
+- Thread transient event diagnosis state through `MenuBarViewModel`, start/cancel work from a new Overview warning action, and clear or replace diagnosis when the selected warning target changes.
+- Extend the Overview warning row rendering with a `sparkles` action while keeping the Events tab call site action-free.
+- Update docs to define the approved manual event diagnostic boundary alongside existing Pod diagnostics.
+- Run focused tests first, then the quality gate.
+
+**failure_behavior:** If Core reader/requester tests fail, stop before exposing the UI action. If UI build fails, revert UI wiring without changing existing Pod log streaming, Pod AI diagnosis, Settings, or refresh behavior.
+
+**security_considerations:** This step sends user-approved Warning Event text to an external provider. It must bound and redact event messages, keep API keys in Keychain, show sanitized errors only, avoid Pod logs/Secrets/kubeconfig/raw JSON/full transcripts, and avoid automatic execution of AI suggestions.

--- a/docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md
+++ b/docs/plans/2026-07-03-001-feat-ai-diagnostic-prompt-customization-plan.md
@@ -1,0 +1,207 @@
+---
+title: "feat: customize AI diagnostic prompts"
+type: feat
+status: planned
+date: 2026-07-03
+origin: .imm/specs/2026-07-03-ai-diagnostic-prompt-customization.md
+---
+
+# feat: customize AI diagnostic prompts
+
+## Summary
+
+- Summary: Add per-surface AI diagnostic prompt customization in `AI Assistant` Settings so users can edit Pod and Warning Event diagnosis instructions from built-in defaults, reset either surface to default, and keep immutable safety/data boundaries in code.
+
+This plan implements the user-confirmed recommendation: Pod and Warning Event diagnosis each get a separate editable prompt, reset clears the override back to the built-in default, and the safety/system prompt remains non-editable.
+
+## Current Slice
+
+- Roadmap source: none
+- Execution scope: `AI Assistant` Settings prompt editors, per-surface prompt override config, default/reset behavior, provider request prompt rendering, docs/tests
+- Deferred phases: full prompt template language, provider-specific prompt tuning, prompt import/export, history, chat UX, cloud sync, global cluster diagnosis, and auto-remediation are outside this plan
+- This is not a global AI assistant customization roadmap.
+
+## Task
+
+- Type: feat
+- Scope: AI Diagnostic Assistant prompt settings, local config persistence, Pod/Event diagnostic requester prompt composition, docs/tests
+- Owner: imm-work
+- Verification: focused Swift tests, Swift build, and full Swift quality gate when practical
+
+## Output Language
+
+Spec and Plan prose are English. Code identifiers, schema fields, CLI commands, file paths, provider names, API names, enum cases, Markdown headings, and Immune-Brain fields remain literal.
+
+## Origin
+
+The user requested support for custom prompts: users should be able to modify a prompt based on Kubebar's default prompt and reset it to the default prompt. The preceding brainstorm recommended this exact product direction, and the user confirmed: proceed with the recommendation.
+
+## Brainstorm manifest
+
+- `BR-REQ-001`: Support custom prompt instructions based on the built-in default prompt.
+- `BR-REQ-002`: Support resetting customized prompt instructions to the built-in default.
+- `BR-REQ-003`: Provide separate prompt customization for `AI Pod diagnosis` and `AI Event diagnosis`.
+- `BR-REQ-004`: Preserve immutable safety/system instructions that users cannot override.
+- `BR-REQ-005`: Persist prompt overrides as non-secret local app configuration while keeping API keys Keychain-only.
+- `BR-REQ-006`: Existing configs without prompt fields must continue to decode and use defaults.
+- `BR-REQ-007`: Prompt customization must not expand the existing Pod/Event diagnostic data boundaries or affect Health category.
+- `BR-OUT-001`: Do not add a full prompt template language or prompt variables UI in this slice.
+- `BR-OUT-002`: Do not add global cluster diagnosis, chat/history, import/export, cloud sync, or auto-remediation.
+- `BR-DEC-001`: Use per-surface prompt overrides instead of one global prompt.
+- `BR-DEC-002`: Reset removes the custom override so future built-in default updates remain effective.
+- `BR-DEC-003`: The user-editable text controls diagnostic instructions only; code still attaches structured context and fixed safety instructions.
+
+## Brainstorm Trace
+
+| Item | Status | Plan coverage |
+| --- | --- | --- |
+| `BR-REQ-001` | covered_by_step | Step 1 adds editable default-backed prompt instructions in `AI Assistant` Settings. |
+| `BR-REQ-002` | covered_by_step | Step 1 adds per-surface reset behavior that clears overrides. |
+| `BR-REQ-003` | covered_by_step | Step 1 stores and renders separate Pod and Event prompt overrides. |
+| `BR-REQ-004` | covered_by_step | Step 1 keeps the requester safety/system prompt code-owned and non-editable. |
+| `BR-REQ-005` | covered_by_step | Step 1 persists prompt overrides in `AppConfig` and leaves credentials in Keychain. |
+| `BR-REQ-006` | covered_by_step | Step 1 includes config decode/default fallback tests. |
+| `BR-REQ-007` | covered_by_step | Step 1 updates requesters without changing submitted diagnostic data or health evaluation. |
+| `BR-OUT-001` | out_of_scope | A full template language is excluded to keep this slice low-risk and bounded. |
+| `BR-OUT-002` | out_of_scope | These are broader AI roadmap items and are not needed for prompt reset/customization. |
+| `BR-DEC-001` | captured_as_decision | Separate prompt surfaces avoid mixing Pod logs and Warning Event diagnosis instructions. |
+| `BR-DEC-002` | captured_as_decision | Reset clears the override rather than saving a copy of the default. |
+| `BR-DEC-003` | captured_as_decision | The editable prompt is an instruction override; structured context and safety stay code-owned. |
+
+## Research
+
+- `CONTEXT.md` defines `AI Diagnostic Assistant`, `AI Provider configuration`, `AI Provider API key`, `AI Pod diagnostic input`, `AI Event diagnostic input`, and the app-owned context/kubeconfig boundaries.
+- `docs/architecture/runtime-invariants.md` requires AI diagnosis to remain display/help behavior only, not affect Health category, keep API keys in Keychain, avoid Secrets/kubeconfig/raw transcripts/raw JSON, and never auto-execute AI suggestions.
+- `.imm/memory/current_iteration.json` shows the Pod and Event diagnostic plans are closed, so prompt customization should be a new executable slice rather than an append to a completed plan.
+- `KubebarCore/Models/AIDiagnosticAssistantConfig.swift` currently stores provider/model/base URL only; it is the natural place for non-secret prompt override fields and default/effective prompt helpers.
+- `KubebarCore/Services/AppConfigStore.swift`, `MenuRuntimeState.swift`, and `SetupFlowState.swift` compare and round-trip `AIDiagnosticAssistantConfig`, so prompt override fields must participate in save/change detection.
+- `Kubebar/Views/SetupView.swift` owns the `AI Assistant` Settings page and currently exposes provider, model, base URL, API key, and Test Connection controls.
+- `KubebarCore/Services/AIPodDiagnosticRequester.swift` and `AIEventDiagnosticRequester.swift` own provider request body construction and currently contain the built-in prompt strings.
+- `KubebarTests/Services/AIPodDiagnosticRequesterTests.swift`, `AIEventDiagnosticRequesterTests.swift`, `KubebarTests/Models/AppConfigTests.swift`, `SetupFlowStateTests.swift`, and `MenuRuntimeStateTests.swift` are the focused test surfaces for prompt rendering and config behavior.
+- `docs/solutions/architecture/ai-event-diagnostics-overview-entry-2026-07-02.md` reinforces that future AI surfaces should keep explicit context/data boundaries rather than letting UI or prompts broaden what gets diagnosed.
+
+## Decisions
+
+- Add Pod and Event prompt override fields to `AIDiagnosticAssistantConfig` or a small nested value type owned by that config.
+- Treat nil, empty, or whitespace-only override text as "use the built-in default".
+- Expose Settings editors that display the effective prompt text so the user starts from the default prompt even when no override is saved.
+- Make `Reset to default` clear the stored override for the selected surface.
+- Keep `systemPrompt`/safety instructions in requester code and non-editable.
+- Keep structured Pod/Event diagnostic context generation in code and attach it to the user-editable instruction text so custom prompts cannot remove bounds, redaction, or the no-auto-execute disclosure.
+- Do not send custom prompts through `AIProviderConnectionTester`; Test Connection stays a provider ping.
+- Update docs to define custom prompt behavior as non-secret AI Provider configuration and preserve health-category independence.
+
+## Assumptions
+
+- TextEditor-based settings controls are acceptable for this slice; no advanced prompt-diff UI is needed.
+- Persisting prompt overrides in local config is acceptable because prompt text is user-authored non-secret configuration. The UI should not imply it is a secret field.
+- The built-in default prompt instructions can be split from the code-owned structured context blocks without changing the diagnostic data included in requests.
+- Focused Core tests can prove request-body behavior; Settings UI is build/quality-gate verified unless existing app-target UI tests are found during execution.
+
+## Planning Quality Gate Notes
+
+- Contract surface: `.imm/specs/2026-07-03-ai-diagnostic-prompt-customization.md`, this Plan, `CONTEXT.md`, `docs/architecture/runtime-invariants.md`, `KubebarCore/Models/AIDiagnosticAssistantConfig.swift`, `AppConfigStore.swift`, `SetupFlowState.swift`, `MenuRuntimeState.swift`, `Kubebar/Views/SetupView.swift`, `AIPodDiagnosticRequester.swift`, `AIEventDiagnosticRequester.swift`, and focused tests.
+- Compatibility: existing config files must decode through optional/default prompt override fields. Reset must remove overrides rather than requiring config migration. API key storage remains unchanged.
+- Interruption recovery: if model/config tests pass but requester/UI work is incomplete, prompt override fields should either remain unused or be reverted coherently before exposing UI. A later `imm-work` run should continue from failing focused tests, not from partial UI state.
+- Rollback path: revert the prompt config/model changes, requester prompt rendering changes, Settings UI additions, docs/spec/plan/changelog, and focused tests. No Kubernetes resources or Keychain entries are modified by the feature itself.
+- Verification strength: tests must inspect serialized config/default fallback and actual provider request bodies, not only check that Settings labels exist. The quality gate confirms Xcode and SwiftPM surfaces compile.
+- Brainstorm traceability: every `BR-*` item is mapped in `Brainstorm Trace`; there are no open `BR-Q-*` items.
+
+## Devil's Advocate Audit
+
+### Rollback resilience
+
+The plan keeps prompt customization in non-secret config and request composition. If requester tests fail, the Settings UI can remain unexposed or the config fields can be reverted without changing existing provider credentials, Pod log reads, Warning Event reads, or health evaluation. Reset is a local config operation only.
+
+### Verification vanity
+
+A visible text editor or label would be vanity evidence. Verification must prove default fallback, custom override persistence, reset clearing semantics, prompt inclusion in provider request bodies, fixed safety/system prompt preservation, bounded Pod/Event context preservation, and unchanged Test Connection behavior.
+
+### Spec dilution detection
+
+The plan covers the confirmed recommendation: per-surface customization, default-backed editing, reset-to-default, and non-editable safety prompt. It explicitly excludes a full template language and broader AI roadmap work instead of silently narrowing the request to a single hard-coded override.
+
+## Scope Boundaries
+
+- In scope: Pod/Event prompt override fields, effective default helpers, Settings editors, per-surface reset, requester prompt composition, config/default tests, request-body tests, docs/tests.
+- Out of scope: user-editable system prompt, prompt variables UI, global diagnosis, Events tab diagnosis expansion, chat/history, auto-remediation, custom headers, provider tuning, import/export, cloud sync, and any expansion of diagnostic payload data.
+
+## Deferred Work
+
+- Add a richer prompt template editor with variables only if users need explicit insertion controls after this MVP.
+- Add import/export or team-managed prompt presets only after local prompt overrides are validated in usage.
+- Add provider-specific output controls or model parameters only under a separate AI settings plan.
+
+## Implementation Units
+
+### Step 1
+
+- Step ID: U1
+- Result: `AI Assistant` Settings supports safe prompt customization/reset for Pod/Event diagnosis.
+- Verification: swift test --filter AIPodDiagnosticRequesterTests && swift test --filter AIEventDiagnosticRequesterTests && swift test --filter AppConfigTests && swift test --filter SetupFlowStateTests && swift test --filter MenuRuntimeStateTests && swift test --filter AIProviderConnectionTesterTests && swift build && ./scripts/swift-quality-gate.sh local && rtk git diff --check
+- Depends on: None
+- Test scenarios: existing configs without prompt fields decode and use defaults; saving config round-trips custom Pod and Event prompt overrides without API keys; blank custom prompt falls back to built-in default; reset clears a surface override rather than saving default text; Settings change detection includes prompt overrides; Pod diagnostic request body includes custom Pod prompt instructions plus fixed safety prompt, bounded redacted last-50 logs, and no-auto-execute disclosure; Event diagnostic request body includes custom Event prompt instructions plus fixed safety prompt, latest-5 matching events, and no Pod logs; Test Connection sends no custom prompt or Kubernetes data; docs preserve Health category independence
+- Discovery cache: KubebarCore/Models/AIDiagnosticAssistantConfig.swift (prompt override config and defaults); KubebarCore/Models/AIDiagnosticAssistantState.swift (Settings editing state helper surface); KubebarCore/Models/SetupFlowState.swift (Settings mutation methods); KubebarCore/Models/MenuRuntimeState.swift (config change detection); KubebarCore/Services/AppConfigStore.swift (config encode/decode compatibility); KubebarCore/Services/AIPodDiagnosticRequester.swift (Pod prompt request composition); KubebarCore/Services/AIEventDiagnosticRequester.swift (Event prompt request composition); KubebarCore/Services/AIProviderConnectionTester.swift (unchanged Test Connection boundary); Kubebar/Views/SetupView.swift (`AI Assistant` Settings UI); KubebarTests/Models/AppConfigTests.swift (config compatibility tests); KubebarTests/Models/SetupFlowStateTests.swift (Settings mutation tests); KubebarTests/Models/MenuRuntimeStateTests.swift (change detection tests); KubebarTests/Services/AIPodDiagnosticRequesterTests.swift (Pod request-body tests); KubebarTests/Services/AIEventDiagnosticRequesterTests.swift (Event request-body tests); docs/architecture/runtime-invariants.md (runtime safety contract); CONTEXT.md (canonical AI diagnostic vocabulary)
+
+**Goal:** Deliver the full user-visible prompt customization/reset loop for the two existing manual AI diagnosis surfaces.
+
+**Verification type:** automated
+
+**Execution note:** test-first
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12
+
+**Dependencies:** None
+
+**Discovery cache:**
+- `KubebarCore/Models/AIDiagnosticAssistantConfig.swift` (prompt override config and defaults)
+- `KubebarCore/Models/AIDiagnosticAssistantState.swift` (Settings editing state helper surface)
+- `KubebarCore/Models/SetupFlowState.swift` (Settings mutation methods)
+- `KubebarCore/Models/MenuRuntimeState.swift` (config change detection)
+- `KubebarCore/Services/AppConfigStore.swift` (config encode/decode compatibility)
+- `KubebarCore/Services/AIPodDiagnosticRequester.swift` (Pod prompt request composition)
+- `KubebarCore/Services/AIEventDiagnosticRequester.swift` (Event prompt request composition)
+- `KubebarCore/Services/AIProviderConnectionTester.swift` (unchanged Test Connection boundary)
+- `Kubebar/Views/SetupView.swift` (`AI Assistant` Settings UI)
+- `KubebarTests/Models/AppConfigTests.swift` (config compatibility tests)
+- `KubebarTests/Models/SetupFlowStateTests.swift` (Settings mutation tests)
+- `KubebarTests/Models/MenuRuntimeStateTests.swift` (change detection tests)
+- `KubebarTests/Services/AIPodDiagnosticRequesterTests.swift` (Pod request-body tests)
+- `KubebarTests/Services/AIEventDiagnosticRequesterTests.swift` (Event request-body tests)
+- `docs/architecture/runtime-invariants.md` (runtime safety contract)
+- `CONTEXT.md` (canonical AI diagnostic vocabulary)
+
+**Parallel probes:**
+- Probe 1: scope `KubebarCore/Models/AIDiagnosticAssistantConfig.swift`, `AppConfigStore.swift`, `SetupFlowState.swift`, `MenuRuntimeState.swift`, and model tests; output concise config/default/reset notes; readonly true.
+- Probe 2: scope `AIPodDiagnosticRequester.swift`, `AIEventDiagnosticRequester.swift`, `AIProviderConnectionTester.swift`, and requester tests; output concise prompt composition and safety-test notes; readonly true.
+- Probe 3: scope `Kubebar/Views/SetupView.swift`, `docs/architecture/runtime-invariants.md`, and `CONTEXT.md`; output concise Settings UI and docs wording notes; readonly true.
+
+**Files:**
+- Modify: `CONTEXT.md`
+- Modify: `docs/architecture/runtime-invariants.md`
+- Modify: `KubebarCore/Models/AIDiagnosticAssistantConfig.swift`
+- Modify: `KubebarCore/Models/AIDiagnosticAssistantState.swift`
+- Modify: `KubebarCore/Models/SetupFlowState.swift`
+- Modify: `KubebarCore/Models/MenuRuntimeState.swift` if change detection needs explicit helpers
+- Modify: `KubebarCore/Services/AIPodDiagnosticRequester.swift`
+- Modify: `KubebarCore/Services/AIEventDiagnosticRequester.swift`
+- Modify: `Kubebar/Views/SetupView.swift`
+- Modify/Add: `KubebarTests/Models/AppConfigTests.swift`
+- Modify/Add: `KubebarTests/Models/SetupFlowStateTests.swift`
+- Modify/Add: `KubebarTests/Models/MenuRuntimeStateTests.swift`
+- Modify/Add: `KubebarTests/Services/AIPodDiagnosticRequesterTests.swift`
+- Modify/Add: `KubebarTests/Services/AIEventDiagnosticRequesterTests.swift`
+- Modify/Add: `KubebarTests/Services/AIProviderConnectionTesterTests.swift` if unchanged Test Connection needs an explicit guard
+- Add: `changelog.d/ai-diagnostic-prompt-customization.added.md`
+
+**Approach:**
+- Extend `AIDiagnosticAssistantConfig` with per-surface prompt override storage plus built-in default/effective prompt helpers.
+- Add `SetupFlowState` mutation/reset helpers and Settings bindings so editing a default-backed field creates or updates the override while reset clears it.
+- Add compact prompt editor sections under `AI Assistant` Settings for Pod diagnosis and Warning Event diagnosis, each with explanatory copy and `Reset to default`.
+- Refactor Pod/Event requester prompt construction to combine fixed system/safety prompt, effective user-editable instructions, and code-owned structured diagnostic context blocks.
+- Add/adjust tests for config decode/encode, reset semantics, request-body prompt inclusion, safety boundary preservation, and Test Connection isolation.
+- Update docs and changelog, then run focused tests followed by the full quality gate.
+
+**failure_behavior:** If config/default tests fail, stop before wiring UI or requester changes. If requester safety tests fail, do not expose Settings controls. If UI build fails, revert UI additions while preserving coherent Core tests only if the config/requester contract is complete; otherwise revert the whole slice.
+
+**security_considerations:** Prompt customization must not make the system prompt editable, must not broaden diagnostic payloads, must not expose or store API keys outside Keychain, must not send custom prompts via Test Connection, and must not enable automatic command execution.

--- a/docs/solutions/app-settings/ai-diagnostic-prompt-customization-2026-07-03.md
+++ b/docs/solutions/app-settings/ai-diagnostic-prompt-customization-2026-07-03.md
@@ -1,0 +1,90 @@
+---
+module: app-settings
+tags:
+  - kubebar
+  - ai-diagnostics
+  - prompt-customization
+  - settings
+  - safety-boundary
+problem_type: customizable-prompt-with-immutable-safety-boundary
+reusability: medium
+key_files:
+  - KubebarCore/Models/AIDiagnosticAssistantConfig.swift
+  - KubebarCore/Services/AIPodDiagnosticRequester.swift
+  - KubebarCore/Services/AIEventDiagnosticRequester.swift
+  - Kubebar/Views/SetupView.swift
+  - docs/architecture/runtime-invariants.md
+next_reuse_scenarios:
+  - Adding user-editable prompt/instruction surfaces to other AI diagnostic flows.
+  - Reviewing any feature that lets users customize text sent to an external provider.
+  - Extending Settings with a default-backed editor plus reset-to-default semantics.
+---
+
+# Customizable AI Prompts Need an Immutable Safety Layer
+
+## Problem
+
+Kubebar's AI Pod and Warning Event diagnoses used hard-coded prompt
+instructions. Users asked to customize those prompts based on the built-in
+default and reset them to the default. The customization surface had to stay
+inside the existing safety boundary: fixed system/safety prompt, bounded
+redacted Kubernetes context, no Secrets/kubeconfig/raw transcripts, no
+auto-executed commands, and no Health-category effect.
+
+## Solution
+
+Split prompt composition into three code-owned layers and let users edit only
+one of them.
+
+- Store per-surface prompt overrides (`podPromptInstructions`,
+  `eventPromptInstructions`) as non-secret optional fields on
+  `AIDiagnosticAssistantConfig`. They persist in `AppConfig`; API keys stay
+  Keychain-only.
+- Treat nil, empty, or whitespace-only override text as "use the built-in
+  default". `effectivePodPromptInstructions` / `effectiveEventPromptInstructions`
+  normalize the stored value before falling back to `defaultPodPromptInstructions`
+  / `defaultEventPromptInstructions`.
+- The Settings editor binds to the effective prompt so the user starts from the
+  default text even when no override is saved. `Reset to default` clears the
+  override (`with(podPromptInstructions: nil)`) instead of persisting a copied
+  default string, so future built-in default updates still reach users who never
+  customized.
+- Requesters combine: fixed `systemPrompt` (safety) + effective user-editable
+  instructions + code-owned structured diagnostic context block. Users cannot
+  remove the safety prefix, the bounded context, or the no-auto-execute
+  disclosure.
+
+## Evidence
+
+- `swift test --filter AIPodDiagnosticRequesterTests` passed.
+- `swift test --filter AIEventDiagnosticRequesterTests` passed.
+- `swift test --filter AppConfigTests` passed.
+- `swift test --filter SetupFlowStateTests` passed.
+- `swift test --filter MenuRuntimeStateTests` passed.
+- `swift test --filter AIProviderConnectionTesterTests` passed.
+- `swift build` passed.
+- `./scripts/swift-quality-gate.sh local` passed.
+- `rtk git diff --check` clean.
+- Code-review and UI-review gates recorded pass.
+
+## Reuse Notes
+
+When the next user-editable prompt/instruction surface is added, keep the
+override as an optional non-secret field, expose effective text through a
+normalized helper, and make reset clear the override rather than copying the
+default. Keep the safety prompt and bounded context generation in code so
+custom text cannot expand the data boundary or enable auto-remediation.
+
+## Reusability Critique
+
+- Falsifiability: this lesson is too local if Kubebar later replaces prompt
+  overrides with a full template language or moves prompt storage to a managed
+  profile. The immutable-safety-layer principle still applies, but the field
+  shape may not.
+- Evidence trail: supported by focused requester/config/state/Test Connection
+  tests, full quality gate, diff check, and recorded review gates. Not supported
+  by live provider calls or VoiceOver traversal.
+- Architecture entropy resistance: this belongs in `docs/solutions/app-settings`
+  because it captures the Settings + requester ownership split for user-editable
+  prompt text. It should not become a generic rule that every Settings field
+  needs a default-backed editor.

--- a/docs/solutions/architecture/ai-event-diagnostics-overview-entry-2026-07-02.md
+++ b/docs/solutions/architecture/ai-event-diagnostics-overview-entry-2026-07-02.md
@@ -1,0 +1,91 @@
+---
+module: architecture
+tags:
+  - kubebar
+  - ai-diagnostics
+  - warning-events
+  - menu-bar
+  - kubectl
+problem_type: scoped-ai-event-diagnostics
+reusability: medium
+key_files:
+  - KubebarCore/Models/MenuDisplayModel.swift
+  - KubebarCore/Models/AIEventDiagnosis.swift
+  - KubebarCore/Services/HealthEvaluator.swift
+  - KubebarCore/Services/WarningEventDiagnosticReader.swift
+  - KubebarCore/Services/AIEventDiagnosticRequester.swift
+  - Kubebar/MenuBarViewModel.swift
+  - Kubebar/Views/OverviewTabView.swift
+  - docs/architecture/runtime-invariants.md
+next_reuse_scenarios:
+  - Adding another AI diagnostic surface that must use a structured display-model target instead of parsing UI text.
+  - Extending Warning Event diagnosis beyond Overview while preserving exact event-group matching.
+  - Reviewing AI features that submit fresh Kubernetes context to an external provider.
+---
+
+# AI Event Diagnostics Need Explicit Warning Targets and Fresh Reads
+
+## Problem
+
+Kubebar already grouped Warning Events for display, but the rows were originally
+presentation-only. Adding an AI action from `Overview` `Recent Warnings` needed
+three boundaries to stay safe:
+
+- the UI must not infer a diagnostic target by parsing displayed location text;
+- the AI payload must use fresh `kubectl` event data rather than stale snapshot
+  rows;
+- the event-diagnostic path must remain distinct from Pod-log diagnosis so it
+  does not silently send logs or broaden the privacy boundary.
+
+## Solution
+
+Use an explicit display-model target and a separate event-only diagnostic path.
+
+- Add a `WarningEventDiagnosticTarget` value derived by `HealthEvaluator` from
+  the same warning group key used for display grouping: `namespace`,
+  `objectKind`, `objectName`, and `reason`.
+- Expose the AI action only when the row has a structured diagnostic target.
+  Do not let SwiftUI views parse `location`, `helpText`, or accessibility text.
+- On click, reread Warning Events through the app-owned context/kubeconfig
+  boundary, filter by exact target key, sort newest first, and cap the provider
+  payload to the latest 5 matching Warning Events.
+- Keep the provider requester event-only: redact messages, include structured
+  event fields, and exclude Pod logs, raw cluster JSON, kubeconfig content,
+  raw command transcripts, and automatic command execution.
+- Keep the result transient in `MenuBarViewModel` and scoped to the active
+  warning target. Provide warning-specific accessibility labels and a dismiss
+  control so the inline panel does not permanently crowd the glanceable menu.
+
+## Evidence
+
+- `swift test --filter AIProviderConnectionTesterTests` passed.
+- `swift test --filter AIEventDiagnosticRequesterTests` passed.
+- `swift test --filter WarningEventDiagnosticReaderTests` passed.
+- `swift test --filter MenuDisplayModelTests` passed.
+- `swift build` passed.
+- `./scripts/swift-quality-gate.sh local` passed.
+- `rtk git diff --check` passed.
+- UI review found same-boundary accessibility/dismissal issues; both were fixed
+  and the quality gate passed again.
+
+## Reuse Notes
+
+For future AI troubleshooting surfaces, start by adding a small explicit target
+value at the display-model boundary. If the view has to parse a display string
+to find what to diagnose, the boundary is too weak. Fresh reads should go
+through injectable command services, not directly from SwiftUI. Provider
+requesters should be input-specific instead of overloading an existing requester
+with a broader privacy contract.
+
+## Reusability Critique
+
+- Falsifiability: this lesson is too local if future Kubernetes Event APIs stop
+  supporting the fields needed for exact matching or if Kubebar replaces
+  snapshot/display grouping with a canonical event identity store.
+- Evidence trail: the guidance is supported by focused reader/requester/model
+  tests, full quality gate, diff check, and UI review follow-up. It is not
+  supported by automated VoiceOver traversal or screenshots.
+- Architecture entropy resistance: this belongs in `docs/solutions/architecture`
+  because it captures ownership boundaries between display targets, fresh
+  command reads, provider requests, and transient UI state. It should not become
+  a generic rule that every display row needs an AI target.


### PR DESCRIPTION
This PR introduces on-demand AI diagnostic actions for pods and warning events in the Kubebar menu bar app.

**What changed**
- Added "Diagnose this Pod" action to the Pod Micro-Logs Drawer, which captures pod logs and sends them to the AI diagnostic service
- Added "Diagnose" action for recent warning events in the Overview tab, which extracts warning event data and triggers AI analysis
- Implemented `AIPodDiagnosticRequester` and `AIEventDiagnosticRequester` services for concurrent request handling
- Added `AIDiagnosticResponseFormatter` for parsing and displaying AI diagnostic results
- Created dedicated views (`AIDiagnosisContentView`, updated `OverviewTabView` and `MenuBarRootView`) for rendering diagnosis UI
- Added comprehensive tests for all new services and formatters
- Updated `runtime-invariants.md` with new diagnostic-related rules

**Why**
Enables users to quickly get AI-powered troubleshooting for pod issues and warning events directly from the menu bar without switching to deeper debugging tools, aligning with Kubebar's glanceable status tool purpose.